### PR TITLE
✨ feat: Flashcards dominio + puertos + migración Flyway completa

### DIFF
--- a/backend/src/main/java/com/akdemya/domain/model/Flashcard.java
+++ b/backend/src/main/java/com/akdemya/domain/model/Flashcard.java
@@ -1,0 +1,42 @@
+package com.akdemya.domain.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class Flashcard {
+
+  private final UUID id;
+  private final UUID unitId;
+  private final String front;
+  private final String back;
+  private final LocalDateTime createdAt;
+  private final LocalDateTime updatedAt;
+
+  public Flashcard(UUID id, UUID unitId, String front, String back,
+                   LocalDateTime createdAt, LocalDateTime updatedAt) {
+    if (id == null) throw new IllegalArgumentException("id cannot be null");
+    if (unitId == null) throw new IllegalArgumentException("unitId cannot be null");
+    if (front == null || front.trim().isEmpty()) throw new IllegalArgumentException("front cannot be blank");
+    if (back == null || back.trim().isEmpty()) throw new IllegalArgumentException("back cannot be blank");
+    if (createdAt == null) throw new IllegalArgumentException("createdAt cannot be null");
+    if (updatedAt == null) throw new IllegalArgumentException("updatedAt cannot be null");
+    this.id = id;
+    this.unitId = unitId;
+    this.front = front.trim();
+    this.back = back.trim();
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  public static Flashcard create(UUID unitId, String front, String back) {
+    LocalDateTime now = LocalDateTime.now();
+    return new Flashcard(UUID.randomUUID(), unitId, front, back, now, now);
+  }
+
+  public UUID getId() { return id; }
+  public UUID getUnitId() { return unitId; }
+  public String getFront() { return front; }
+  public String getBack() { return back; }
+  public LocalDateTime getCreatedAt() { return createdAt; }
+  public LocalDateTime getUpdatedAt() { return updatedAt; }
+}

--- a/backend/src/main/java/com/akdemya/domain/model/FlashcardReview.java
+++ b/backend/src/main/java/com/akdemya/domain/model/FlashcardReview.java
@@ -1,0 +1,99 @@
+package com.akdemya.domain.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * SRS state for a given user + flashcard pair.
+ * Mutable fields reflect the spaced-repetition algorithm output after each review.
+ */
+public class FlashcardReview {
+
+  private static final double MIN_EASE_FACTOR = 1.3;
+
+  private final UUID id;
+  private final UUID userId;
+  private final UUID flashcardId;
+  private ReviewState state;
+  private double easeFactor;
+  private int intervalDays;
+  private int repetitions;
+  private int lapses;
+  private LocalDateTime dueAt;
+  private LocalDateTime lastReviewedAt;
+  private final LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  public FlashcardReview(UUID id, UUID userId, UUID flashcardId,
+                         ReviewState state, double easeFactor, int intervalDays,
+                         int repetitions, int lapses,
+                         LocalDateTime dueAt, LocalDateTime lastReviewedAt,
+                         LocalDateTime createdAt, LocalDateTime updatedAt) {
+    if (id == null) throw new IllegalArgumentException("id cannot be null");
+    if (userId == null) throw new IllegalArgumentException("userId cannot be null");
+    if (flashcardId == null) throw new IllegalArgumentException("flashcardId cannot be null");
+    if (state == null) throw new IllegalArgumentException("state cannot be null");
+    if (easeFactor < MIN_EASE_FACTOR)
+      throw new IllegalArgumentException("easeFactor must be >= " + MIN_EASE_FACTOR);
+    if (intervalDays < 0) throw new IllegalArgumentException("intervalDays cannot be negative");
+    if (repetitions < 0) throw new IllegalArgumentException("repetitions cannot be negative");
+    if (lapses < 0) throw new IllegalArgumentException("lapses cannot be negative");
+    if (dueAt == null) throw new IllegalArgumentException("dueAt cannot be null");
+    if (createdAt == null) throw new IllegalArgumentException("createdAt cannot be null");
+    if (updatedAt == null) throw new IllegalArgumentException("updatedAt cannot be null");
+    this.id = id;
+    this.userId = userId;
+    this.flashcardId = flashcardId;
+    this.state = state;
+    this.easeFactor = easeFactor;
+    this.intervalDays = intervalDays;
+    this.repetitions = repetitions;
+    this.lapses = lapses;
+    this.dueAt = dueAt;
+    this.lastReviewedAt = lastReviewedAt;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+
+  /** Factory for the first time a user encounters a flashcard. */
+  public static FlashcardReview createNew(UUID userId, UUID flashcardId, LocalDateTime dueAt) {
+    LocalDateTime now = LocalDateTime.now();
+    return new FlashcardReview(
+        UUID.randomUUID(), userId, flashcardId,
+        ReviewState.NEW, 2.5, 0, 0, 0,
+        dueAt, null, now, now);
+  }
+
+  /** Apply the result of an SM-2 calculation (called from the use-case layer). */
+  public void update(ReviewState state, double easeFactor, int intervalDays,
+                     int repetitions, int lapses, LocalDateTime dueAt) {
+    if (state == null) throw new IllegalArgumentException("state cannot be null");
+    if (easeFactor < MIN_EASE_FACTOR)
+      throw new IllegalArgumentException("easeFactor must be >= " + MIN_EASE_FACTOR);
+    if (intervalDays < 0) throw new IllegalArgumentException("intervalDays cannot be negative");
+    if (repetitions < 0) throw new IllegalArgumentException("repetitions cannot be negative");
+    if (lapses < 0) throw new IllegalArgumentException("lapses cannot be negative");
+    if (dueAt == null) throw new IllegalArgumentException("dueAt cannot be null");
+    this.state = state;
+    this.easeFactor = easeFactor;
+    this.intervalDays = intervalDays;
+    this.repetitions = repetitions;
+    this.lapses = lapses;
+    this.dueAt = dueAt;
+    this.lastReviewedAt = LocalDateTime.now();
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  public UUID getId() { return id; }
+  public UUID getUserId() { return userId; }
+  public UUID getFlashcardId() { return flashcardId; }
+  public ReviewState getState() { return state; }
+  public double getEaseFactor() { return easeFactor; }
+  public int getIntervalDays() { return intervalDays; }
+  public int getRepetitions() { return repetitions; }
+  public int getLapses() { return lapses; }
+  public LocalDateTime getDueAt() { return dueAt; }
+  public LocalDateTime getLastReviewedAt() { return lastReviewedAt; }
+  public LocalDateTime getCreatedAt() { return createdAt; }
+  public LocalDateTime getUpdatedAt() { return updatedAt; }
+}

--- a/backend/src/main/java/com/akdemya/domain/model/FlashcardReviewLog.java
+++ b/backend/src/main/java/com/akdemya/domain/model/FlashcardReviewLog.java
@@ -1,0 +1,65 @@
+package com.akdemya.domain.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Immutable historical record of a single flashcard review event.
+ */
+public class FlashcardReviewLog {
+
+  private final UUID id;
+  private final UUID userId;
+  private final UUID flashcardId;
+  private final ReviewGrade grade;
+  private final LocalDateTime reviewedAt;
+  private final Integer intervalBefore;
+  private final Integer intervalAfter;
+  private final Double easeBefore;
+  private final Double easeAfter;
+  private final LocalDateTime createdAt;
+
+  public FlashcardReviewLog(UUID id, UUID userId, UUID flashcardId, ReviewGrade grade,
+                            LocalDateTime reviewedAt,
+                            Integer intervalBefore, Integer intervalAfter,
+                            Double easeBefore, Double easeAfter,
+                            LocalDateTime createdAt) {
+    if (id == null) throw new IllegalArgumentException("id cannot be null");
+    if (userId == null) throw new IllegalArgumentException("userId cannot be null");
+    if (flashcardId == null) throw new IllegalArgumentException("flashcardId cannot be null");
+    if (grade == null) throw new IllegalArgumentException("grade cannot be null");
+    if (reviewedAt == null) throw new IllegalArgumentException("reviewedAt cannot be null");
+    if (createdAt == null) throw new IllegalArgumentException("createdAt cannot be null");
+    this.id = id;
+    this.userId = userId;
+    this.flashcardId = flashcardId;
+    this.grade = grade;
+    this.reviewedAt = reviewedAt;
+    this.intervalBefore = intervalBefore;
+    this.intervalAfter = intervalAfter;
+    this.easeBefore = easeBefore;
+    this.easeAfter = easeAfter;
+    this.createdAt = createdAt;
+  }
+
+  public static FlashcardReviewLog create(UUID userId, UUID flashcardId, ReviewGrade grade,
+                                          LocalDateTime reviewedAt,
+                                          Integer intervalBefore, Integer intervalAfter,
+                                          Double easeBefore, Double easeAfter) {
+    return new FlashcardReviewLog(
+        UUID.randomUUID(), userId, flashcardId, grade, reviewedAt,
+        intervalBefore, intervalAfter, easeBefore, easeAfter,
+        LocalDateTime.now());
+  }
+
+  public UUID getId() { return id; }
+  public UUID getUserId() { return userId; }
+  public UUID getFlashcardId() { return flashcardId; }
+  public ReviewGrade getGrade() { return grade; }
+  public LocalDateTime getReviewedAt() { return reviewedAt; }
+  public Integer getIntervalBefore() { return intervalBefore; }
+  public Integer getIntervalAfter() { return intervalAfter; }
+  public Double getEaseBefore() { return easeBefore; }
+  public Double getEaseAfter() { return easeAfter; }
+  public LocalDateTime getCreatedAt() { return createdAt; }
+}

--- a/backend/src/main/java/com/akdemya/domain/model/ReviewGrade.java
+++ b/backend/src/main/java/com/akdemya/domain/model/ReviewGrade.java
@@ -1,0 +1,5 @@
+package com.akdemya.domain.model;
+
+public enum ReviewGrade {
+  AGAIN, HARD, GOOD, EASY
+}

--- a/backend/src/main/java/com/akdemya/domain/model/ReviewState.java
+++ b/backend/src/main/java/com/akdemya/domain/model/ReviewState.java
@@ -1,0 +1,5 @@
+package com.akdemya.domain.model;
+
+public enum ReviewState {
+  NEW, LEARNING, REVIEW
+}

--- a/backend/src/main/java/com/akdemya/domain/port/out/FlashcardRepository.java
+++ b/backend/src/main/java/com/akdemya/domain/port/out/FlashcardRepository.java
@@ -1,0 +1,18 @@
+package com.akdemya.domain.port.out;
+
+import com.akdemya.domain.model.Flashcard;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface FlashcardRepository {
+
+  Optional<Flashcard> findById(UUID id);
+
+  List<Flashcard> findByUnitId(UUID unitId);
+
+  Flashcard save(Flashcard flashcard);
+
+  void deleteById(UUID id);
+}

--- a/backend/src/main/java/com/akdemya/domain/port/out/FlashcardReviewLogRepository.java
+++ b/backend/src/main/java/com/akdemya/domain/port/out/FlashcardReviewLogRepository.java
@@ -1,0 +1,13 @@
+package com.akdemya.domain.port.out;
+
+import com.akdemya.domain.model.FlashcardReviewLog;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface FlashcardReviewLogRepository {
+
+  FlashcardReviewLog save(FlashcardReviewLog log);
+
+  List<FlashcardReviewLog> findRecentByUserId(UUID userId, int limit);
+}

--- a/backend/src/main/java/com/akdemya/domain/port/out/FlashcardReviewRepository.java
+++ b/backend/src/main/java/com/akdemya/domain/port/out/FlashcardReviewRepository.java
@@ -1,0 +1,17 @@
+package com.akdemya.domain.port.out;
+
+import com.akdemya.domain.model.FlashcardReview;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface FlashcardReviewRepository {
+
+  Optional<FlashcardReview> findByUserIdAndFlashcardId(UUID userId, UUID flashcardId);
+
+  /** Returns all due cards for a user ordered by dueAt ascending. */
+  List<FlashcardReview> findDueByUserId(UUID userId);
+
+  FlashcardReview save(FlashcardReview review);
+}

--- a/backend/src/test/java/com/akdemya/application/service/ExamManagerResumeTest.java
+++ b/backend/src/test/java/com/akdemya/application/service/ExamManagerResumeTest.java
@@ -217,6 +217,14 @@ class ExamManagerResumeTest {
     public long countByUnitId(UUID unitId) {
       return data.values().stream().filter(q -> q.getUnitId().equals(unitId)).count();
     }
+
+    @Override
+    public long countByUnitIdAndDifficulty(UUID unitId, String difficulty) {
+      return data.values().stream()
+          .filter(q -> q.getUnitId().equals(unitId) && q.getDifficulty() != null
+              && q.getDifficulty().name().equals(difficulty))
+          .count();
+    }
   }
 
   static class InMemoryAnswerRepo implements AnswerRepository {

--- a/backend/src/test/java/com/akdemya/domain/model/FlashcardReviewTest.java
+++ b/backend/src/test/java/com/akdemya/domain/model/FlashcardReviewTest.java
@@ -1,0 +1,111 @@
+package com.akdemya.domain.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FlashcardReviewTest {
+
+  private final UUID userId = UUID.randomUUID();
+  private final UUID flashcardId = UUID.randomUUID();
+  private final LocalDateTime now = LocalDateTime.now();
+
+  // --- easeFactor ---
+
+  @Test
+  void easeFactorBelowMinimumThrows() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new FlashcardReview(UUID.randomUUID(), userId, flashcardId,
+            ReviewState.NEW, 1.2, 0, 0, 0, now, null, now, now));
+  }
+
+  @Test
+  void easeFactorAtExactMinimumIsAllowed() {
+    assertDoesNotThrow(
+        () -> new FlashcardReview(UUID.randomUUID(), userId, flashcardId,
+            ReviewState.NEW, 1.3, 0, 0, 0, now, null, now, now));
+  }
+
+  // --- intervalDays ---
+
+  @Test
+  void negativeIntervalDaysThrows() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new FlashcardReview(UUID.randomUUID(), userId, flashcardId,
+            ReviewState.NEW, 2.5, -1, 0, 0, now, null, now, now));
+  }
+
+  @Test
+  void zeroIntervalDaysIsAllowed() {
+    assertDoesNotThrow(
+        () -> new FlashcardReview(UUID.randomUUID(), userId, flashcardId,
+            ReviewState.NEW, 2.5, 0, 0, 0, now, null, now, now));
+  }
+
+  // --- repetitions ---
+
+  @Test
+  void negativeRepetitionsThrows() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new FlashcardReview(UUID.randomUUID(), userId, flashcardId,
+            ReviewState.LEARNING, 2.5, 1, -1, 0, now, now, now, now));
+  }
+
+  // --- lapses ---
+
+  @Test
+  void negativeLapsesThrows() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new FlashcardReview(UUID.randomUUID(), userId, flashcardId,
+            ReviewState.REVIEW, 2.5, 7, 3, -1, now, now, now, now));
+  }
+
+  // --- dueAt ---
+
+  @Test
+  void dueAtCannotBeNull() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new FlashcardReview(UUID.randomUUID(), userId, flashcardId,
+            ReviewState.NEW, 2.5, 0, 0, 0, null, null, now, now));
+  }
+
+  // --- createNew ---
+
+  @Test
+  void createNewInitialisesCorrectDefaults() {
+    var review = FlashcardReview.createNew(userId, flashcardId, now);
+    assertEquals(ReviewState.NEW, review.getState());
+    assertEquals(2.5, review.getEaseFactor());
+    assertEquals(0, review.getIntervalDays());
+    assertEquals(0, review.getRepetitions());
+    assertEquals(0, review.getLapses());
+    assertEquals(now, review.getDueAt());
+    assertNull(review.getLastReviewedAt());
+    assertNotNull(review.getId());
+  }
+
+  // --- update ---
+
+  @Test
+  void updateAppliesNewSrsValues() {
+    var review = FlashcardReview.createNew(userId, flashcardId, now);
+    LocalDateTime nextDue = now.plusDays(1);
+    review.update(ReviewState.LEARNING, 2.3, 1, 1, 0, nextDue);
+    assertEquals(ReviewState.LEARNING, review.getState());
+    assertEquals(2.3, review.getEaseFactor());
+    assertEquals(1, review.getIntervalDays());
+    assertEquals(1, review.getRepetitions());
+    assertEquals(nextDue, review.getDueAt());
+    assertNotNull(review.getLastReviewedAt());
+  }
+
+  @Test
+  void updateRejectsInvalidEaseFactor() {
+    var review = FlashcardReview.createNew(userId, flashcardId, now);
+    assertThrows(IllegalArgumentException.class,
+        () -> review.update(ReviewState.LEARNING, 1.0, 1, 1, 0, now.plusDays(1)));
+  }
+}

--- a/backend/src/test/java/com/akdemya/domain/model/FlashcardTest.java
+++ b/backend/src/test/java/com/akdemya/domain/model/FlashcardTest.java
@@ -1,0 +1,80 @@
+package com.akdemya.domain.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FlashcardTest {
+
+  private final UUID unitId = UUID.randomUUID();
+
+  // --- unitId ---
+
+  @Test
+  void unitIdCannotBeNull() {
+    assertThrows(IllegalArgumentException.class,
+        () -> Flashcard.create(null, "front", "back"));
+  }
+
+  // --- front ---
+
+  @Test
+  void frontCannotBeNull() {
+    assertThrows(IllegalArgumentException.class,
+        () -> Flashcard.create(unitId, null, "back"));
+  }
+
+  @Test
+  void frontCannotBeEmpty() {
+    assertThrows(IllegalArgumentException.class,
+        () -> Flashcard.create(unitId, "", "back"));
+  }
+
+  @Test
+  void frontCannotBeBlankWhitespace() {
+    assertThrows(IllegalArgumentException.class,
+        () -> Flashcard.create(unitId, "   ", "back"));
+  }
+
+  // --- back ---
+
+  @Test
+  void backCannotBeNull() {
+    assertThrows(IllegalArgumentException.class,
+        () -> Flashcard.create(unitId, "front", null));
+  }
+
+  @Test
+  void backCannotBeEmpty() {
+    assertThrows(IllegalArgumentException.class,
+        () -> Flashcard.create(unitId, "front", ""));
+  }
+
+  @Test
+  void backCannotBeBlankWhitespace() {
+    assertThrows(IllegalArgumentException.class,
+        () -> Flashcard.create(unitId, "front", "   "));
+  }
+
+  // --- happy path ---
+
+  @Test
+  void validFlashcardIsCreated() {
+    var f = Flashcard.create(unitId, "What is Java?", "A programming language");
+    assertNotNull(f.getId());
+    assertEquals(unitId, f.getUnitId());
+    assertEquals("What is Java?", f.getFront());
+    assertEquals("A programming language", f.getBack());
+    assertNotNull(f.getCreatedAt());
+    assertNotNull(f.getUpdatedAt());
+  }
+
+  @Test
+  void frontAndBackAreTrimmed() {
+    var f = Flashcard.create(unitId, "  front  ", "  back  ");
+    assertEquals("front", f.getFront());
+    assertEquals("back", f.getBack());
+  }
+}


### PR DESCRIPTION
## Resumen

- 🗃️ Migración completa del esquema a Flyway: `V1__init_schema.sql` unifica todas las tablas (incluyendo `questions`, `answers`, `exam_attempts`, `exam_attempt_answers`). Se añade `R__seed_basic_data.sql` en `db/migration/dev/` para datos de seed idempotentes.
- ✨ Dominio de Flashcards (AKDMIA-39): entidades `Flashcard`, `FlashcardReview`, `FlashcardReviewLog`, enums `ReviewGrade` / `ReviewState` y los tres puertos de salida, sin dependencias de infraestructura.

## Cambios destacados

- `V1__init_schema.sql` — esquema completo (10 tablas)
- `db/migration/dev/R__seed_basic_data.sql` — seed idempotente (TRUNCATE + INSERT)
- `application.properties` — `ddl-auto=none`; Flyway es el único dueño del esquema
- `application-dev.properties` — `flyway.locations` incluye classpath dev
- `docker-compose.yaml` / `docker-compose-prod.yaml` — `DDL_AUTO=none`
- Entidades de dominio inmutables con invariantes validadas en constructor
- Tests unitarios: `FlashcardTest` y `FlashcardReviewTest` (18 casos)

## Test plan

- [ ] `./gradlew test` — todos los tests en verde
- [ ] `docker compose down -v && docker compose up --build` — Flyway aplica V1 + R seed
- [ ] Login con `student@akadem.ia` / `admin@akadem.ia` funciona
- [ ] `flyway_schema_history` contiene 2 entradas (V1 + R)
- [ ] Sección Constitución Española muestra preguntas en todas las unidades