### PR TITLE
fix(oauth2): restore full Google OAuth2 flow and fix redirect routing

### DIFF
--- a/backend/src/main/java/com/akdemya/adapter/infrastructure/security/GoogleOAuth2UserService.java
+++ b/backend/src/main/java/com/akdemya/adapter/infrastructure/security/GoogleOAuth2UserService.java
@@ -1,0 +1,20 @@
+package com.akdemya.adapter.infrastructure.security;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+/**
+ * Loads the OAuth2 user from Google. User creation/lookup is handled by
+ * OAuth2SuccessHandler after successful authentication.
+ */
+@Service
+public class GoogleOAuth2UserService extends DefaultOAuth2UserService {
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        return super.loadUser(userRequest);
+    }
+}

--- a/backend/src/main/java/com/akdemya/adapter/infrastructure/security/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/akdemya/adapter/infrastructure/security/OAuth2SuccessHandler.java
@@ -1,0 +1,38 @@
+package com.akdemya.adapter.infrastructure.security;
+
+import com.akdemya.domain.port.in.AuthUseCase;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final AuthUseCase authUseCase;
+    private final String frontendUrl;
+
+    public OAuth2SuccessHandler(AuthUseCase authUseCase,
+                                @Value("${app.frontend-url}") String frontendUrl) {
+        this.authUseCase = authUseCase;
+        this.frontendUrl = frontendUrl;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+        OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;
+        OAuth2User oAuth2User = token.getPrincipal();
+        String email = oAuth2User.getAttribute("email");
+        String name = oAuth2User.getAttribute("name");
+        AuthUseCase.AuthResponse authResponse = authUseCase.loginWithOAuth2(email, name);
+        response.sendRedirect(frontendUrl + "/oauth2/callback?token=" + authResponse.accessToken());
+    }
+}

--- a/backend/src/main/java/com/akdemya/adapter/infrastructure/security/PasswordEncoderConfig.java
+++ b/backend/src/main/java/com/akdemya/adapter/infrastructure/security/PasswordEncoderConfig.java
@@ -1,0 +1,20 @@
+package com.akdemya.adapter.infrastructure.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * Extracted from SecurityConfig to break the circular dependency:
+ * SecurityConfig -> OAuth2SuccessHandler -> AuthManager ->
+ * SpringSecurityPasswordHasher -> PasswordEncoder (@Bean in SecurityConfig).
+ */
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/com/akdemya/adapter/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/com/akdemya/adapter/infrastructure/security/SecurityConfig.java
@@ -14,8 +14,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -32,32 +30,36 @@ import jakarta.servlet.http.HttpServletResponse;
 public class SecurityConfig {
 
     private final JwtService jwt;
+    private final GoogleOAuth2UserService googleOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
-    public SecurityConfig(JwtService jwt) {
+    public SecurityConfig(JwtService jwt,
+                          GoogleOAuth2UserService googleOAuth2UserService,
+                          OAuth2SuccessHandler oAuth2SuccessHandler) {
         this.jwt = jwt;
+        this.googleOAuth2UserService = googleOAuth2UserService;
+        this.oAuth2SuccessHandler = oAuth2SuccessHandler;
     }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
-                .cors(cors -> cors.configurationSource(corsConfigurationSource())) // <- habilita CORS
-                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                // IF_REQUIRED: stateless for JWT requests, but creates session when needed
+                // for the OAuth2 state verification during the authorization code flow.
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .authorizeHttpRequests(reg -> reg
-                        // Permite preflight de CORS
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-
-                        // Endpoints públicos
                         .requestMatchers("/api/auth/**").permitAll()
-
-                        // Admin only
+                        .requestMatchers("/login/oauth2/**", "/oauth2/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .anyRequest().authenticated())
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(ui -> ui.userService(googleOAuth2UserService))
+                        .successHandler(oAuth2SuccessHandler));
 
-                        // Resto autenticado
-                        .anyRequest().authenticated());
-
-        // Mantén tu filtro JWT si lo tienes
-        http.addFilterBefore(new SecurityConfig.JwtAuthFilter(jwt),
+        http.addFilterBefore(new JwtAuthFilter(jwt),
                 org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
@@ -66,8 +68,6 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration cfg = new CorsConfiguration();
-
-        // En dev: permite tu frontend
         cfg.setAllowedOrigins(List.of(
                 "http://localhost:5173",
                 "http://127.0.0.1:5173",
@@ -76,24 +76,19 @@ public class SecurityConfig {
                 "http://192.168.1.175:3000",
                 "https://akademia.diegobarrioh.dev"
         ));
-        // Si usas otras URLs (puertos distintos, etc.), añádelas aquí
-        // cfg.setAllowedOriginPatterns(List.of("*")); // alternativa amplia en dev
-
         cfg.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
         cfg.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept", "Origin", "X-Requested-With"));
         cfg.setExposedHeaders(List.of("Authorization", "Content-Type"));
-        cfg.setAllowCredentials(true); // si vas a enviar cookies/autenticación
+        cfg.setAllowCredentials(true);
         cfg.setMaxAge(3600L);
-
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", cfg);
         return source;
     }
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+    // PasswordEncoder @Bean lives in PasswordEncoderConfig to avoid the circular
+    // dependency: SecurityConfig -> OAuth2SuccessHandler -> AuthManager ->
+    // SpringSecurityPasswordHasher -> PasswordEncoder (@Bean here) -> cycle.
 
     static class JwtAuthFilter extends OncePerRequestFilter {
         private final JwtService jwt;

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -15,6 +15,16 @@ spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
 security.jwt.secret=${JWT_SECRET}
 
+# Google OAuth2
+spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID:}
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET:}
+spring.security.oauth2.client.registration.google.scope=openid,email,profile
+app.frontend-url=${FRONTEND_URL:http://localhost:5173}
+
+# Trust X-Forwarded-* headers so Spring constructs the correct redirect_uri
+# (https://domain/login/oauth2/code/google) when running behind the nginx proxy.
+server.forward-headers-strategy=framework
+
 app.flashcards.learning-steps-minutes=1,10
 app.flashcards.easy-interval-days=4
 app.flashcards.review-again-relearn-minutes=10

--- a/compose.yaml
+++ b/compose.yaml
@@ -33,6 +33,9 @@ services:
       JWT_SECRET: "akdemya-secret-key-please-change-me-32bytes"
       GROQ_API_KEY: ${GROQ_API_KEY}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
+      FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
     depends_on:
       db:
         condition: service_healthy

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,12 @@
-FROM node:20-alpine
+FROM node:20-alpine AS builder
 WORKDIR /app
 COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
 RUN if [ -f yarn.lock ]; then yarn --frozen-lockfile; elif [ -f pnpm-lock.yaml ]; then npm i -g pnpm && pnpm i --frozen-lockfile; else npm i; fi;
 COPY . .
 RUN npm run build
+
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 3000
-CMD ["npx", "serve", "-s", "dist", "-l", "3000"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,40 @@
+server {
+    listen 3000;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Proxy API, OAuth2 authorization and callback endpoints to the backend.
+    # This is critical: without this, the SPA catches /oauth2/* routes and
+    # React Router redirects to home because it has no matching route.
+    location /api/ {
+        proxy_pass         http://api:8080/api/;
+        proxy_set_header   Host              $http_host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header   X-Forwarded-Host  $http_host;
+    }
+
+    location /oauth2/ {
+        proxy_pass         http://api:8080/oauth2/;
+        proxy_set_header   Host              $http_host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header   X-Forwarded-Host  $http_host;
+    }
+
+    location /login/oauth2/ {
+        proxy_pass         http://api:8080/login/oauth2/;
+        proxy_set_header   Host              $http_host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header   X-Forwarded-Host  $http_host;
+    }
+
+    # SPA fallback: serve index.html for all other routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,7 +7,12 @@ export default defineConfig({
   server: {
     host: true,
     port: 3000,
-    allowedHosts: ['akademia.diegobarrioh.dev']
+    allowedHosts: ['akademia.diegobarrioh.dev'],
+    proxy: {
+      '/api': { target: 'http://localhost:8080', changeOrigin: true },
+      '/oauth2': { target: 'http://localhost:8080', changeOrigin: true },
+      '/login/oauth2': { target: 'http://localhost:8080', changeOrigin: true }
+    }
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Problemas resueltos

### 1. El botón no lleva a Google (producción)
Cuando el usuario accede desde \`akademia.diegobarrioh.dev\`, \`apiBase = window.location.origin\`. El botón linkea a \`https://akademia.diegobarrioh.dev/oauth2/authorization/google\`. \`npx serve\` no tiene proxy, devuelve \`index.html\`, y React Router no tiene ruta para ese path → redirige a home.

### 2. Dependencia circular al arrancar
\`SecurityConfig → OAuth2SuccessHandler → AuthManager → SpringSecurityPasswordHasher → PasswordEncoder (@Bean en SecurityConfig)\`

### 3. \`redirect_uri\` incorrecto detrás del proxy
Spring usaba el hostname interno Docker (\`api:8080\`) en lugar del dominio público al construir la \`redirect_uri\` enviada a Google.

---

## Solución

### Frontend
- **\`Dockerfile\`**: reemplaza \`npx serve\` por \`nginx\` (multi-stage build)
- **\`nginx.conf\`** (nuevo): proxy \`/api/\`, \`/oauth2/\`, \`/login/oauth2/\` → \`api:8080\`; SPA fallback para el resto
- **\`vite.config.ts\`**: añade el mismo proxy para desarrollo local sin Docker

### Backend
- **\`PasswordEncoderConfig.java\`** (nuevo): extrae \`@Bean PasswordEncoder\` de \`SecurityConfig\` → rompe el ciclo
- **\`SecurityConfig.java\`**: re-añade \`oauth2Login\`, restaura \`SessionCreationPolicy.IF_REQUIRED\` (\`STATELESS\` rompe la verificación del estado OAuth2), elimina \`@Bean PasswordEncoder\`
- **\`GoogleOAuth2UserService.java\`** (nuevo): solo delega en \`DefaultOAuth2UserService\`; la creación de usuario es responsabilidad de \`OAuth2SuccessHandler\`
- **\`OAuth2SuccessHandler.java\`** (nuevo): encuentra/crea el usuario, genera JWT, redirige a \`\${FRONTEND_URL}/oauth2/callback?token=\`
- **\`application.properties\`**: restaura propiedades OAuth2, añade \`server.forward-headers-strategy=framework\` para que Spring lea los headers \`X-Forwarded-*\` del proxy
- **\`compose.yaml\`**: restaura \`GOOGLE_CLIENT_ID\`, \`GOOGLE_CLIENT_SECRET\`, \`FRONTEND_URL\`

---

## Flujo completo tras los cambios

```
Browser (diegobarrioh.dev)
  → /oauth2/authorization/google
  → nginx proxy → api:8080
  → Spring → Google (redirect_uri = https://diegobarrioh.dev/login/oauth2/code/google)
  → Google autentica
  → /login/oauth2/code/google?code=...
  → nginx proxy → api:8080
  → Spring verifica state + intercambia code
  → OAuth2SuccessHandler → /oauth2/callback?token=JWT
  → nginx → index.html (SPA)
  → OAuth2CallbackPage → token guardado → /subjects
```

## Pendiente por configurar en Google Cloud Console
- Authorized redirect URIs:
  - \`http://localhost:8080/login/oauth2/code/google\` (dev local sin Docker)
  - \`https://akademia.diegobarrioh.dev/login/oauth2/code/google\` (producción)
- \`FRONTEND_URL=https://akademia.diegobarrioh.dev\` en \`.env\` para producción

https://claude.ai/code/session_01NTxGV2DbfG6HffqT37L6xu