### PR TITLE
💄 AKDMIA-73: feat: UI/UX improvements across exam and study flows

### DIFF
--- a/frontend/src/components/ExamRunner.tsx
+++ b/frontend/src/components/ExamRunner.tsx
@@ -89,11 +89,13 @@ export default function ExamRunner({ questions, totalTimeSeconds, onFinish, init
     <div className="max-w-3xl mx-auto p-4">
       <header className="flex items-center justify-between mb-4">
         <div className="text-xl font-semibold">Pregunta {index+1} / {shuffled.length}</div>
-        <div aria-label="Timer" className="font-mono text-lg">⏱ {Math.floor(remaining/60)}:{String(remaining%60).padStart(2,'0')}</div>
+        <div aria-label="Timer" className={`font-mono text-lg font-bold ${remaining < 120 ? 'text-red-500 animate-pulse' : ''}`}>
+          ⏱ {Math.floor(remaining/60)}:{String(remaining%60).padStart(2,'0')}
+        </div>
       </header>
 
-      <div className="w-full bg-slate-700 h-2 rounded mb-6">
-        <div className="h-2 bg-accent rounded" style={{ width: `${progress}%` }} />
+      <div className="w-full h-2 rounded-full overflow-hidden bg-secondary/20 dark:bg-slate-700 mb-6">
+        <div className="h-full bg-primary rounded-full transition-all" style={{ width: `${progress}%` }} />
       </div>
 
       <h2 className="text-2xl font-bold mb-3">{q.text}</h2>

--- a/frontend/src/components/flashcards/UnitCard.tsx
+++ b/frontend/src/components/flashcards/UnitCard.tsx
@@ -14,7 +14,7 @@ export default function UnitCard({ unit }: { unit: UnitSummary }) {
     <button
       type="button"
       onClick={() => navigate(`/flashcards/study?unitId=${unit.unitId}`)}
-      className="w-full text-left rounded-2xl border border-gray-200 bg-white/90 p-4 shadow-sm transition hover:shadow-md hover:scale-[1.01] dark:border-slate-700 dark:bg-slate-800"
+      className="w-full text-left rounded-2xl border border-gray-200 bg-white/90 p-4 shadow-sm transition hover:shadow-md hover:scale-[1.01] dark:border-slate-700 dark:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2"
     >
       <div className="flex items-center gap-3">
         <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-white/80 text-secondary dark:bg-slate-700/70">

--- a/frontend/src/components/flashcards/UnitList.tsx
+++ b/frontend/src/components/flashcards/UnitList.tsx
@@ -30,8 +30,9 @@ export default function UnitList({
 
   if (!units.length) {
     return (
-      <div className="rounded-2xl border border-gray-200 bg-white/80 px-4 py-3 text-sm text-slate-500">
-        No hay unidades disponibles.
+      <div className="rounded-2xl border border-gray-200 bg-white/80 px-4 py-6 text-center dark:border-slate-700 dark:bg-slate-800/50">
+        <p className="text-sm font-medium text-slate-700 dark:text-slate-300">No hay unidades con tarjetas</p>
+        <p className="mt-1 text-sm text-slate-500">Ve a <strong>Ajustes</strong> para añadir flashcards a tus unidades.</p>
       </div>
     );
   }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,6 +18,12 @@
   .btn-outline {
     @apply border border-secondary/60 text-text;
   }
+  .btn-sm {
+    @apply px-2 py-1 text-xs rounded-md;
+  }
+  .btn-lg {
+    @apply px-5 py-3 text-base rounded-xl;
+  }
   nav[role="navigation"] [data-testid="flowbite-navbar-collapse"] ul {
     line-height: 2.25rem;
     align-items: center;

--- a/frontend/src/pages/ExamResultPage.tsx
+++ b/frontend/src/pages/ExamResultPage.tsx
@@ -1,5 +1,5 @@
 import { Navigate, Link } from 'react-router-dom';
-import { ArrowLeft } from 'flowbite-react-icons/outline';
+import { ArrowLeft, Plus } from 'flowbite-react-icons/outline';
 import type { ExamResult } from '../types';
 import { ROUTES } from '../constants/routes';
 
@@ -33,10 +33,14 @@ export default function ExamResultPage({ result }: { result: ExamResult | null }
         <p>Porcentaje neto: <strong>{result.percentage.toFixed(1)}%</strong></p>
       </div>
       <p className="text-slate-400 mt-3">Cada 3 fallos restan 1 acierto.</p>
-      <div className="mt-4">
-        <Link className="btn btn-secondary flex items-center gap-2" to={ROUTES.subjects}>
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+        <Link className="btn btn-primary flex items-center gap-2" to={ROUTES.subjects}>
+          <Plus className="w-4 h-4" />
+          Nuevo examen
+        </Link>
+        <Link className="btn btn-outline flex items-center gap-2" to={ROUTES.subjects}>
           <ArrowLeft className="w-4 h-4" />
-          Volver a exámenes
+          Volver
         </Link>
       </div>
     </div>

--- a/frontend/src/pages/FlashcardsStudyPage.tsx
+++ b/frontend/src/pages/FlashcardsStudyPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ArrowLeft } from 'flowbite-react-icons/outline';
+import { Modal, Button, ModalBody, ModalFooter, ModalHeader } from 'flowbite-react';
 import { apiAuthJson, apiBase } from '../api';
 
 type IntervalHints = {
@@ -208,8 +209,8 @@ export default function FlashcardsStudyPage() {
           </div>
           <span>⏱ {progressPct}%</span>
         </div>
-        <div className="h-2 w-full overflow-hidden rounded-full bg-white/80 dark:bg-slate-800">
-          <div className="h-full bg-primary" style={{ width: `${progressPct}%` }} />
+        <div className="h-2 w-full overflow-hidden rounded-full bg-secondary/20 dark:bg-slate-700">
+          <div className="h-full bg-primary rounded-full transition-all" style={{ width: `${progressPct}%` }} />
         </div>
       </div>
 
@@ -278,18 +279,19 @@ export default function FlashcardsStudyPage() {
         <button className="btn btn-primary" onClick={handleFinish}>Terminar</button>
       </div>
 
-      {confirmOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
-          <div className="w-full max-w-sm rounded-2xl bg-white dark:bg-slate-900 p-6 shadow-xl">
-            <h3 className="text-lg font-semibold">Te quedan {remaining} tarjetas</h3>
-            <p className="mt-2 text-sm text-secondary">¿Quieres terminar la sesión?</p>
-            <div className="mt-4 flex justify-end gap-2">
-              <button className="btn btn-secondary" onClick={() => setConfirmOpen(false)}>Cancelar</button>
-              <button className="btn btn-primary" onClick={confirmFinish}>Terminar</button>
-            </div>
-          </div>
-        </div>
-      )}
+      <Modal show={confirmOpen} onClose={() => setConfirmOpen(false)} theme={{
+        root: { base: 'fixed inset-x-0 top-0 z-50 h-screen overflow-y-auto overflow-x-hidden md:inset-0 md:h-full' },
+        content: { base: 'relative h-full w-full p-4 md:h-auto', inner: 'relative flex max-h-[90dvh] flex-col rounded-lg bg-bg text-text shadow border border-secondary/40' }
+      }}>
+        <ModalHeader className="border-b border-secondary/40">Te quedan {remaining} tarjetas</ModalHeader>
+        <ModalBody>
+          <p className="text-text/70">¿Quieres terminar la sesión?</p>
+        </ModalBody>
+        <ModalFooter className="border-t border-secondary/40">
+          <Button color="light" onClick={() => setConfirmOpen(false)} className="btn btn-outline shadow-none">Cancelar</Button>
+          <Button onClick={confirmFinish} className="btn btn-primary">Terminar</Button>
+        </ModalFooter>
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/pages/SubjectsPage.tsx
+++ b/frontend/src/pages/SubjectsPage.tsx
@@ -19,6 +19,16 @@ export default function SubjectsPage({ subjects, activeAttemptId, token, onUnaut
   const [history, setHistory] = useState<ExamAttemptSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [showAll, setShowAll] = useState(false);
+
+  const INITIAL_SHOW = 5;
+
+  function scoreColor(percent: number) {
+    if (percent < 50) return 'text-red-500';
+    if (percent <= 60) return 'text-orange-500';
+    if (percent <= 80) return 'text-yellow-500';
+    return 'text-lime-500';
+  }
 
   useEffect(() => {
     setLoading(true);
@@ -78,7 +88,7 @@ export default function SubjectsPage({ subjects, activeAttemptId, token, onUnaut
         )}
         {!loading && !error && history.length > 0 && (
           <div className="grid gap-3">
-            {history.map(h => {
+            {(showAll ? history : history.slice(0, INITIAL_SHOW)).map(h => {
               const finished = Boolean(h.finishedAt);
               const timeSpent = finished && h.startedAt && h.finishedAt
                 ? Math.max(0, Math.floor((new Date(h.finishedAt).getTime() - new Date(h.startedAt).getTime()) / 1000))
@@ -89,7 +99,12 @@ export default function SubjectsPage({ subjects, activeAttemptId, token, onUnaut
                     <div className="font-semibold">{h.subjectName || 'Materia'}</div>
                     <div className="text-sm text-text/70">{new Date(h.startedAt).toLocaleString()}</div>
                     <div className="text-sm mt-1">Estado: <strong>{finished ? 'Finalizado' : 'En curso'}</strong></div>
-                    <div className="text-sm">Resultado: <strong>{(h.score ?? 0)} ({h.percent.toFixed(1)}%)</strong></div>
+                    <div className="text-sm">
+                      Resultado:{' '}
+                      <strong className={finished ? scoreColor(h.percent) : ''}>
+                        {(h.score ?? 0).toFixed(2)} ({h.percent.toFixed(1)}%)
+                      </strong>
+                    </div>
                     <div className="text-sm">Tiempo empleado: <strong>{finished ? formatDuration(timeSpent) : formatDuration(h.totalTimeSeconds)}</strong></div>
                   </div>
                   <div className="flex gap-2">
@@ -114,6 +129,14 @@ export default function SubjectsPage({ subjects, activeAttemptId, token, onUnaut
                 </Card>
               );
             })}
+            {history.length > INITIAL_SHOW && (
+              <button
+                className="btn btn-outline w-full"
+                onClick={() => setShowAll(v => !v)}
+              >
+                {showAll ? 'Ver menos' : `Ver ${history.length - INITIAL_SHOW} más`}
+              </button>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

9 UI/UX improvements across exam and flashcard study flows:

- **#1 Timer urgente**: ExamRunner timer turns red + pulse animation when < 2 min remaining
- **#2 Color-coded history**: Exam history scores colored red/orange/yellow/lime matching ExamResultPage logic
- **#3 Paginated history**: Show last 5 attempts by default with "Ver más/menos" toggle
- **#4 Keyboard accessibility**: `focus-visible` ring on UnitCard for keyboard navigation
- **#5 Consistent progress bars**: Standardized track (`bg-secondary/20`) and fill (`bg-primary`) across ExamRunner and FlashcardsStudyPage
- **#6 Unified modals**: FlashcardsStudyPage finish modal converted from custom inline div to Flowbite Modal (same pattern as ExamRunner)
- **#7 Button size variants**: Added `.btn-sm` and `.btn-lg` to `index.css`
- **#8 ExamResult CTAs**: Added primary "Nuevo examen" button alongside "Volver"
- **#9 Empty state**: UnitList empty state improved with instructions to go to Settings

## Test plan

- [ ] Start an exam with < 2 min — timer goes red and pulses
- [ ] Check exam history — scores are color-coded by result
- [ ] With > 5 exams in history — "Ver más" button appears and expands the list
- [ ] Tab through FlashcardsPage unit cards — focus ring is visible
- [ ] Progress bars look consistent between exam and flashcard study sessions
- [ ] "Terminar" in study session opens Flowbite modal (not custom div)
- [ ] ExamResult page shows "Nuevo examen" (primary) + "Volver" (outline) buttons
- [ ] FlashcardsPage with no units shows improved empty state with Settings hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)