### PR TITLE
🗃️ feat (backend): adaptadores de persistencia JPA para Flashcards (AKDMIA-40)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ coverage/
 # Misc
 *.tmp
 ._*
+
+# Claude Code
+CLAUDE.md
+.claude/

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/FlashcardRepositoryAdapter.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/FlashcardRepositoryAdapter.java
@@ -1,0 +1,43 @@
+package com.akdemya.adapter.outbound.persistence;
+
+import com.akdemya.adapter.outbound.persistence.mapper.FlashcardJpaMapper;
+import com.akdemya.adapter.outbound.persistence.repository.JpaFlashcardRepository;
+import com.akdemya.domain.model.Flashcard;
+import com.akdemya.domain.port.out.FlashcardRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public class FlashcardRepositoryAdapter implements FlashcardRepository {
+
+  private final JpaFlashcardRepository jpa;
+  private final FlashcardJpaMapper mapper;
+
+  public FlashcardRepositoryAdapter(JpaFlashcardRepository jpa, FlashcardJpaMapper mapper) {
+    this.jpa = jpa;
+    this.mapper = mapper;
+  }
+
+  @Override
+  public Optional<Flashcard> findById(UUID id) {
+    return jpa.findById(id).map(mapper::toDomain);
+  }
+
+  @Override
+  public List<Flashcard> findByUnitId(UUID unitId) {
+    return jpa.findByUnitId(unitId).stream().map(mapper::toDomain).toList();
+  }
+
+  @Override
+  public Flashcard save(Flashcard flashcard) {
+    return mapper.toDomain(jpa.save(mapper.toEntity(flashcard)));
+  }
+
+  @Override
+  public void deleteById(UUID id) {
+    jpa.deleteById(id);
+  }
+}

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/FlashcardReviewLogRepositoryAdapter.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/FlashcardReviewLogRepositoryAdapter.java
@@ -1,0 +1,37 @@
+package com.akdemya.adapter.outbound.persistence;
+
+import com.akdemya.adapter.outbound.persistence.mapper.FlashcardReviewLogJpaMapper;
+import com.akdemya.adapter.outbound.persistence.repository.JpaFlashcardReviewLogRepository;
+import com.akdemya.domain.model.FlashcardReviewLog;
+import com.akdemya.domain.port.out.FlashcardReviewLogRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class FlashcardReviewLogRepositoryAdapter implements FlashcardReviewLogRepository {
+
+  private final JpaFlashcardReviewLogRepository jpa;
+  private final FlashcardReviewLogJpaMapper mapper;
+
+  public FlashcardReviewLogRepositoryAdapter(JpaFlashcardReviewLogRepository jpa,
+                                             FlashcardReviewLogJpaMapper mapper) {
+    this.jpa = jpa;
+    this.mapper = mapper;
+  }
+
+  @Override
+  public FlashcardReviewLog save(FlashcardReviewLog log) {
+    return mapper.toDomain(jpa.save(mapper.toEntity(log)));
+  }
+
+  @Override
+  public List<FlashcardReviewLog> findRecentByUserId(UUID userId, int limit) {
+    return jpa.findByUserIdOrderByReviewedAtDesc(userId, PageRequest.of(0, limit))
+        .stream()
+        .map(mapper::toDomain)
+        .toList();
+  }
+}

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/FlashcardReviewRepositoryAdapter.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/FlashcardReviewRepositoryAdapter.java
@@ -1,0 +1,62 @@
+package com.akdemya.adapter.outbound.persistence;
+
+import com.akdemya.adapter.outbound.persistence.entity.FlashcardReviewEntity;
+import com.akdemya.adapter.outbound.persistence.mapper.FlashcardReviewJpaMapper;
+import com.akdemya.adapter.outbound.persistence.repository.JpaFlashcardReviewRepository;
+import com.akdemya.domain.model.FlashcardReview;
+import com.akdemya.domain.port.out.FlashcardReviewRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public class FlashcardReviewRepositoryAdapter implements FlashcardReviewRepository {
+
+  private final JpaFlashcardReviewRepository jpa;
+  private final FlashcardReviewJpaMapper mapper;
+
+  public FlashcardReviewRepositoryAdapter(JpaFlashcardReviewRepository jpa, FlashcardReviewJpaMapper mapper) {
+    this.jpa = jpa;
+    this.mapper = mapper;
+  }
+
+  @Override
+  public Optional<FlashcardReview> findByUserIdAndFlashcardId(UUID userId, UUID flashcardId) {
+    return jpa.findByUserIdAndFlashcardId(userId, flashcardId).map(mapper::toDomain);
+  }
+
+  @Override
+  public List<FlashcardReview> findDueByUserId(UUID userId, LocalDateTime upTo, int limit) {
+    return jpa.findByUserIdAndDueAtLessThanEqualOrderByDueAtAsc(
+            userId,
+            upTo.toInstant(ZoneOffset.UTC),
+            PageRequest.of(0, limit))
+        .stream()
+        .map(mapper::toDomain)
+        .toList();
+  }
+
+  /**
+   * Upsert: if a review already exists for (userId, flashcardId) patch its SRS fields;
+   * otherwise insert a new row. This avoids unique-constraint violations on re-saves.
+   */
+  @Override
+  public FlashcardReview save(FlashcardReview review) {
+    Optional<FlashcardReviewEntity> existing =
+        jpa.findByUserIdAndFlashcardId(review.getUserId(), review.getFlashcardId());
+
+    FlashcardReviewEntity entity;
+    if (existing.isPresent()) {
+      entity = existing.get();
+      mapper.updateEntity(entity, review);
+    } else {
+      entity = mapper.toEntity(review);
+    }
+    return mapper.toDomain(jpa.save(entity));
+  }
+}

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/entity/FlashcardEntity.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/entity/FlashcardEntity.java
@@ -1,0 +1,52 @@
+package com.akdemya.adapter.outbound.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "flashcards")
+public class FlashcardEntity {
+
+  @Id
+  private UUID id;
+
+  @Column(name = "unit_id", nullable = false)
+  private UUID unitId;
+
+  @Column(columnDefinition = "text", nullable = false)
+  private String front;
+
+  @Column(columnDefinition = "text", nullable = false)
+  private String back;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  public FlashcardEntity() {}
+
+  public UUID getId() { return id; }
+  public void setId(UUID id) { this.id = id; }
+
+  public UUID getUnitId() { return unitId; }
+  public void setUnitId(UUID unitId) { this.unitId = unitId; }
+
+  public String getFront() { return front; }
+  public void setFront(String front) { this.front = front; }
+
+  public String getBack() { return back; }
+  public void setBack(String back) { this.back = back; }
+
+  public Instant getCreatedAt() { return createdAt; }
+  public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+  public Instant getUpdatedAt() { return updatedAt; }
+  public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/entity/FlashcardReviewEntity.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/entity/FlashcardReviewEntity.java
@@ -1,0 +1,93 @@
+package com.akdemya.adapter.outbound.persistence.entity;
+
+import com.akdemya.domain.model.ReviewState;
+import jakarta.persistence.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(
+    name = "flashcard_reviews",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uq_flashcard_reviews_user_flashcard",
+        columnNames = {"user_id", "flashcard_id"}
+    )
+)
+public class FlashcardReviewEntity {
+
+  @Id
+  private UUID id;
+
+  @Column(name = "user_id", nullable = false)
+  private UUID userId;
+
+  @Column(name = "flashcard_id", nullable = false)
+  private UUID flashcardId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private ReviewState state;
+
+  @Column(name = "ease_factor", nullable = false)
+  private double easeFactor;
+
+  @Column(name = "interval_days", nullable = false)
+  private int intervalDays;
+
+  @Column(nullable = false)
+  private int repetitions;
+
+  @Column(nullable = false)
+  private int lapses;
+
+  @Column(name = "due_at", nullable = false)
+  private Instant dueAt;
+
+  @Column(name = "last_reviewed_at")
+  private Instant lastReviewedAt;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  public FlashcardReviewEntity() {}
+
+  public UUID getId() { return id; }
+  public void setId(UUID id) { this.id = id; }
+
+  public UUID getUserId() { return userId; }
+  public void setUserId(UUID userId) { this.userId = userId; }
+
+  public UUID getFlashcardId() { return flashcardId; }
+  public void setFlashcardId(UUID flashcardId) { this.flashcardId = flashcardId; }
+
+  public ReviewState getState() { return state; }
+  public void setState(ReviewState state) { this.state = state; }
+
+  public double getEaseFactor() { return easeFactor; }
+  public void setEaseFactor(double easeFactor) { this.easeFactor = easeFactor; }
+
+  public int getIntervalDays() { return intervalDays; }
+  public void setIntervalDays(int intervalDays) { this.intervalDays = intervalDays; }
+
+  public int getRepetitions() { return repetitions; }
+  public void setRepetitions(int repetitions) { this.repetitions = repetitions; }
+
+  public int getLapses() { return lapses; }
+  public void setLapses(int lapses) { this.lapses = lapses; }
+
+  public Instant getDueAt() { return dueAt; }
+  public void setDueAt(Instant dueAt) { this.dueAt = dueAt; }
+
+  public Instant getLastReviewedAt() { return lastReviewedAt; }
+  public void setLastReviewedAt(Instant lastReviewedAt) { this.lastReviewedAt = lastReviewedAt; }
+
+  public Instant getCreatedAt() { return createdAt; }
+  public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+  public Instant getUpdatedAt() { return updatedAt; }
+  public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/entity/FlashcardReviewLogEntity.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/entity/FlashcardReviewLogEntity.java
@@ -1,0 +1,75 @@
+package com.akdemya.adapter.outbound.persistence.entity;
+
+import com.akdemya.domain.model.ReviewGrade;
+import jakarta.persistence.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "flashcard_review_log")
+public class FlashcardReviewLogEntity {
+
+  @Id
+  private UUID id;
+
+  @Column(name = "user_id", nullable = false)
+  private UUID userId;
+
+  @Column(name = "flashcard_id", nullable = false)
+  private UUID flashcardId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private ReviewGrade grade;
+
+  @Column(name = "reviewed_at", nullable = false)
+  private Instant reviewedAt;
+
+  @Column(name = "interval_before")
+  private Integer intervalBefore;
+
+  @Column(name = "interval_after")
+  private Integer intervalAfter;
+
+  @Column(name = "ease_before")
+  private Double easeBefore;
+
+  @Column(name = "ease_after")
+  private Double easeAfter;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  public FlashcardReviewLogEntity() {}
+
+  public UUID getId() { return id; }
+  public void setId(UUID id) { this.id = id; }
+
+  public UUID getUserId() { return userId; }
+  public void setUserId(UUID userId) { this.userId = userId; }
+
+  public UUID getFlashcardId() { return flashcardId; }
+  public void setFlashcardId(UUID flashcardId) { this.flashcardId = flashcardId; }
+
+  public ReviewGrade getGrade() { return grade; }
+  public void setGrade(ReviewGrade grade) { this.grade = grade; }
+
+  public Instant getReviewedAt() { return reviewedAt; }
+  public void setReviewedAt(Instant reviewedAt) { this.reviewedAt = reviewedAt; }
+
+  public Integer getIntervalBefore() { return intervalBefore; }
+  public void setIntervalBefore(Integer intervalBefore) { this.intervalBefore = intervalBefore; }
+
+  public Integer getIntervalAfter() { return intervalAfter; }
+  public void setIntervalAfter(Integer intervalAfter) { this.intervalAfter = intervalAfter; }
+
+  public Double getEaseBefore() { return easeBefore; }
+  public void setEaseBefore(Double easeBefore) { this.easeBefore = easeBefore; }
+
+  public Double getEaseAfter() { return easeAfter; }
+  public void setEaseAfter(Double easeAfter) { this.easeAfter = easeAfter; }
+
+  public Instant getCreatedAt() { return createdAt; }
+  public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+}

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/mapper/FlashcardJpaMapper.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/mapper/FlashcardJpaMapper.java
@@ -1,0 +1,43 @@
+package com.akdemya.adapter.outbound.persistence.mapper;
+
+import com.akdemya.adapter.outbound.persistence.entity.FlashcardEntity;
+import com.akdemya.domain.model.Flashcard;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+@Component
+public class FlashcardJpaMapper {
+
+  public Flashcard toDomain(FlashcardEntity e) {
+    return new Flashcard(
+        e.getId(),
+        e.getUnitId(),
+        e.getFront(),
+        e.getBack(),
+        toLocalDateTime(e.getCreatedAt()),
+        toLocalDateTime(e.getUpdatedAt())
+    );
+  }
+
+  public FlashcardEntity toEntity(Flashcard d) {
+    FlashcardEntity e = new FlashcardEntity();
+    e.setId(d.getId());
+    e.setUnitId(d.getUnitId());
+    e.setFront(d.getFront());
+    e.setBack(d.getBack());
+    e.setCreatedAt(toInstant(d.getCreatedAt()));
+    e.setUpdatedAt(toInstant(d.getUpdatedAt()));
+    return e;
+  }
+
+  private static LocalDateTime toLocalDateTime(Instant instant) {
+    return instant == null ? null : LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+  }
+
+  private static Instant toInstant(LocalDateTime ldt) {
+    return ldt == null ? null : ldt.toInstant(ZoneOffset.UTC);
+  }
+}

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/mapper/FlashcardReviewJpaMapper.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/mapper/FlashcardReviewJpaMapper.java
@@ -1,0 +1,67 @@
+package com.akdemya.adapter.outbound.persistence.mapper;
+
+import com.akdemya.adapter.outbound.persistence.entity.FlashcardReviewEntity;
+import com.akdemya.domain.model.FlashcardReview;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+@Component
+public class FlashcardReviewJpaMapper {
+
+  public FlashcardReview toDomain(FlashcardReviewEntity e) {
+    return new FlashcardReview(
+        e.getId(),
+        e.getUserId(),
+        e.getFlashcardId(),
+        e.getState(),
+        e.getEaseFactor(),
+        e.getIntervalDays(),
+        e.getRepetitions(),
+        e.getLapses(),
+        toLocalDateTime(e.getDueAt()),
+        toLocalDateTime(e.getLastReviewedAt()),
+        toLocalDateTime(e.getCreatedAt()),
+        toLocalDateTime(e.getUpdatedAt())
+    );
+  }
+
+  public FlashcardReviewEntity toEntity(FlashcardReview d) {
+    FlashcardReviewEntity e = new FlashcardReviewEntity();
+    e.setId(d.getId());
+    e.setUserId(d.getUserId());
+    e.setFlashcardId(d.getFlashcardId());
+    e.setState(d.getState());
+    e.setEaseFactor(d.getEaseFactor());
+    e.setIntervalDays(d.getIntervalDays());
+    e.setRepetitions(d.getRepetitions());
+    e.setLapses(d.getLapses());
+    e.setDueAt(toInstant(d.getDueAt()));
+    e.setLastReviewedAt(toInstant(d.getLastReviewedAt()));
+    e.setCreatedAt(toInstant(d.getCreatedAt()));
+    e.setUpdatedAt(toInstant(d.getUpdatedAt()));
+    return e;
+  }
+
+  /** Patch the mutable SRS fields on an existing entity (used in upsert logic). */
+  public void updateEntity(FlashcardReviewEntity e, FlashcardReview d) {
+    e.setState(d.getState());
+    e.setEaseFactor(d.getEaseFactor());
+    e.setIntervalDays(d.getIntervalDays());
+    e.setRepetitions(d.getRepetitions());
+    e.setLapses(d.getLapses());
+    e.setDueAt(toInstant(d.getDueAt()));
+    e.setLastReviewedAt(toInstant(d.getLastReviewedAt()));
+    e.setUpdatedAt(toInstant(d.getUpdatedAt()));
+  }
+
+  private static LocalDateTime toLocalDateTime(Instant instant) {
+    return instant == null ? null : LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+  }
+
+  private static Instant toInstant(LocalDateTime ldt) {
+    return ldt == null ? null : ldt.toInstant(ZoneOffset.UTC);
+  }
+}

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/mapper/FlashcardReviewLogJpaMapper.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/mapper/FlashcardReviewLogJpaMapper.java
@@ -1,0 +1,51 @@
+package com.akdemya.adapter.outbound.persistence.mapper;
+
+import com.akdemya.adapter.outbound.persistence.entity.FlashcardReviewLogEntity;
+import com.akdemya.domain.model.FlashcardReviewLog;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+@Component
+public class FlashcardReviewLogJpaMapper {
+
+  public FlashcardReviewLog toDomain(FlashcardReviewLogEntity e) {
+    return new FlashcardReviewLog(
+        e.getId(),
+        e.getUserId(),
+        e.getFlashcardId(),
+        e.getGrade(),
+        toLocalDateTime(e.getReviewedAt()),
+        e.getIntervalBefore(),
+        e.getIntervalAfter(),
+        e.getEaseBefore(),
+        e.getEaseAfter(),
+        toLocalDateTime(e.getCreatedAt())
+    );
+  }
+
+  public FlashcardReviewLogEntity toEntity(FlashcardReviewLog d) {
+    FlashcardReviewLogEntity e = new FlashcardReviewLogEntity();
+    e.setId(d.getId());
+    e.setUserId(d.getUserId());
+    e.setFlashcardId(d.getFlashcardId());
+    e.setGrade(d.getGrade());
+    e.setReviewedAt(toInstant(d.getReviewedAt()));
+    e.setIntervalBefore(d.getIntervalBefore());
+    e.setIntervalAfter(d.getIntervalAfter());
+    e.setEaseBefore(d.getEaseBefore());
+    e.setEaseAfter(d.getEaseAfter());
+    e.setCreatedAt(toInstant(d.getCreatedAt()));
+    return e;
+  }
+
+  private static LocalDateTime toLocalDateTime(Instant instant) {
+    return instant == null ? null : LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+  }
+
+  private static Instant toInstant(LocalDateTime ldt) {
+    return ldt == null ? null : ldt.toInstant(ZoneOffset.UTC);
+  }
+}

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/repository/JpaFlashcardRepository.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/repository/JpaFlashcardRepository.java
@@ -1,0 +1,12 @@
+package com.akdemya.adapter.outbound.persistence.repository;
+
+import com.akdemya.adapter.outbound.persistence.entity.FlashcardEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface JpaFlashcardRepository extends JpaRepository<FlashcardEntity, UUID> {
+
+  List<FlashcardEntity> findByUnitId(UUID unitId);
+}

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/repository/JpaFlashcardReviewLogRepository.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/repository/JpaFlashcardReviewLogRepository.java
@@ -1,0 +1,13 @@
+package com.akdemya.adapter.outbound.persistence.repository;
+
+import com.akdemya.adapter.outbound.persistence.entity.FlashcardReviewLogEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface JpaFlashcardReviewLogRepository extends JpaRepository<FlashcardReviewLogEntity, UUID> {
+
+  List<FlashcardReviewLogEntity> findByUserIdOrderByReviewedAtDesc(UUID userId, Pageable pageable);
+}

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/repository/JpaFlashcardReviewRepository.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/repository/JpaFlashcardReviewRepository.java
@@ -1,0 +1,18 @@
+package com.akdemya.adapter.outbound.persistence.repository;
+
+import com.akdemya.adapter.outbound.persistence.entity.FlashcardReviewEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface JpaFlashcardReviewRepository extends JpaRepository<FlashcardReviewEntity, UUID> {
+
+  Optional<FlashcardReviewEntity> findByUserIdAndFlashcardId(UUID userId, UUID flashcardId);
+
+  Page<FlashcardReviewEntity> findByUserIdAndDueAtLessThanEqualOrderByDueAtAsc(
+      UUID userId, Instant dueAt, Pageable pageable);
+}

--- a/backend/src/main/java/com/akdemya/domain/port/out/FlashcardReviewRepository.java
+++ b/backend/src/main/java/com/akdemya/domain/port/out/FlashcardReviewRepository.java
@@ -2,6 +2,7 @@ package com.akdemya.domain.port.out;
 
 import com.akdemya.domain.model.FlashcardReview;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -10,8 +11,8 @@ public interface FlashcardReviewRepository {
 
   Optional<FlashcardReview> findByUserIdAndFlashcardId(UUID userId, UUID flashcardId);
 
-  /** Returns all due cards for a user ordered by dueAt ascending. */
-  List<FlashcardReview> findDueByUserId(UUID userId);
+  /** Returns up to {@code limit} cards due for {@code userId} at or before {@code upTo}, ordered by dueAt asc. */
+  List<FlashcardReview> findDueByUserId(UUID userId, LocalDateTime upTo, int limit);
 
   FlashcardReview save(FlashcardReview review);
 }

--- a/backend/src/test/java/com/akdemya/adapter/outbound/persistence/FlashcardPersistenceAdapterTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/outbound/persistence/FlashcardPersistenceAdapterTest.java
@@ -1,0 +1,181 @@
+package com.akdemya.adapter.outbound.persistence;
+
+import com.akdemya.adapter.outbound.persistence.entity.FlashcardEntity;
+import com.akdemya.adapter.outbound.persistence.entity.FlashcardReviewEntity;
+import com.akdemya.adapter.outbound.persistence.entity.FlashcardReviewLogEntity;
+import com.akdemya.adapter.outbound.persistence.mapper.FlashcardJpaMapper;
+import com.akdemya.adapter.outbound.persistence.mapper.FlashcardReviewJpaMapper;
+import com.akdemya.adapter.outbound.persistence.mapper.FlashcardReviewLogJpaMapper;
+import com.akdemya.adapter.outbound.persistence.repository.JpaFlashcardRepository;
+import com.akdemya.adapter.outbound.persistence.repository.JpaFlashcardReviewLogRepository;
+import com.akdemya.adapter.outbound.persistence.repository.JpaFlashcardReviewRepository;
+import com.akdemya.domain.model.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@TestPropertySource(properties = {
+    "spring.flyway.enabled=false",
+    "spring.sql.init.mode=never",
+    "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+@Import({
+    FlashcardJpaMapper.class,
+    FlashcardReviewJpaMapper.class,
+    FlashcardReviewLogJpaMapper.class
+})
+class FlashcardPersistenceAdapterTest {
+
+  @Autowired JpaFlashcardRepository flashcardRepo;
+  @Autowired JpaFlashcardReviewRepository reviewRepo;
+  @Autowired JpaFlashcardReviewLogRepository logRepo;
+  @Autowired FlashcardJpaMapper flashcardMapper;
+  @Autowired FlashcardReviewJpaMapper reviewMapper;
+  @Autowired FlashcardReviewLogJpaMapper logMapper;
+
+  private FlashcardRepositoryAdapter flashcardAdapter;
+  private FlashcardReviewRepositoryAdapter reviewAdapter;
+  private FlashcardReviewLogRepositoryAdapter logAdapter;
+
+  private final UUID unitId = UUID.randomUUID();
+  private final UUID userId = UUID.randomUUID();
+
+  @BeforeEach
+  void setUp() {
+    flashcardAdapter = new FlashcardRepositoryAdapter(flashcardRepo, flashcardMapper);
+    reviewAdapter    = new FlashcardReviewRepositoryAdapter(reviewRepo, reviewMapper);
+    logAdapter       = new FlashcardReviewLogRepositoryAdapter(logRepo, logMapper);
+  }
+
+  // ── Flashcard ─────────────────────────────────────────────────────────────
+
+  @Test
+  void saveAndFindFlashcardById() {
+    Flashcard card = Flashcard.create(unitId, "Capital de Francia", "París");
+    Flashcard saved = flashcardAdapter.save(card);
+
+    var found = flashcardAdapter.findById(saved.getId());
+    assertTrue(found.isPresent());
+    assertEquals("Capital de Francia", found.get().getFront());
+    assertEquals("París", found.get().getBack());
+  }
+
+  @Test
+  void findByUnitIdReturnsOnlyCardsForThatUnit() {
+    UUID otherUnit = UUID.randomUUID();
+    flashcardAdapter.save(Flashcard.create(unitId, "Q1", "A1"));
+    flashcardAdapter.save(Flashcard.create(unitId, "Q2", "A2"));
+    flashcardAdapter.save(Flashcard.create(otherUnit, "Q3", "A3"));
+
+    List<Flashcard> cards = flashcardAdapter.findByUnitId(unitId);
+    assertEquals(2, cards.size());
+    assertTrue(cards.stream().allMatch(c -> c.getUnitId().equals(unitId)));
+  }
+
+  @Test
+  void deleteFlashcardById() {
+    Flashcard card = flashcardAdapter.save(Flashcard.create(unitId, "front", "back"));
+    flashcardAdapter.deleteById(card.getId());
+    assertTrue(flashcardAdapter.findById(card.getId()).isEmpty());
+  }
+
+  // ── FlashcardReview ───────────────────────────────────────────────────────
+
+  @Test
+  void saveAndFindReviewByUserIdAndFlashcardId() {
+    UUID flashcardId = UUID.randomUUID();
+    FlashcardReview review = FlashcardReview.createNew(userId, flashcardId, LocalDateTime.now());
+    reviewAdapter.save(review);
+
+    var found = reviewAdapter.findByUserIdAndFlashcardId(userId, flashcardId);
+    assertTrue(found.isPresent());
+    assertEquals(ReviewState.NEW, found.get().getState());
+    assertEquals(2.5, found.get().getEaseFactor());
+  }
+
+  @Test
+  void saveTwiceSameUserCardUpserts() {
+    UUID flashcardId = UUID.randomUUID();
+    LocalDateTime due = LocalDateTime.now();
+    FlashcardReview review = FlashcardReview.createNew(userId, flashcardId, due);
+    reviewAdapter.save(review);
+
+    // apply a fake SM-2 update
+    review.update(ReviewState.LEARNING, 2.3, 1, 1, 0, due.plusDays(1));
+    reviewAdapter.save(review);
+
+    List<FlashcardReviewEntity> all = reviewRepo.findAll();
+    assertEquals(1, all.size(), "Upsert must not create a duplicate row");
+    assertEquals(ReviewState.LEARNING, all.get(0).getState());
+  }
+
+  @Test
+  void findDueByUserIdReturnsCardsOrderedByDueAtAsc() {
+    LocalDateTime now = LocalDateTime.now();
+    UUID card1 = UUID.randomUUID();
+    UUID card2 = UUID.randomUUID();
+    UUID card3 = UUID.randomUUID();
+
+    // card3 is due in the future — should NOT appear
+    reviewAdapter.save(FlashcardReview.createNew(userId, card1, now.minusDays(2)));
+    reviewAdapter.save(FlashcardReview.createNew(userId, card2, now.minusDays(1)));
+    reviewAdapter.save(FlashcardReview.createNew(userId, card3, now.plusDays(1)));
+
+    List<FlashcardReview> due = reviewAdapter.findDueByUserId(userId, now, 10);
+    assertEquals(2, due.size());
+    assertTrue(due.get(0).getDueAt().isBefore(due.get(1).getDueAt()));
+  }
+
+  @Test
+  void findDueByUserIdRespectsLimit() {
+    LocalDateTime now = LocalDateTime.now();
+    for (int i = 0; i < 5; i++) {
+      reviewAdapter.save(FlashcardReview.createNew(userId, UUID.randomUUID(), now.minusDays(i + 1)));
+    }
+    List<FlashcardReview> due = reviewAdapter.findDueByUserId(userId, now, 3);
+    assertEquals(3, due.size());
+  }
+
+  // ── FlashcardReviewLog ────────────────────────────────────────────────────
+
+  @Test
+  void saveLogAndFindRecentByUserId() {
+    UUID flashcardId = UUID.randomUUID();
+    LocalDateTime now = LocalDateTime.now();
+
+    FlashcardReviewLog log1 = FlashcardReviewLog.create(
+        userId, flashcardId, ReviewGrade.GOOD, now.minusMinutes(5), 0, 1, 2.5, 2.5);
+    FlashcardReviewLog log2 = FlashcardReviewLog.create(
+        userId, flashcardId, ReviewGrade.EASY, now, 1, 3, 2.5, 2.6);
+
+    logAdapter.save(log1);
+    logAdapter.save(log2);
+
+    List<FlashcardReviewLog> recent = logAdapter.findRecentByUserId(userId, 10);
+    assertEquals(2, recent.size());
+    // Most recent first
+    assertEquals(ReviewGrade.EASY, recent.get(0).getGrade());
+    assertEquals(ReviewGrade.GOOD, recent.get(1).getGrade());
+  }
+
+  @Test
+  void findRecentByUserIdRespectsLimit() {
+    LocalDateTime now = LocalDateTime.now();
+    UUID flashcardId = UUID.randomUUID();
+    for (int i = 0; i < 4; i++) {
+      logAdapter.save(FlashcardReviewLog.create(
+          userId, flashcardId, ReviewGrade.AGAIN, now.minusMinutes(i), null, null, null, null));
+    }
+    assertEquals(2, logAdapter.findRecentByUserId(userId, 2).size());
+  }
+}


### PR DESCRIPTION
## Summary

- Añade entidades JPA, mappers y repositorios Spring Data para `Flashcard`, `FlashcardReview` y `FlashcardReviewLog`
- Implementa los tres adaptadores de persistencia que cumplen los ports de salida del dominio
- Actualiza `FlashcardReviewRepository` para aceptar `upTo` y `limit` en `findDueByUserId`
- Actualiza `.gitignore` para excluir `CLAUDE.md` y `.claude/`

## Test plan

- [x] Verificar que el build de Gradle pasa sin errores (`./gradlew build`)
- [x] Verificar que los tests de `FlashcardPersistenceAdapterTest` pasan (`./gradlew test --tests "*FlashcardPersistenceAdapter*"`)
- [x] Arrancar el stack con `docker compose up --build` y comprobar que Flyway aplica las migraciones sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)