### PR TITLE
🐛 fix(tests): update tests for new constructor signatures and interfaces

### DIFF
--- a/backend/src/main/java/com/akdemya/adapter/infrastructure/chunking/SemanticChunker.java
+++ b/backend/src/main/java/com/akdemya/adapter/infrastructure/chunking/SemanticChunker.java
@@ -47,7 +47,7 @@ public class SemanticChunker implements TextChunkerPort {
     private static final int MIN_SEMANTIC_SPLITS = 3;
 
     /** Chunks shorter than this are considered TOC remnants and are discarded. */
-    private static final int MIN_CHUNK_CONTENT_CHARS = 300;
+    private static final int MIN_CHUNK_CONTENT_CHARS = 50;
 
     private static final ObjectMapper JSON = new ObjectMapper();
 

--- a/backend/src/test/java/com/akdemya/adapter/inbound/web/FlashcardControllerTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/inbound/web/FlashcardControllerTest.java
@@ -8,12 +8,14 @@ import com.akdemya.domain.model.FlashcardReviewLog;
 import com.akdemya.domain.model.ReviewGrade;
 import com.akdemya.domain.model.ReviewState;
 import com.akdemya.domain.model.Unit;
+import com.akdemya.domain.port.in.FlashcardImportExportUseCase;
 import com.akdemya.domain.port.in.FlashcardManagementUseCase;
 import com.akdemya.domain.port.in.FlashcardReviewUseCase;
 import com.akdemya.domain.port.in.FlashcardStudyUseCase;
 import com.akdemya.domain.port.out.FlashcardRepository;
 import com.akdemya.domain.port.out.FlashcardReviewLogRepository;
 import com.akdemya.domain.port.out.FlashcardReviewRepository;
+import com.akdemya.domain.port.out.SubjectRepository;
 import com.akdemya.domain.port.out.UnitRepository;
 import com.akdemya.domain.port.out.UserRepository;
 import org.junit.jupiter.api.Test;
@@ -34,6 +36,10 @@ import static org.mockito.Mockito.*;
 
 class FlashcardControllerTest {
 
+
+  private final FlashcardImportExportUseCase importExportUseCase = mock(FlashcardImportExportUseCase.class);
+  private final SubjectRepository subjectRepo = mock(SubjectRepository.class);
+
   private final FlashcardStudyUseCase studyUseCase = mock(FlashcardStudyUseCase.class);
   private final FlashcardReviewUseCase reviewUseCase = mock(FlashcardReviewUseCase.class);
   private final FlashcardManagementUseCase managementUseCase = mock(FlashcardManagementUseCase.class);
@@ -44,7 +50,16 @@ class FlashcardControllerTest {
   private final UnitRepository unitRepo = mock(UnitRepository.class);
 
   private final FlashcardController controller = new FlashcardController(
-      studyUseCase, reviewUseCase, managementUseCase, flashcardRepo, reviewRepo, reviewLogRepo, userRepo, unitRepo);
+      studyUseCase,
+       reviewUseCase,
+       managementUseCase,
+       importExportUseCase,
+       flashcardRepo,
+       reviewRepo,
+       reviewLogRepo,
+       userRepo,
+       unitRepo,
+       subjectRepo);
 
   @Test
   void studyQueueReturnsCounts() {

--- a/backend/src/test/java/com/akdemya/application/service/GenerateQuizServiceTest.java
+++ b/backend/src/test/java/com/akdemya/application/service/GenerateQuizServiceTest.java
@@ -175,6 +175,8 @@ class GenerateQuizServiceTest {
         @Override public List<SourceDocument> findBySubjectId(UUID subjectId) {
             return store.values().stream().filter(d -> subjectId.equals(d.getSubjectId())).toList();
         }
+        @Override  public Optional<SourceDocument> findBySubjectIdAndName(UUID subjectId, String name) {return Optional.empty();}
+        @Override public void deleteById(UUID id) {}
     }
 
     static class StubSourceChunkRepository implements SourceChunkRepository {


### PR DESCRIPTION
## Summary
- **FlashcardControllerTest**: añadidos mocks de `FlashcardImportExportUseCase` y `SubjectRepository` para coincidir con el constructor actualizado de `FlashcardController`
- **GenerateQuizServiceTest**: añadidos métodos stub `findBySubjectIdAndName` y `deleteById` para satisfacer la interfaz `SourceDocumentRepository`
- **SemanticChunker**: reducido `MIN_CHUNK_CONTENT_CHARS` de 300 a 50 para no descartar chunks cortos pero válidos

## Test plan
- [ ] Verificar que `FlashcardControllerTest` compila y pasa
- [ ] Verificar que `GenerateQuizServiceTest` compila y pasa
- [ ] Verificar que el SemanticChunker no descarta chunks válidos cortos

🤖 Generated with [Claude Code](https://claude.com/claude-code)