### PR TITLE
✨ AKDMIA-47: feat: Study UI — resumen del día

### DIFF
--- a/backend/src/main/java/com/akdemya/adapter/inbound/web/FlashcardController.java
+++ b/backend/src/main/java/com/akdemya/adapter/inbound/web/FlashcardController.java
@@ -109,7 +109,7 @@ public class FlashcardController {
   }
 
   @GetMapping("/study/queue")
-  public ResponseEntity<FlashcardDto.StudyQueueResponse> getStudyQueue(@RequestParam UUID unitId,
+  public ResponseEntity<FlashcardDto.StudyQueueResponse> getStudyQueue(@RequestParam(required = false) UUID unitId,
                                                                        @RequestParam(required = false) Integer limit,
                                                                        @AuthenticationPrincipal User principal) {
     UUID userId = requireUserId(principal);

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/FlashcardRepositoryAdapter.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/FlashcardRepositoryAdapter.java
@@ -52,6 +52,11 @@ public class FlashcardRepositoryAdapter implements FlashcardRepository {
   }
 
   @Override
+  public long countNewByUserId(UUID userId) {
+    return jpa.countNewByUserId(userId);
+  }
+
+  @Override
   public Flashcard save(Flashcard flashcard) {
     return mapper.toDomain(jpa.save(mapper.toEntity(flashcard)));
   }

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/FlashcardReviewRepositoryAdapter.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/FlashcardReviewRepositoryAdapter.java
@@ -79,6 +79,11 @@ public class FlashcardReviewRepositoryAdapter implements FlashcardReviewReposito
         userId, unitId, fromExclusive.toInstant(ZoneOffset.UTC), toInclusive.toInstant(ZoneOffset.UTC));
   }
 
+  @Override
+  public long countDueByUserIdAndStateIn(UUID userId, LocalDateTime upTo, List<ReviewState> states) {
+    return jpa.countDueByUserIdAndStateIn(userId, upTo.toInstant(ZoneOffset.UTC), states);
+  }
+
   /**
    * Upsert: if a review already exists for (userId, flashcardId) patch its SRS fields;
    * otherwise insert a new row. This avoids unique-constraint violations on re-saves.

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/repository/JpaFlashcardRepository.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/repository/JpaFlashcardRepository.java
@@ -38,4 +38,13 @@ public interface JpaFlashcardRepository extends JpaRepository<FlashcardEntity, U
       """)
   long countNewByUserIdAndUnitId(@Param("userId") UUID userId,
                                  @Param("unitId") UUID unitId);
+
+  @Query("""
+      select count(f) from FlashcardEntity f
+      where not exists (
+        select 1 from FlashcardReviewEntity r
+        where r.userId = :userId and r.flashcardId = f.id
+      )
+      """)
+  long countNewByUserId(@Param("userId") UUID userId);
 }

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/repository/JpaFlashcardReviewRepository.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/repository/JpaFlashcardReviewRepository.java
@@ -80,4 +80,14 @@ public interface JpaFlashcardReviewRepository extends JpaRepository<FlashcardRev
                                        @Param("unitId") UUID unitId,
                                        @Param("fromExclusive") Instant fromExclusive,
                                        @Param("toInclusive") Instant toInclusive);
+
+  @Query("""
+      select count(r) from FlashcardReviewEntity r
+      where r.userId = :userId
+        and r.dueAt <= :upTo
+        and r.state in :states
+      """)
+  long countDueByUserIdAndStateIn(@Param("userId") UUID userId,
+                                  @Param("upTo") Instant upTo,
+                                  @Param("states") List<ReviewState> states);
 }

--- a/backend/src/main/java/com/akdemya/application/service/FlashcardStudyService.java
+++ b/backend/src/main/java/com/akdemya/application/service/FlashcardStudyService.java
@@ -41,14 +41,23 @@ public class FlashcardStudyService implements FlashcardStudyUseCase {
   public StudyQueueResponse getStudyQueue(StudyQueueCommand command) {
     if (command == null) throw new IllegalArgumentException("command cannot be null");
     if (command.userId() == null) throw new IllegalArgumentException("userId cannot be null");
-    if (command.unitId() == null) throw new IllegalArgumentException("unitId cannot be null");
     LocalDateTime now = command.now() != null ? command.now() : LocalDateTime.now();
 
-    long learningCount = reviewRepo.countDueByUserIdAndUnitIdAndStateIn(
-        command.userId(), command.unitId(), now, List.of(ReviewState.LEARNING));
-    long dueCount = reviewRepo.countDueByUserIdAndUnitIdAndStateIn(
-        command.userId(), command.unitId(), now, List.of(ReviewState.REVIEW));
-    long newCount = flashcardRepo.countNewByUserIdAndUnitId(command.userId(), command.unitId());
+    long learningCount;
+    long dueCount;
+    long newCount;
+
+    if (command.unitId() == null) {
+      learningCount = reviewRepo.countDueByUserIdAndStateIn(command.userId(), now, List.of(ReviewState.LEARNING));
+      dueCount = reviewRepo.countDueByUserIdAndStateIn(command.userId(), now, List.of(ReviewState.REVIEW));
+      newCount = flashcardRepo.countNewByUserId(command.userId());
+    } else {
+      learningCount = reviewRepo.countDueByUserIdAndUnitIdAndStateIn(
+          command.userId(), command.unitId(), now, List.of(ReviewState.LEARNING));
+      dueCount = reviewRepo.countDueByUserIdAndUnitIdAndStateIn(
+          command.userId(), command.unitId(), now, List.of(ReviewState.REVIEW));
+      newCount = flashcardRepo.countNewByUserIdAndUnitId(command.userId(), command.unitId());
+    }
 
     return new StudyQueueResponse(newCount, dueCount, learningCount);
   }

--- a/backend/src/main/java/com/akdemya/domain/port/out/FlashcardRepository.java
+++ b/backend/src/main/java/com/akdemya/domain/port/out/FlashcardRepository.java
@@ -18,6 +18,8 @@ public interface FlashcardRepository {
 
   long countNewByUserIdAndUnitId(UUID userId, UUID unitId);
 
+  long countNewByUserId(UUID userId);
+
   Flashcard save(Flashcard flashcard);
 
   void deleteById(UUID id);

--- a/backend/src/main/java/com/akdemya/domain/port/out/FlashcardReviewRepository.java
+++ b/backend/src/main/java/com/akdemya/domain/port/out/FlashcardReviewRepository.java
@@ -27,5 +27,7 @@ public interface FlashcardReviewRepository {
 
   long countDueByUserIdAndUnitIdBetween(UUID userId, UUID unitId, LocalDateTime fromExclusive, LocalDateTime toInclusive);
 
+  long countDueByUserIdAndStateIn(UUID userId, LocalDateTime upTo, List<ReviewState> states);
+
   FlashcardReview save(FlashcardReview review);
 }

--- a/backend/src/test/java/com/akdemya/application/service/FlashcardReviewServiceTest.java
+++ b/backend/src/test/java/com/akdemya/application/service/FlashcardReviewServiceTest.java
@@ -99,6 +99,11 @@ class FlashcardReviewServiceTest {
     }
 
     @Override
+    public long countNewByUserId(UUID userId) {
+      return 0;
+    }
+
+    @Override
     public Flashcard save(Flashcard flashcard) {
       data.put(flashcard.getId(), flashcard);
       return flashcard;
@@ -149,6 +154,11 @@ class FlashcardReviewServiceTest {
     @Override
     public long countDueByUserIdAndUnitIdBetween(UUID userId, UUID unitId, LocalDateTime fromExclusive,
                                                  LocalDateTime toInclusive) {
+      return 0;
+    }
+
+    @Override
+    public long countDueByUserIdAndStateIn(UUID userId, LocalDateTime upTo, List<ReviewState> states) {
       return 0;
     }
 

--- a/backend/src/test/java/com/akdemya/application/service/FlashcardStudyServiceTest.java
+++ b/backend/src/test/java/com/akdemya/application/service/FlashcardStudyServiceTest.java
@@ -72,6 +72,94 @@ class FlashcardStudyServiceTest {
   }
 
   @Test
+  void studyQueueReturnsZerosForUserWithNoCards() {
+    InMemoryFlashcardRepo flashcardRepo = new InMemoryFlashcardRepo();
+    InMemoryReviewRepo reviewRepo = new InMemoryReviewRepo(flashcardRepo);
+    flashcardRepo.attach(reviewRepo);
+
+    FlashcardStudyService service = new FlashcardStudyService(flashcardRepo, reviewRepo, schedulerProperties);
+    var response = service.getStudyQueue(new FlashcardStudyUseCase.StudyQueueCommand(userId, null, 5, now));
+
+    assertEquals(0, response.newCount());
+    assertEquals(0, response.dueCount());
+    assertEquals(0, response.learningCount());
+  }
+
+  @Test
+  void studyQueueOnlyNewCards() {
+    InMemoryFlashcardRepo flashcardRepo = new InMemoryFlashcardRepo();
+    InMemoryReviewRepo reviewRepo = new InMemoryReviewRepo(flashcardRepo);
+    flashcardRepo.attach(reviewRepo);
+
+    flashcardRepo.save(flashcard("card1", unitId));
+    flashcardRepo.save(flashcard("card2", unitId));
+
+    FlashcardStudyService service = new FlashcardStudyService(flashcardRepo, reviewRepo, schedulerProperties);
+    var response = service.getStudyQueue(new FlashcardStudyUseCase.StudyQueueCommand(userId, null, 5, now));
+
+    assertEquals(2, response.newCount());
+    assertEquals(0, response.dueCount());
+    assertEquals(0, response.learningCount());
+  }
+
+  @Test
+  void studyQueueOnlyLearningDue() {
+    InMemoryFlashcardRepo flashcardRepo = new InMemoryFlashcardRepo();
+    InMemoryReviewRepo reviewRepo = new InMemoryReviewRepo(flashcardRepo);
+    flashcardRepo.attach(reviewRepo);
+
+    Flashcard card = flashcard("card1", unitId);
+    flashcardRepo.save(card);
+    reviewRepo.save(review(card.getId(), now.minusMinutes(5), ReviewState.LEARNING));
+
+    FlashcardStudyService service = new FlashcardStudyService(flashcardRepo, reviewRepo, schedulerProperties);
+    var response = service.getStudyQueue(new FlashcardStudyUseCase.StudyQueueCommand(userId, null, 5, now));
+
+    assertEquals(0, response.newCount());
+    assertEquals(0, response.dueCount());
+    assertEquals(1, response.learningCount());
+  }
+
+  @Test
+  void studyQueueGlobalAcrossUnits() {
+    InMemoryFlashcardRepo flashcardRepo = new InMemoryFlashcardRepo();
+    InMemoryReviewRepo reviewRepo = new InMemoryReviewRepo(flashcardRepo);
+    flashcardRepo.attach(reviewRepo);
+
+    UUID unitId2 = UUID.randomUUID();
+    flashcardRepo.save(flashcard("card-unit1", unitId));
+    flashcardRepo.save(flashcard("card-unit2", unitId2));
+
+    FlashcardStudyService service = new FlashcardStudyService(flashcardRepo, reviewRepo, schedulerProperties);
+    var response = service.getStudyQueue(new FlashcardStudyUseCase.StudyQueueCommand(userId, null, 5, now));
+
+    assertEquals(2, response.newCount());
+    assertEquals(0, response.dueCount());
+    assertEquals(0, response.learningCount());
+  }
+
+  @Test
+  void studyQueueFutureCardsNotCounted() {
+    InMemoryFlashcardRepo flashcardRepo = new InMemoryFlashcardRepo();
+    InMemoryReviewRepo reviewRepo = new InMemoryReviewRepo(flashcardRepo);
+    flashcardRepo.attach(reviewRepo);
+
+    Flashcard learningCard = flashcard("learning-future", unitId);
+    Flashcard reviewCard = flashcard("review-future", unitId);
+    flashcardRepo.save(learningCard);
+    flashcardRepo.save(reviewCard);
+    reviewRepo.save(review(learningCard.getId(), now.plusMinutes(30), ReviewState.LEARNING));
+    reviewRepo.save(review(reviewCard.getId(), now.plusDays(1), ReviewState.REVIEW));
+
+    FlashcardStudyService service = new FlashcardStudyService(flashcardRepo, reviewRepo, schedulerProperties);
+    var response = service.getStudyQueue(new FlashcardStudyUseCase.StudyQueueCommand(userId, null, 5, now));
+
+    assertEquals(0, response.newCount());
+    assertEquals(0, response.dueCount());
+    assertEquals(0, response.learningCount());
+  }
+
+  @Test
   void dashboardCountsAreCoherent() {
     InMemoryFlashcardRepo flashcardRepo = new InMemoryFlashcardRepo();
     InMemoryReviewRepo reviewRepo = new InMemoryReviewRepo(flashcardRepo);
@@ -158,6 +246,13 @@ class FlashcardStudyServiceTest {
     }
 
     @Override
+    public long countNewByUserId(UUID userId) {
+      return data.values().stream()
+          .filter(f -> reviewRepo.findByUserIdAndFlashcardId(userId, f.getId()).isEmpty())
+          .count();
+    }
+
+    @Override
     public Flashcard save(Flashcard flashcard) {
       data.put(flashcard.getId(), flashcard);
       return flashcard;
@@ -239,6 +334,15 @@ class FlashcardStudyServiceTest {
           .filter(r -> r.getDueAt().isAfter(fromExclusive) && !r.getDueAt().isAfter(toInclusive))
           .filter(r -> flashcardRepo.findById(r.getFlashcardId())
               .map(f -> f.getUnitId().equals(unitId)).orElse(false))
+          .count();
+    }
+
+    @Override
+    public long countDueByUserIdAndStateIn(UUID userId, LocalDateTime upTo, List<ReviewState> states) {
+      return data.values().stream()
+          .filter(r -> r.getUserId().equals(userId))
+          .filter(r -> states.contains(r.getState()))
+          .filter(r -> !r.getDueAt().isAfter(upTo))
           .count();
     }
 

--- a/frontend/src/pages/FlashcardsPage.tsx
+++ b/frontend/src/pages/FlashcardsPage.tsx
@@ -13,12 +13,16 @@ export type UnitSummary = {
   dueCount?: number;
 };
 
+type GlobalQueue = { new: number; due: number; learning: number };
+
 export default function FlashcardsPage(){
   const navigate = useNavigate();
   const [units, setUnits] = useState<UnitSummary[]>([]);
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>('');
+  const [globalQueue, setGlobalQueue] = useState<GlobalQueue | null>(null);
+  const [globalLoading, setGlobalLoading] = useState(true);
 
   const token = localStorage.getItem('ak_token') || '';
 
@@ -42,11 +46,29 @@ export default function FlashcardsPage(){
     return () => { mounted = false; };
   }, [token]);
 
+  useEffect(() => {
+    let mounted = true;
+    setGlobalLoading(true);
+    apiAuthJson<GlobalQueue>(`${apiBase}/api/flashcards/study/queue`, token)
+      .then((data) => {
+        if (!mounted) return;
+        setGlobalQueue(data || null);
+      })
+      .catch(() => { /* silencioso, no bloquea la lista de unidades */ })
+      .finally(() => {
+        if (!mounted) return;
+        setGlobalLoading(false);
+      });
+    return () => { mounted = false; };
+  }, [token]);
+
   const filteredUnits = useMemo(() => {
     const q = search.trim().toLowerCase();
     if (!q) return units;
     return units.filter((u) => u.unitName.toLowerCase().includes(q));
   }, [units, search]);
+
+  const totalPending = globalQueue ? globalQueue.new + globalQueue.due + globalQueue.learning : 0;
 
   return (
     <div className="space-y-6">
@@ -57,6 +79,20 @@ export default function FlashcardsPage(){
           if (tab === 'historial') navigate('/flashcards/history');
         }} />
       </header>
+
+      {globalLoading ? (
+        <div className="animate-pulse h-12 rounded-2xl bg-white/60 dark:bg-slate-800/60" />
+      ) : globalQueue && totalPending === 0 ? (
+        <div className="rounded-2xl bg-white dark:bg-slate-900 px-4 py-3 shadow text-center text-sm text-secondary">
+          Nada pendiente hoy 🎉
+        </div>
+      ) : globalQueue ? (
+        <div className="flex items-center justify-around rounded-2xl bg-white dark:bg-slate-900 px-4 py-3 shadow text-sm font-medium">
+          <span className="text-emerald-600">🆕 {globalQueue.new} nuevas</span>
+          <span className="text-amber-500">⚡ {globalQueue.learning} aprendiendo</span>
+          <span className="text-blue-500">🔁 {globalQueue.due} pendientes</span>
+        </div>
+      ) : null}
 
       <section className="space-y-4">
         <SearchInput value={search} onChange={setSearch} />

--- a/frontend/src/pages/FlashcardsStudyPage.tsx
+++ b/frontend/src/pages/FlashcardsStudyPage.tsx
@@ -110,18 +110,6 @@ export default function FlashcardsStudyPage() {
     }
   }, [remaining, loading, currentItem]);
 
-  const decrementQueueCounts = (state?: ReviewState) => {
-    setQueueCounts((prev) => {
-      if (state === 'LEARNING') {
-        return { ...prev, learning: Math.max(prev.learning - 1, 0) };
-      }
-      if (state === 'REVIEW') {
-        return { ...prev, due: Math.max(prev.due - 1, 0) };
-      }
-      return { ...prev, new: Math.max(prev.new - 1, 0) };
-    });
-  };
-
   const handleReview = async (grade: ReviewRequest['grade']) => {
     if (!currentItem || submitting) return;
     setSubmitting(true);
@@ -135,12 +123,11 @@ export default function FlashcardsStudyPage() {
           reviewedAt: new Date().toISOString()
         } satisfies ReviewRequest)
       });
-      decrementQueueCounts(currentItem.state ?? 'NEW');
+      const [newQueue, next] = await Promise.all([fetchQueue(), fetchNext()]);
+      if (newQueue) setQueueCounts(newQueue);
       setAnsweredCount((prev) => prev + 1);
       setShowAnswer(false);
-      const next = await fetchNext();
       if (!next) {
-        setQueueCounts({ new: 0, due: 0, learning: 0 });
         setFinished(true);
         return;
       }


### PR DESCRIPTION
## Summary

- **Global study queue endpoint**: `GET /api/flashcards/study/queue` now accepts `unitId` as optional — when omitted, returns aggregate new/due/learning counts across all units
- **Motivational summary banner** in `FlashcardsPage`: fetches global queue on mount and displays new/learning/due counters (skeleton while loading, empty-state "Nada pendiente hoy 🎉" when all zeros)
- **Accurate queue counts during study**: `FlashcardsStudyPage` now refetches the queue from the backend after each card review instead of doing local decrement, keeping counters in sync with real state

## Backend changes

- Added `countNewByUserId` to `FlashcardRepository` port + JPA query + adapter
- Added `countDueByUserIdAndStateIn` to `FlashcardReviewRepository` port + JPA query + adapter
- Bifurcated `FlashcardStudyService.getStudyQueue()`: null `unitId` → global query, non-null → existing per-unit logic
- 5 new unit tests in `FlashcardStudyServiceTest` covering global queue scenarios

## Test plan

- [ ] `./gradlew test` passes (all tests green, including 5 new)
- [ ] `GET /api/flashcards/study/queue` without `unitId` returns correct global `{new, due, learning}`
- [ ] `FlashcardsPage` shows the summary banner with 3 counters
- [ ] Answering a card in study session updates counters from backend (not local decrement)
- [ ] `npm run build` has no new TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)