### PR TITLE
🔧 chore(build): add JaCoCo and SonarQube plugins

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'java'
     id 'idea'
+    id 'jacoco'
+    id 'org.sonarqube' version '6.0.1.5171'
     id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.6'
 }
@@ -41,5 +43,37 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.85
+            }
+        }
+    }
+}
+
+sonar {
+    properties {
+        property "sonar.projectKey", "guilu_akadem.ia"
+        property "sonar.organization", "guilu"
+        property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
+    }
 }
 


### PR DESCRIPTION
## Summary
- Added JaCoCo 0.8.12 plugin for test coverage reporting (XML + HTML) with 85% minimum threshold
- Added SonarQube plugin 6.0.1.5171 configured for SonarCloud (org: guilu, project: guilu_akadem.ia)
- Test task auto-generates JaCoCo report via `finalizedBy`

## Changes
- `backend/build.gradle`: added `jacoco` and `org.sonarqube` plugins, JaCoCo config, coverage verification rule, Sonar properties

## Test plan
- [ ] `./gradlew test` compiles and passes
- [ ] `./gradlew jacocoTestReport` generates reports in `build/reports/jacoco/`
- [ ] `./gradlew sonar -Dsonar.token=$SONAR_CLAUDE_TOKEN` runs analysis against SonarCloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)