### PR TITLE
✨ feat(flashcards): improve UX feedback, empty states and subject-level export

### DIFF
--- a/backend/src/main/java/com/akdemya/adapter/inbound/web/FlashcardController.java
+++ b/backend/src/main/java/com/akdemya/adapter/inbound/web/FlashcardController.java
@@ -23,11 +23,22 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @RestController
@@ -218,11 +229,17 @@ public class FlashcardController {
 
   @GetMapping("/export")
   public ResponseEntity<String> exportFlashcards(
-      @RequestParam UUID unitId,
+      @RequestParam(required = false) UUID unitId,
+      @RequestParam(required = false) UUID subjectId,
       @RequestParam(defaultValue = "csv") String format,
       @AuthenticationPrincipal User principal) {
     requireUserId(principal);
-    String content = importExportUseCase.exportFlashcards(unitId, format);
+    if (unitId == null && subjectId == null) {
+      return ResponseEntity.badRequest().body("Se requiere unitId o subjectId");
+    }
+    String content = unitId != null
+        ? importExportUseCase.exportFlashcards(unitId, format)
+        : importExportUseCase.exportFlashcardsBySubject(subjectId, format);
     boolean isJson = "json".equalsIgnoreCase(format);
     String contentType = isJson ? "application/json; charset=UTF-8" : "text/csv; charset=UTF-8";
     String filename = isJson ? "flashcards.json" : "flashcards.csv";

--- a/backend/src/main/java/com/akdemya/adapter/inbound/web/UserProfileController.java
+++ b/backend/src/main/java/com/akdemya/adapter/inbound/web/UserProfileController.java
@@ -7,7 +7,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.UUID;
@@ -16,44 +20,44 @@ import java.util.UUID;
 @RequestMapping("/api/v1/users/me")
 public class UserProfileController {
 
-    private final UserProfileUseCase userProfileUseCase;
-    private final UserRepository userRepo;
+  private final UserProfileUseCase userProfileUseCase;
+  private final UserRepository userRepo;
 
-    public UserProfileController(UserProfileUseCase userProfileUseCase, UserRepository userRepo) {
-        this.userProfileUseCase = userProfileUseCase;
-        this.userRepo = userRepo;
+  public UserProfileController(UserProfileUseCase userProfileUseCase, UserRepository userRepo) {
+    this.userProfileUseCase = userProfileUseCase;
+    this.userRepo = userRepo;
+  }
+
+  @GetMapping
+  public ResponseEntity<GetProfileResponse> getProfile(@AuthenticationPrincipal User principal) {
+    UUID userId = requireUserId(principal);
+    var result = userProfileUseCase.getProfile(userId);
+    return ResponseEntity.ok(toResponse(result));
+  }
+
+  @PatchMapping
+  public ResponseEntity<GetProfileResponse> updateProfile(@RequestBody UpdateProfileRequest req,
+      @AuthenticationPrincipal User principal) {
+    UUID userId = requireUserId(principal);
+    var result = userProfileUseCase.updateProfile(userId,
+        new UserProfileUseCase.UpdateProfileCommand(req.firstName(), req.lastName()));
+    return ResponseEntity.ok(toResponse(result));
+  }
+
+  private UUID requireUserId(User principal) {
+    if (principal == null) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
     }
+    return userRepo.findByEmail(principal.getUsername())
+        .map(AppUser::getId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+  }
 
-    @GetMapping
-    public ResponseEntity<GetProfileResponse> getProfile(@AuthenticationPrincipal User principal) {
-        UUID userId = requireUserId(principal);
-        var result = userProfileUseCase.getProfile(userId);
-        return ResponseEntity.ok(toResponse(result));
-    }
+  private GetProfileResponse toResponse(UserProfileUseCase.GetProfileResponse result) {
+    return new GetProfileResponse(result.id(), result.email(), result.firstName(), result.lastName());
+  }
 
-    @PatchMapping
-    public ResponseEntity<GetProfileResponse> updateProfile(@RequestBody UpdateProfileRequest req,
-                                                            @AuthenticationPrincipal User principal) {
-        UUID userId = requireUserId(principal);
-        var result = userProfileUseCase.updateProfile(userId,
-            new UserProfileUseCase.UpdateProfileCommand(req.firstName(), req.lastName()));
-        return ResponseEntity.ok(toResponse(result));
-    }
+  record GetProfileResponse(UUID id, String email, String firstName, String lastName) {}
 
-    private UUID requireUserId(User principal) {
-        if (principal == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
-        }
-        return userRepo.findByEmail(principal.getUsername())
-            .map(AppUser::getId)
-            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-    }
-
-    private GetProfileResponse toResponse(UserProfileUseCase.GetProfileResponse result) {
-        return new GetProfileResponse(result.id(), result.email(), result.firstName(), result.lastName());
-    }
-
-    record GetProfileResponse(UUID id, String email, String firstName, String lastName) {}
-
-    record UpdateProfileRequest(String firstName, String lastName) {}
+  record UpdateProfileRequest(String firstName, String lastName) {}
 }

--- a/backend/src/main/java/com/akdemya/application/service/FlashcardImportExportService.java
+++ b/backend/src/main/java/com/akdemya/application/service/FlashcardImportExportService.java
@@ -3,6 +3,7 @@ package com.akdemya.application.service;
 import com.akdemya.domain.model.Flashcard;
 import com.akdemya.domain.port.in.FlashcardImportExportUseCase;
 import com.akdemya.domain.port.in.FlashcardManagementUseCase;
+import com.akdemya.domain.port.out.UnitRepository;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
@@ -16,11 +17,14 @@ import java.util.UUID;
 public class FlashcardImportExportService implements FlashcardImportExportUseCase {
 
   private final FlashcardManagementUseCase managementUseCase;
+  private final UnitRepository unitRepository;
   private final ObjectMapper objectMapper;
 
   public FlashcardImportExportService(FlashcardManagementUseCase managementUseCase,
+                                      UnitRepository unitRepository,
                                       ObjectMapper objectMapper) {
     this.managementUseCase = managementUseCase;
+    this.unitRepository = unitRepository;
     this.objectMapper = objectMapper;
   }
 
@@ -74,6 +78,30 @@ public class FlashcardImportExportService implements FlashcardImportExportUseCas
   @Override
   public String exportFlashcards(UUID unitId, String format) {
     List<Flashcard> flashcards = managementUseCase.listByUnit(unitId);
+
+    if ("json".equalsIgnoreCase(format)) {
+      List<Map<String, String>> list = flashcards.stream()
+          .map(f -> Map.of("front", f.getFront(), "back", f.getBack()))
+          .toList();
+      try {
+        return objectMapper.writeValueAsString(list);
+      } catch (Exception e) {
+        throw new RuntimeException("Error al generar JSON", e);
+      }
+    }
+
+    StringBuilder sb = new StringBuilder("front,back\n");
+    for (Flashcard f : flashcards) {
+      sb.append(csvEscape(f.getFront())).append(',').append(csvEscape(f.getBack())).append('\n');
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public String exportFlashcardsBySubject(UUID subjectId, String format) {
+    List<Flashcard> flashcards = unitRepository.findBySubjectId(subjectId).stream()
+        .flatMap(unit -> managementUseCase.listByUnit(unit.getId()).stream())
+        .toList();
 
     if ("json".equalsIgnoreCase(format)) {
       List<Map<String, String>> list = flashcards.stream()

--- a/backend/src/main/java/com/akdemya/application/service/UserProfileService.java
+++ b/backend/src/main/java/com/akdemya/application/service/UserProfileService.java
@@ -13,54 +13,54 @@ import java.util.UUID;
 @Transactional
 public class UserProfileService implements UserProfileUseCase {
 
-    private final UserRepository userRepository;
+  private final UserRepository userRepository;
 
-    public UserProfileService(UserRepository userRepository) {
-        this.userRepository = userRepository;
+  public UserProfileService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public GetProfileResponse getProfile(UUID userId) {
+    AppUser user = userRepository.findById(userId)
+        .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
+    return toResponse(user);
+  }
+
+  @Override
+  public GetProfileResponse updateProfile(UUID userId, UpdateProfileCommand command) {
+    AppUser user = userRepository.findById(userId)
+        .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
+
+    validateName(command.firstName(), "firstName");
+    validateName(command.lastName(), "lastName");
+
+    AppUser updated = new AppUser(
+        user.getId(),
+        user.getEmail(),
+        user.getPasswordHash(),
+        user.getRole(),
+        command.firstName(),
+        command.lastName(),
+        user.getOccupation()
+    );
+
+    AppUser saved = userRepository.save(updated);
+    return toResponse(saved);
+  }
+
+  private void validateName(String value, String field) {
+    if (value != null && value.length() > 100) {
+      throw new IllegalArgumentException(field + "_too_long");
     }
+  }
 
-    @Override
-    @Transactional(readOnly = true)
-    public GetProfileResponse getProfile(UUID userId) {
-        AppUser user = userRepository.findById(userId)
-            .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
-        return toResponse(user);
-    }
-
-    @Override
-    public GetProfileResponse updateProfile(UUID userId, UpdateProfileCommand command) {
-        AppUser user = userRepository.findById(userId)
-            .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
-
-        validateName(command.firstName(), "firstName");
-        validateName(command.lastName(), "lastName");
-
-        AppUser updated = new AppUser(
-            user.getId(),
-            user.getEmail(),
-            user.getPasswordHash(),
-            user.getRole(),
-            command.firstName(),
-            command.lastName(),
-            user.getOccupation()
-        );
-
-        AppUser saved = userRepository.save(updated);
-        return toResponse(saved);
-    }
-
-    private void validateName(String value, String field) {
-        if (value != null && value.length() > 100) {
-            throw new IllegalArgumentException(field + "_too_long");
-        }
-    }
-
-    private GetProfileResponse toResponse(AppUser user) {
-        return new GetProfileResponse(
-            user.getId(),
-            user.getEmail(),
-            user.getFirstName(),
-            user.getLastName()
-        );
-    }
+  private GetProfileResponse toResponse(AppUser user) {
+    return new GetProfileResponse(
+        user.getId(),
+        user.getEmail(),
+        user.getFirstName(),
+        user.getLastName()
+    );
+  }
 }

--- a/backend/src/main/java/com/akdemya/domain/port/in/FlashcardImportExportUseCase.java
+++ b/backend/src/main/java/com/akdemya/domain/port/in/FlashcardImportExportUseCase.java
@@ -9,5 +9,7 @@ public interface FlashcardImportExportUseCase {
 
   String exportFlashcards(UUID unitId, String format);
 
+  String exportFlashcardsBySubject(UUID subjectId, String format);
+
   record ImportResult(int imported, int skipped, List<String> errors) {}
 }

--- a/backend/src/test/java/com/akdemya/adapter/inbound/web/FlashcardControllerTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/inbound/web/FlashcardControllerTest.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -152,6 +153,72 @@ class FlashcardControllerTest {
     verify(reviewLogRepo).findRecentByUserId(userId, 20);
   }
 
+  // --- export endpoint ---
+
+  @Test
+  void exportBySubjectIdCsvReturnsContent() {
+    UUID userId = UUID.randomUUID();
+    UUID subjectId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+    when(importExportUseCase.exportFlashcardsBySubject(subjectId, "csv"))
+        .thenReturn("front,back\nHello,Hola\n");
+
+    ResponseEntity<String> response = controller.exportFlashcards(null, subjectId, "csv", principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    org.junit.jupiter.api.Assertions.assertTrue(response.getBody().contains("Hello,Hola"));
+    verify(importExportUseCase).exportFlashcardsBySubject(subjectId, "csv");
+  }
+
+  @Test
+  void exportBySubjectIdJsonReturnsContent() {
+    UUID userId = UUID.randomUUID();
+    UUID subjectId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+    when(importExportUseCase.exportFlashcardsBySubject(subjectId, "json"))
+        .thenReturn("[{\"front\":\"Hello\",\"back\":\"Hola\"}]");
+
+    ResponseEntity<String> response = controller.exportFlashcards(null, subjectId, "json", principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    org.junit.jupiter.api.Assertions.assertTrue(response.getBody().contains("Hello"));
+    verify(importExportUseCase).exportFlashcardsBySubject(subjectId, "json");
+  }
+
+  @Test
+  void exportWithNeitherParamReturns400() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    ResponseEntity<String> response = controller.exportFlashcards(null, null, "csv", principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  @Test
+  void exportByUnitIdStillWorksWhenUnitIdProvided() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+    when(importExportUseCase.exportFlashcards(unitId, "csv"))
+        .thenReturn("front,back\nQ,A\n");
+
+    ResponseEntity<String> response = controller.exportFlashcards(unitId, null, "csv", principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    verify(importExportUseCase).exportFlashcards(unitId, "csv");
+  }
+
   @Test
   void createWithoutAuthReturns401() {
     var req = new FlashcardDto.CreateRequest(UUID.randomUUID(), "front", "back");
@@ -167,5 +234,348 @@ class FlashcardControllerTest {
   @Test
   void deleteWithoutAuthReturns401() {
     assertThrows(ResponseStatusException.class, () -> controller.delete(UUID.randomUUID(), null));
+  }
+
+  // --- create ---
+
+  @Test
+  void createReturnsSavedFlashcard() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    UUID flashcardId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    Flashcard saved = new Flashcard(flashcardId, unitId, "front", "back",
+        LocalDateTime.now(), LocalDateTime.now());
+    when(managementUseCase.createFlashcard(any())).thenReturn(saved);
+
+    var req = new FlashcardDto.CreateRequest(unitId, "front", "back");
+    ResponseEntity<FlashcardDto.FlashcardResponse> response = controller.create(req, principal);
+
+    assertEquals(201, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertEquals(flashcardId, response.getBody().id());
+  }
+
+  @Test
+  void createWithNullUnitIdReturns400() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    var req = new FlashcardDto.CreateRequest(null, "front", "back");
+    ResponseEntity<FlashcardDto.FlashcardResponse> response = controller.create(req, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  @Test
+  void createWithIllegalArgumentReturns400() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+    when(managementUseCase.createFlashcard(any())).thenThrow(new IllegalArgumentException("invalid"));
+
+    var req = new FlashcardDto.CreateRequest(UUID.randomUUID(), "front", "back");
+    ResponseEntity<FlashcardDto.FlashcardResponse> response = controller.create(req, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  // --- update ---
+
+  @Test
+  void updateReturnsUpdatedFlashcard() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    UUID flashcardId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    Flashcard updated = new Flashcard(flashcardId, unitId, "front2", "back2",
+        LocalDateTime.now(), LocalDateTime.now());
+    when(managementUseCase.updateFlashcard(any())).thenReturn(updated);
+
+    var req = new FlashcardDto.UpdateRequest(unitId, "front2", "back2");
+    ResponseEntity<FlashcardDto.FlashcardResponse> response = controller.update(flashcardId, req, principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertEquals(flashcardId, response.getBody().id());
+  }
+
+  @Test
+  void updateWithNullRequestReturns400() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    ResponseEntity<FlashcardDto.FlashcardResponse> response = controller.update(UUID.randomUUID(), null, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  @Test
+  void updateNotFoundReturns404() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+    when(managementUseCase.updateFlashcard(any())).thenThrow(new java.util.NoSuchElementException());
+
+    var req = new FlashcardDto.UpdateRequest(UUID.randomUUID(), "front", "back");
+    ResponseEntity<FlashcardDto.FlashcardResponse> response = controller.update(UUID.randomUUID(), req, principal);
+
+    assertEquals(404, response.getStatusCodeValue());
+  }
+
+  @Test
+  void updateWithIllegalArgumentReturns400() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+    when(managementUseCase.updateFlashcard(any())).thenThrow(new IllegalArgumentException("invalid"));
+
+    var req = new FlashcardDto.UpdateRequest(UUID.randomUUID(), "front", "back");
+    ResponseEntity<FlashcardDto.FlashcardResponse> response = controller.update(UUID.randomUUID(), req, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  // --- delete ---
+
+  @Test
+  void deleteReturns204() {
+    UUID userId = UUID.randomUUID();
+    UUID flashcardId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+    doNothing().when(managementUseCase).deleteFlashcard(flashcardId);
+
+    ResponseEntity<Void> response = controller.delete(flashcardId, principal);
+
+    assertEquals(204, response.getStatusCodeValue());
+    verify(managementUseCase).deleteFlashcard(flashcardId);
+  }
+
+  // --- listByUnit ---
+
+  @Test
+  void listByUnitReturnsFlashcards() {
+    UUID unitId = UUID.randomUUID();
+    Flashcard card = new Flashcard(UUID.randomUUID(), unitId, "front", "back",
+        LocalDateTime.now(), LocalDateTime.now());
+    when(managementUseCase.listByUnit(unitId)).thenReturn(List.of(card));
+
+    List<FlashcardDto.FlashcardResponse> response = controller.listByUnit(unitId);
+
+    assertEquals(1, response.size());
+    assertEquals("front", response.get(0).front());
+  }
+
+  // --- getStudyNext ---
+
+  @Test
+  void studyNextReturnsFlashcard() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    UUID flashcardId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    when(studyUseCase.getStudyNext(any()))
+        .thenReturn(new FlashcardStudyUseCase.StudyNextResponse(
+            flashcardId, unitId, "front", "back", ReviewState.NEW, null,
+            new FlashcardStudyUseCase.IntervalHints("1m", "10m", "4d")));
+
+    ResponseEntity<FlashcardDto.StudyNextResponse> response = controller.getStudyNext(unitId, principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertEquals(flashcardId, response.getBody().flashcardId());
+    assertNotNull(response.getBody().intervalHints());
+  }
+
+  @Test
+  void studyNextReturns204WhenNoCards() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+    when(studyUseCase.getStudyNext(any())).thenReturn(null);
+
+    ResponseEntity<FlashcardDto.StudyNextResponse> response = controller.getStudyNext(unitId, principal);
+
+    assertEquals(204, response.getStatusCodeValue());
+  }
+
+  @Test
+  void studyNextWithNullIntervalHintsStillReturns200() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    UUID flashcardId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    when(studyUseCase.getStudyNext(any()))
+        .thenReturn(new FlashcardStudyUseCase.StudyNextResponse(
+            flashcardId, unitId, "front", "back", ReviewState.NEW, null, null));
+
+    ResponseEntity<FlashcardDto.StudyNextResponse> response = controller.getStudyNext(unitId, principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertNull(response.getBody().intervalHints());
+  }
+
+  // --- getDashboard ---
+
+  @Test
+  void dashboardReturnsAggregatedData() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    when(studyUseCase.getDashboard(any()))
+        .thenReturn(new FlashcardStudyUseCase.DashboardResponse(3, 2, 1, 0, 5, 6));
+
+    ResponseEntity<FlashcardDto.DashboardResponse> response = controller.getDashboard(unitId, principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertEquals(3, response.getBody().dueToday());
+    assertEquals(5, response.getBody().newCards());
+  }
+
+  // --- importFlashcards ---
+
+  @Test
+  void importFlashcardsReturnsImportResult() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    when(importExportUseCase.importFlashcards(unitId, "csv", "front,back\nHello,Hola\n"))
+        .thenReturn(new com.akdemya.domain.port.in.FlashcardImportExportUseCase.ImportResult(1, 0, List.of()));
+
+    ResponseEntity<FlashcardDto.ImportResult> response =
+        controller.importFlashcards(unitId, "csv", "front,back\nHello,Hola\n", principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertEquals(1, response.getBody().imported());
+    assertEquals(0, response.getBody().skipped());
+  }
+
+  // --- studyQueue edge cases ---
+
+  @Test
+  void studyQueueReturns400WhenLimitIsNegative() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    ResponseEntity<FlashcardDto.StudyQueueResponse> response =
+        controller.getStudyQueue(unitId, -1, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  @Test
+  void studyQueueReturns400WhenLimitExceedsMax() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    ResponseEntity<FlashcardDto.StudyQueueResponse> response =
+        controller.getStudyQueue(unitId, 101, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  // --- history edge cases ---
+
+  @Test
+  void historyReturns400WhenLimitIsNegative() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    ResponseEntity<List<FlashcardDto.HistoryItem>> response = controller.getHistory(-1, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  @Test
+  void historyWithNullFlashcardInMapReturnsNullFrontAndBack() {
+    UUID userId = UUID.randomUUID();
+    UUID flashcardId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    FlashcardReviewLog log = FlashcardReviewLog.create(userId, flashcardId, ReviewGrade.GOOD,
+        LocalDateTime.now(), 1, 3, 2.5, 2.6);
+    when(reviewLogRepo.findRecentByUserId(eq(userId), eq(20))).thenReturn(List.of(log));
+    when(flashcardRepo.findByIds(any())).thenReturn(List.of()); // no matching flashcard
+
+    ResponseEntity<List<FlashcardDto.HistoryItem>> response = controller.getHistory(null, principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertEquals(1, response.getBody().size());
+    assertNull(response.getBody().get(0).front());
+    assertNull(response.getBody().get(0).back());
+  }
+
+  // --- reviewRequest edge cases ---
+
+  @Test
+  void registerReviewWithNullRequestReturns400() {
+    var principal = new User("user@example.com", "", List.of());
+
+    ResponseEntity<FlashcardDto.ReviewResponse> response = controller.registerReview(null, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  @Test
+  void registerReviewWithNullFlashcardIdReturns400() {
+    var principal = new User("user@example.com", "", List.of());
+
+    var req = new FlashcardDto.ReviewRequest(null, ReviewGrade.GOOD, LocalDateTime.now());
+    ResponseEntity<FlashcardDto.ReviewResponse> response = controller.registerReview(req, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  @Test
+  void registerReviewWithNullGradeReturns400() {
+    var principal = new User("user@example.com", "", List.of());
+
+    var req = new FlashcardDto.ReviewRequest(UUID.randomUUID(), null, LocalDateTime.now());
+    ResponseEntity<FlashcardDto.ReviewResponse> response = controller.registerReview(req, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
   }
 }

--- a/backend/src/test/java/com/akdemya/adapter/inbound/web/UserProfileControllerTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/inbound/web/UserProfileControllerTest.java
@@ -12,69 +12,73 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class UserProfileControllerTest {
 
-    private final UserProfileUseCase userProfileUseCase = mock(UserProfileUseCase.class);
-    private final UserRepository userRepo = mock(UserRepository.class);
+  private final UserProfileUseCase userProfileUseCase = mock(UserProfileUseCase.class);
+  private final UserRepository userRepo = mock(UserRepository.class);
 
-    private final UserProfileController controller =
-        new UserProfileController(userProfileUseCase, userRepo);
+  private final UserProfileController controller =
+      new UserProfileController(userProfileUseCase, userRepo);
 
-    @Test
-    void getProfile_authenticated_returns200WithProfile() {
-        UUID userId = UUID.randomUUID();
-        var principal = new User("user@example.com", "", List.of());
-        when(userRepo.findByEmail("user@example.com"))
-            .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", "John", "Doe", null)));
-        when(userProfileUseCase.getProfile(userId))
-            .thenReturn(new UserProfileUseCase.GetProfileResponse(userId, "user@example.com", "John", "Doe"));
+  @Test
+  void getProfile_authenticated_returns200WithProfile() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", "John", "Doe", null)));
+    when(userProfileUseCase.getProfile(userId))
+        .thenReturn(new UserProfileUseCase.GetProfileResponse(userId, "user@example.com", "John", "Doe"));
 
-        ResponseEntity<UserProfileController.GetProfileResponse> response = controller.getProfile(principal);
+    ResponseEntity<UserProfileController.GetProfileResponse> response = controller.getProfile(principal);
 
-        assertEquals(200, response.getStatusCodeValue());
-        assertNotNull(response.getBody());
-        assertEquals("John", response.getBody().firstName());
-        assertEquals("Doe", response.getBody().lastName());
-        assertEquals("user@example.com", response.getBody().email());
-    }
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertEquals("John", response.getBody().firstName());
+    assertEquals("Doe", response.getBody().lastName());
+    assertEquals("user@example.com", response.getBody().email());
+  }
 
-    @Test
-    void getProfile_unauthenticated_throws401() {
-        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-            () -> controller.getProfile(null));
-        assertEquals(401, ex.getStatusCode().value());
-    }
+  @Test
+  void getProfile_unauthenticated_throws401() {
+    ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+        () -> controller.getProfile(null));
+    assertEquals(401, ex.getStatusCode().value());
+  }
 
-    @Test
-    void updateProfile_validBody_returns200WithUpdatedProfile() {
-        UUID userId = UUID.randomUUID();
-        var principal = new User("user@example.com", "", List.of());
-        when(userRepo.findByEmail("user@example.com"))
-            .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", "Old", "Name", null)));
-        when(userProfileUseCase.updateProfile(eq(userId), any()))
-            .thenReturn(new UserProfileUseCase.GetProfileResponse(userId, "user@example.com", "Jane", "Smith"));
+  @Test
+  void updateProfile_validBody_returns200WithUpdatedProfile() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", "Old", "Name", null)));
+    when(userProfileUseCase.updateProfile(eq(userId), any()))
+        .thenReturn(new UserProfileUseCase.GetProfileResponse(userId, "user@example.com", "Jane", "Smith"));
 
-        var req = new UserProfileController.UpdateProfileRequest("Jane", "Smith");
-        ResponseEntity<UserProfileController.GetProfileResponse> response = controller.updateProfile(req, principal);
+    var req = new UserProfileController.UpdateProfileRequest("Jane", "Smith");
+    ResponseEntity<UserProfileController.GetProfileResponse> response = controller.updateProfile(req, principal);
 
-        assertEquals(200, response.getStatusCodeValue());
-        assertNotNull(response.getBody());
-        assertEquals("Jane", response.getBody().firstName());
-        assertEquals("Smith", response.getBody().lastName());
-        verify(userProfileUseCase).updateProfile(eq(userId),
-            eq(new UserProfileUseCase.UpdateProfileCommand("Jane", "Smith")));
-    }
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertEquals("Jane", response.getBody().firstName());
+    assertEquals("Smith", response.getBody().lastName());
+    verify(userProfileUseCase).updateProfile(eq(userId),
+        eq(new UserProfileUseCase.UpdateProfileCommand("Jane", "Smith")));
+  }
 
-    @Test
-    void updateProfile_unauthenticated_throws401() {
-        var req = new UserProfileController.UpdateProfileRequest("Jane", "Smith");
-        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-            () -> controller.updateProfile(req, null));
-        assertEquals(401, ex.getStatusCode().value());
-    }
+  @Test
+  void updateProfile_unauthenticated_throws401() {
+    var req = new UserProfileController.UpdateProfileRequest("Jane", "Smith");
+    ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+        () -> controller.updateProfile(req, null));
+    assertEquals(401, ex.getStatusCode().value());
+  }
 }

--- a/backend/src/test/java/com/akdemya/application/service/FlashcardImportExportServiceTest.java
+++ b/backend/src/test/java/com/akdemya/application/service/FlashcardImportExportServiceTest.java
@@ -1,0 +1,359 @@
+package com.akdemya.application.service;
+
+import com.akdemya.domain.model.Flashcard;
+import com.akdemya.domain.model.Unit;
+import com.akdemya.domain.port.in.FlashcardImportExportUseCase;
+import com.akdemya.domain.port.in.FlashcardManagementUseCase;
+import com.akdemya.domain.port.out.UnitRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class FlashcardImportExportServiceTest {
+
+  private final FlashcardManagementUseCase managementUseCase = mock(FlashcardManagementUseCase.class);
+  private final UnitRepository unitRepository = mock(UnitRepository.class);
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private final FlashcardImportExportService service =
+      new FlashcardImportExportService(managementUseCase, unitRepository, objectMapper);
+
+  private Flashcard flashcard(UUID unitId, String front, String back) {
+    return new Flashcard(UUID.randomUUID(), unitId, front, back,
+        LocalDateTime.now(), LocalDateTime.now());
+  }
+
+  private Unit unit(UUID subjectId) {
+    return new Unit(UUID.randomUUID(), subjectId, "Unit", "", 1);
+  }
+
+  // --- exportFlashcardsBySubject: CSV ---
+
+  @Test
+  void exportFlashcardsBySubject_csvMergesAllUnits() {
+    UUID subjectId = UUID.randomUUID();
+    Unit unit1 = unit(subjectId);
+    Unit unit2 = unit(subjectId);
+    Flashcard card1 = flashcard(unit1.getId(), "Hello", "Hola");
+    Flashcard card2 = flashcard(unit2.getId(), "Goodbye", "Adiós");
+
+    when(unitRepository.findBySubjectId(subjectId)).thenReturn(List.of(unit1, unit2));
+    when(managementUseCase.listByUnit(unit1.getId())).thenReturn(List.of(card1));
+    when(managementUseCase.listByUnit(unit2.getId())).thenReturn(List.of(card2));
+
+    String result = service.exportFlashcardsBySubject(subjectId, "csv");
+
+    assertTrue(result.startsWith("front,back\n"));
+    assertTrue(result.contains("Hello,Hola"));
+    assertTrue(result.contains("Goodbye,Adiós"));
+  }
+
+  @Test
+  void exportFlashcardsBySubject_jsonMergesAllUnits() throws Exception {
+    UUID subjectId = UUID.randomUUID();
+    Unit unit1 = unit(subjectId);
+    Unit unit2 = unit(subjectId);
+    Flashcard card1 = flashcard(unit1.getId(), "Cat", "Gato");
+    Flashcard card2 = flashcard(unit2.getId(), "Dog", "Perro");
+
+    when(unitRepository.findBySubjectId(subjectId)).thenReturn(List.of(unit1, unit2));
+    when(managementUseCase.listByUnit(unit1.getId())).thenReturn(List.of(card1));
+    when(managementUseCase.listByUnit(unit2.getId())).thenReturn(List.of(card2));
+
+    String result = service.exportFlashcardsBySubject(subjectId, "json");
+
+    var parsed = objectMapper.readValue(result, List.class);
+    assertEquals(2, parsed.size());
+  }
+
+  @Test
+  void exportFlashcardsBySubject_noUnitsReturnsCsvHeader() {
+    UUID subjectId = UUID.randomUUID();
+    when(unitRepository.findBySubjectId(subjectId)).thenReturn(List.of());
+
+    String result = service.exportFlashcardsBySubject(subjectId, "csv");
+
+    assertEquals("front,back\n", result);
+  }
+
+  @Test
+  void exportFlashcardsBySubject_noUnitsReturnsEmptyJsonArray() {
+    UUID subjectId = UUID.randomUUID();
+    when(unitRepository.findBySubjectId(subjectId)).thenReturn(List.of());
+
+    String result = service.exportFlashcardsBySubject(subjectId, "json");
+
+    assertEquals("[]", result);
+  }
+
+  @Test
+  void exportFlashcardsBySubject_unitsWithNoFlashcardsReturnsCsvHeader() {
+    UUID subjectId = UUID.randomUUID();
+    Unit unit1 = unit(subjectId);
+
+    when(unitRepository.findBySubjectId(subjectId)).thenReturn(List.of(unit1));
+    when(managementUseCase.listByUnit(unit1.getId())).thenReturn(List.of());
+
+    String result = service.exportFlashcardsBySubject(subjectId, "csv");
+
+    assertEquals("front,back\n", result);
+  }
+
+  // --- exportFlashcards (by unit) ---
+
+  @Test
+  void exportFlashcards_csvFormatReturnsHeaderAndRows() {
+    UUID unitId = UUID.randomUUID();
+    Flashcard card = flashcard(unitId, "Question", "Answer");
+    when(managementUseCase.listByUnit(unitId)).thenReturn(List.of(card));
+
+    String result = service.exportFlashcards(unitId, "csv");
+
+    assertTrue(result.startsWith("front,back\n"));
+    assertTrue(result.contains("Question,Answer"));
+  }
+
+  @Test
+  void exportFlashcards_jsonFormatReturnsJsonArray() throws Exception {
+    UUID unitId = UUID.randomUUID();
+    Flashcard card = flashcard(unitId, "Front", "Back");
+    when(managementUseCase.listByUnit(unitId)).thenReturn(List.of(card));
+
+    String result = service.exportFlashcards(unitId, "json");
+
+    var parsed = objectMapper.readValue(result, List.class);
+    assertEquals(1, parsed.size());
+  }
+
+  @Test
+  void exportFlashcards_csvEscapesCommasInFields() {
+    UUID unitId = UUID.randomUUID();
+    Flashcard card = flashcard(unitId, "A, B", "C, D");
+    when(managementUseCase.listByUnit(unitId)).thenReturn(List.of(card));
+
+    String result = service.exportFlashcards(unitId, "csv");
+
+    assertTrue(result.contains("\"A, B\""));
+    assertTrue(result.contains("\"C, D\""));
+  }
+
+  @Test
+  void exportFlashcards_csvEscapesQuotesInFields() {
+    UUID unitId = UUID.randomUUID();
+    Flashcard card = flashcard(unitId, "Say \"hello\"", "reply");
+    when(managementUseCase.listByUnit(unitId)).thenReturn(List.of(card));
+
+    String result = service.exportFlashcards(unitId, "csv");
+
+    assertTrue(result.contains("\"Say \"\"hello\"\"\""));
+  }
+
+  @Test
+  void exportFlashcards_emptyUnitReturnsCsvHeader() {
+    UUID unitId = UUID.randomUUID();
+    when(managementUseCase.listByUnit(unitId)).thenReturn(List.of());
+
+    String result = service.exportFlashcards(unitId, "csv");
+
+    assertEquals("front,back\n", result);
+  }
+
+  // --- importFlashcards: CSV ---
+
+  @Test
+  void importFlashcards_csvImportsValidRows() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "front,back\nHello,Hola\nGoodbye,Adiós\n";
+
+    Flashcard created = flashcard(unitId, "Hello", "Hola");
+    when(managementUseCase.createFlashcard(any())).thenReturn(created);
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(2, result.imported());
+    assertEquals(0, result.skipped());
+    assertTrue(result.errors().isEmpty());
+    verify(managementUseCase, times(2)).createFlashcard(any());
+  }
+
+  @Test
+  void importFlashcards_csvSkipsBlankRows() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "front,back\nHello,Hola\n\nGoodbye,Adiós\n";
+
+    Flashcard created = flashcard(unitId, "Hello", "Hola");
+    when(managementUseCase.createFlashcard(any())).thenReturn(created);
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(2, result.imported());
+    assertEquals(0, result.skipped());
+  }
+
+  @Test
+  void importFlashcards_csvErrorsWhenFrontIsEmpty() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "front,back\n,Hola\n";
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(0, result.imported());
+    assertEquals(1, result.skipped());
+    assertEquals(1, result.errors().size());
+    assertTrue(result.errors().get(0).contains("anverso"));
+  }
+
+  @Test
+  void importFlashcards_csvErrorsWhenBackIsEmpty() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "front,back\nHello,\n";
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(0, result.imported());
+    assertEquals(1, result.skipped());
+    assertEquals(1, result.errors().size());
+    assertTrue(result.errors().get(0).contains("reverso"));
+  }
+
+  @Test
+  void importFlashcards_csvSkipsBothEmptyFrontAndBack() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "front,back\n,\n";
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(0, result.imported());
+    assertEquals(1, result.skipped());
+    assertTrue(result.errors().isEmpty());
+  }
+
+  @Test
+  void importFlashcards_csvHandlesCreateException() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "front,back\nHello,Hola\n";
+
+    when(managementUseCase.createFlashcard(any()))
+        .thenThrow(new IllegalArgumentException("duplicate"));
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(0, result.imported());
+    assertEquals(1, result.skipped());
+    assertEquals(1, result.errors().size());
+    assertTrue(result.errors().get(0).contains("duplicate"));
+  }
+
+  @Test
+  void importFlashcards_csvWithoutHeaderLineStillImports() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "Hello,Hola\nGoodbye,Adiós\n";
+
+    Flashcard created = flashcard(unitId, "Hello", "Hola");
+    when(managementUseCase.createFlashcard(any())).thenReturn(created);
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(2, result.imported());
+  }
+
+  @Test
+  void importFlashcards_csvWithQuotedFields() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "front,back\n\"Hello, world\",\"Hola, mundo\"\n";
+
+    Flashcard created = flashcard(unitId, "Hello, world", "Hola, mundo");
+    when(managementUseCase.createFlashcard(any())).thenReturn(created);
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(1, result.imported());
+    assertEquals(0, result.skipped());
+  }
+
+  @Test
+  void importFlashcards_csvWithEscapedQuotesInFields() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "front,back\n\"Say \"\"hi\"\"\",reply\n";
+
+    Flashcard created = flashcard(unitId, "Say \"hi\"", "reply");
+    when(managementUseCase.createFlashcard(any())).thenReturn(created);
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(1, result.imported());
+  }
+
+  // --- importFlashcards: JSON ---
+
+  @Test
+  void importFlashcards_jsonImportsValidRows() {
+    UUID unitId = UUID.randomUUID();
+    String json = "[{\"front\":\"Hello\",\"back\":\"Hola\"},{\"front\":\"Bye\",\"back\":\"Adiós\"}]";
+
+    Flashcard created = flashcard(unitId, "Hello", "Hola");
+    when(managementUseCase.createFlashcard(any())).thenReturn(created);
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "json", json);
+
+    assertEquals(2, result.imported());
+    assertEquals(0, result.skipped());
+    assertTrue(result.errors().isEmpty());
+  }
+
+  @Test
+  void importFlashcards_jsonHandlesMissingFrontKey() {
+    UUID unitId = UUID.randomUUID();
+    String json = "[{\"back\":\"Hola\"}]";
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "json", json);
+
+    assertEquals(0, result.imported());
+    assertEquals(1, result.skipped());
+    assertEquals(1, result.errors().size());
+    assertTrue(result.errors().get(0).contains("anverso"));
+  }
+
+  @Test
+  void importFlashcards_jsonHandlesMissingBackKey() {
+    UUID unitId = UUID.randomUUID();
+    String json = "[{\"front\":\"Hello\"}]";
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "json", json);
+
+    assertEquals(0, result.imported());
+    assertEquals(1, result.skipped());
+    assertEquals(1, result.errors().size());
+    assertTrue(result.errors().get(0).contains("reverso"));
+  }
+
+  @Test
+  void importFlashcards_jsonReturnsParseErrorOnInvalidJson() {
+    UUID unitId = UUID.randomUUID();
+    String badJson = "not valid json";
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "json", badJson);
+
+    assertEquals(0, result.imported());
+    assertEquals(1, result.errors().size());
+    assertTrue(result.errors().get(0).contains("parsear"));
+  }
+
+  @Test
+  void importFlashcards_csvReturnsParseErrorOnNullContent() {
+    UUID unitId = UUID.randomUUID();
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", null);
+
+    assertEquals(0, result.imported());
+    assertEquals(1, result.errors().size());
+    assertTrue(result.errors().get(0).contains("parsear"));
+  }
+}

--- a/backend/src/test/java/com/akdemya/application/service/UserProfileServiceTest.java
+++ b/backend/src/test/java/com/akdemya/application/service/UserProfileServiceTest.java
@@ -18,162 +18,164 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UserProfileServiceTest {
 
-    private InMemoryUserRepository userRepo;
-    private UserProfileService service;
+  private InMemoryUserRepository userRepo;
+  private UserProfileService service;
 
-    @BeforeEach
-    void setUp() {
-        userRepo = new InMemoryUserRepository();
-        service = new UserProfileService(userRepo);
+  @BeforeEach
+  void setUp() {
+    userRepo = new InMemoryUserRepository();
+    service = new UserProfileService(userRepo);
+  }
+
+  // -------------------------------------------------------------------------
+  // getProfile — happy path
+  // -------------------------------------------------------------------------
+
+  @Test
+  void getProfile_happyPath_returnsUserData() {
+    AppUser user = AppUser.create("alice@example.com", "hash", "STUDENT", "Alice", "Smith", null);
+    userRepo.save(user);
+
+    GetProfileResponse response = service.getProfile(user.getId());
+
+    assertEquals(user.getId(), response.id());
+    assertEquals("alice@example.com", response.email());
+    assertEquals("Alice", response.firstName());
+    assertEquals("Smith", response.lastName());
+  }
+
+  // -------------------------------------------------------------------------
+  // getProfile — user not found
+  // -------------------------------------------------------------------------
+
+  @Test
+  void getProfile_whenUserNotFound_throwsException() {
+    UUID unknownId = UUID.randomUUID();
+
+    assertThrows(NoSuchElementException.class, () -> service.getProfile(unknownId));
+  }
+
+  // -------------------------------------------------------------------------
+  // updateProfile — happy path
+  // -------------------------------------------------------------------------
+
+  @Test
+  void updateProfile_happyPath_persistsNewNamesAndReturnsResponse() {
+    AppUser user = AppUser.create("bob@example.com", "hash", "STUDENT", "Bob", "Old", null);
+    userRepo.save(user);
+
+    GetProfileResponse response = service.updateProfile(
+        user.getId(),
+        new UpdateProfileCommand("Robert", "New")
+    );
+
+    assertEquals("Robert", response.firstName());
+    assertEquals("New", response.lastName());
+
+    AppUser persisted = userRepo.findById(user.getId()).orElseThrow();
+    assertEquals("Robert", persisted.getFirstName());
+    assertEquals("New", persisted.getLastName());
+  }
+
+  // -------------------------------------------------------------------------
+  // updateProfile — preserves unchanged fields
+  // -------------------------------------------------------------------------
+
+  @Test
+  void updateProfile_preservesUnchangedFieldsLikeEmailAndRole() {
+    AppUser user = AppUser.create("carol@example.com", "secret-hash", "ADMIN", "Carol", "Doe", "Engineer");
+    userRepo.save(user);
+
+    service.updateProfile(user.getId(), new UpdateProfileCommand("Caroline", null));
+
+    AppUser persisted = userRepo.findById(user.getId()).orElseThrow();
+    assertEquals("carol@example.com", persisted.getEmail());
+    assertEquals("secret-hash", persisted.getPasswordHash());
+    assertEquals("ADMIN", persisted.getRole());
+    assertEquals("Engineer", persisted.getOccupation());
+    assertEquals("Caroline", persisted.getFirstName());
+    assertNull(persisted.getLastName());
+  }
+
+  // -------------------------------------------------------------------------
+  // updateProfile — user not found
+  // -------------------------------------------------------------------------
+
+  @Test
+  void updateProfile_whenUserNotFound_throwsException() {
+    UUID unknownId = UUID.randomUUID();
+
+    assertThrows(NoSuchElementException.class, () ->
+        service.updateProfile(unknownId, new UpdateProfileCommand("X", "Y"))
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // updateProfile — firstName too long
+  // -------------------------------------------------------------------------
+
+  @Test
+  void updateProfile_whenFirstNameExceeds100Chars_throwsIllegalArgumentException() {
+    AppUser user = AppUser.create("dave@example.com", "hash", "STUDENT", "Dave", "Short", null);
+    userRepo.save(user);
+
+    String tooLong = "A".repeat(101);
+
+    assertThrows(IllegalArgumentException.class, () ->
+        service.updateProfile(user.getId(), new UpdateProfileCommand(tooLong, "Valid"))
+    );
+  }
+
+  // =========================================================================
+  // In-memory fake
+  // =========================================================================
+
+  static class InMemoryUserRepository implements UserRepository {
+    private final Map<UUID, AppUser> store = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<AppUser> findByEmail(String email) {
+      return store.values().stream().filter(u -> u.getEmail().equals(email)).findFirst();
     }
 
-    // -------------------------------------------------------------------------
-    // getProfile — happy path
-    // -------------------------------------------------------------------------
-
-    @Test
-    void getProfile_happyPath_returnsUserData() {
-        AppUser user = AppUser.create("alice@example.com", "hash", "STUDENT", "Alice", "Smith", null);
-        userRepo.save(user);
-
-        GetProfileResponse response = service.getProfile(user.getId());
-
-        assertEquals(user.getId(), response.id());
-        assertEquals("alice@example.com", response.email());
-        assertEquals("Alice", response.firstName());
-        assertEquals("Smith", response.lastName());
+    @Override
+    public AppUser save(AppUser user) {
+      store.put(user.getId(), user);
+      return user;
     }
 
-    // -------------------------------------------------------------------------
-    // getProfile — user not found
-    // -------------------------------------------------------------------------
-
-    @Test
-    void getProfile_whenUserNotFound_throwsException() {
-        UUID unknownId = UUID.randomUUID();
-
-        assertThrows(NoSuchElementException.class, () -> service.getProfile(unknownId));
+    @Override
+    public Optional<AppUser> findById(UUID id) {
+      return Optional.ofNullable(store.get(id));
     }
 
-    // -------------------------------------------------------------------------
-    // updateProfile — happy path
-    // -------------------------------------------------------------------------
-
-    @Test
-    void updateProfile_happyPath_persistsNewNamesAndReturnsResponse() {
-        AppUser user = AppUser.create("bob@example.com", "hash", "STUDENT", "Bob", "Old", null);
-        userRepo.save(user);
-
-        GetProfileResponse response = service.updateProfile(
-            user.getId(),
-            new UpdateProfileCommand("Robert", "New")
-        );
-
-        assertEquals("Robert", response.firstName());
-        assertEquals("New", response.lastName());
-
-        AppUser persisted = userRepo.findById(user.getId()).orElseThrow();
-        assertEquals("Robert", persisted.getFirstName());
-        assertEquals("New", persisted.getLastName());
+    @Override
+    public boolean existsByEmail(String email) {
+      return store.values().stream().anyMatch(u -> u.getEmail().equals(email));
     }
 
-    // -------------------------------------------------------------------------
-    // updateProfile — preserves unchanged fields
-    // -------------------------------------------------------------------------
-
-    @Test
-    void updateProfile_preservesUnchangedFieldsLikeEmailAndRole() {
-        AppUser user = AppUser.create("carol@example.com", "secret-hash", "ADMIN", "Carol", "Doe", "Engineer");
-        userRepo.save(user);
-
-        service.updateProfile(user.getId(), new UpdateProfileCommand("Caroline", null));
-
-        AppUser persisted = userRepo.findById(user.getId()).orElseThrow();
-        assertEquals("carol@example.com", persisted.getEmail());
-        assertEquals("secret-hash", persisted.getPasswordHash());
-        assertEquals("ADMIN", persisted.getRole());
-        assertEquals("Engineer", persisted.getOccupation());
-        assertEquals("Caroline", persisted.getFirstName());
-        assertNull(persisted.getLastName());
+    @Override
+    public List<AppUser> findAll() {
+      return new ArrayList<>(store.values());
     }
 
-    // -------------------------------------------------------------------------
-    // updateProfile — user not found
-    // -------------------------------------------------------------------------
-
-    @Test
-    void updateProfile_whenUserNotFound_throwsException() {
-        UUID unknownId = UUID.randomUUID();
-
-        assertThrows(NoSuchElementException.class, () ->
-            service.updateProfile(unknownId, new UpdateProfileCommand("X", "Y"))
-        );
+    @Override
+    public Page<AppUser> findPage(int page, int size) {
+      List<AppUser> all = findAll();
+      int from = Math.min(page * size, all.size());
+      int to = Math.min(from + size, all.size());
+      return new PageImpl<>(all.subList(from, to), PageRequest.of(page, size), all.size());
     }
 
-    // -------------------------------------------------------------------------
-    // updateProfile — firstName too long
-    // -------------------------------------------------------------------------
-
-    @Test
-    void updateProfile_whenFirstNameExceeds100Chars_throwsIllegalArgumentException() {
-        AppUser user = AppUser.create("dave@example.com", "hash", "STUDENT", "Dave", "Short", null);
-        userRepo.save(user);
-
-        String tooLong = "A".repeat(101);
-
-        assertThrows(IllegalArgumentException.class, () ->
-            service.updateProfile(user.getId(), new UpdateProfileCommand(tooLong, "Valid"))
-        );
+    @Override
+    public void deleteById(UUID id) {
+      store.remove(id);
     }
-
-    // =========================================================================
-    // In-memory fake
-    // =========================================================================
-
-    static class InMemoryUserRepository implements UserRepository {
-        private final Map<UUID, AppUser> store = new ConcurrentHashMap<>();
-
-        @Override
-        public Optional<AppUser> findByEmail(String email) {
-            return store.values().stream().filter(u -> u.getEmail().equals(email)).findFirst();
-        }
-
-        @Override
-        public AppUser save(AppUser user) {
-            store.put(user.getId(), user);
-            return user;
-        }
-
-        @Override
-        public Optional<AppUser> findById(UUID id) {
-            return Optional.ofNullable(store.get(id));
-        }
-
-        @Override
-        public boolean existsByEmail(String email) {
-            return store.values().stream().anyMatch(u -> u.getEmail().equals(email));
-        }
-
-        @Override
-        public List<AppUser> findAll() {
-            return new ArrayList<>(store.values());
-        }
-
-        @Override
-        public Page<AppUser> findPage(int page, int size) {
-            List<AppUser> all = findAll();
-            int from = Math.min(page * size, all.size());
-            int to = Math.min(from + size, all.size());
-            return new PageImpl<>(all.subList(from, to), PageRequest.of(page, size), all.size());
-        }
-
-        @Override
-        public void deleteById(UUID id) {
-            store.remove(id);
-        }
-    }
+  }
 }

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getMyProfile, updateMyProfile, apiAuthJson, apiJson } from '../api';
+import {
+  getMyProfile, updateMyProfile, apiAuthJson, apiJson, exportFlashcardsBySubject,
+  uploadSource, confirmIndex, getSources, generateQuiz, getDrafts, approveDraft,
+  rejectDraft, getUnitsForSubject, deleteSource
+} from '../api';
 
 // Mock global fetch
 const mockFetch = vi.fn();
@@ -147,5 +151,226 @@ describe('apiJson', () => {
     mockFetch.mockRejectedValue(abortErr);
 
     await expect(apiJson('http://localhost/data')).rejects.toMatchObject({ message: 'timeout', code: 'timeout' });
+  });
+});
+
+describe('apiAuthJson with timeoutMs', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clears timeout after successful response', async () => {
+    vi.useFakeTimers();
+    const clearSpy = vi.spyOn(window, 'clearTimeout');
+    mockFetch.mockResolvedValue(makeResponse({ data: 'ok' }));
+
+    const result = await apiAuthJson<{ data: string }>('http://localhost/test', 'token', { timeoutMs: 5000 });
+
+    expect(result).toEqual({ data: 'ok' });
+    expect(clearSpy).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});
+
+describe('RAG API functions', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('uploadSource posts FormData and returns IndexPreview', async () => {
+    const preview = { documentId: 'doc-1', units: [] };
+    mockFetch.mockResolvedValue(makeResponse(preview));
+
+    const file = new File(['content'], 'test.pdf', { type: 'application/pdf' });
+    const result = await uploadSource('token', file, 'subj-1');
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/sources');
+    expect(options.method).toBe('POST');
+    expect(options.headers.Authorization).toBe('Bearer token');
+    expect(result).toEqual(preview);
+  });
+
+  it('uploadSource throws api_error on failure', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 400, json: () => Promise.resolve({}) } as unknown as Response);
+
+    const file = new File([''], 'test.pdf');
+    await expect(uploadSource('token', file, 'subj-1')).rejects.toMatchObject({ message: 'api_error', status: 400 });
+  });
+
+  it('confirmIndex posts to confirm endpoint and returns result', async () => {
+    const result = { document: { id: 'doc-1' }, savedUnits: [] };
+    mockFetch.mockResolvedValue(makeResponse(result));
+
+    const res = await confirmIndex('token', 'doc-1', []);
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/sources/doc-1/confirm');
+    expect(options.method).toBe('POST');
+    expect(res).toEqual(result);
+  });
+
+  it('getSources returns list of sources', async () => {
+    const sources = [{ id: 'src-1', name: 'Document' }];
+    mockFetch.mockResolvedValue(makeResponse(sources));
+
+    const result = await getSources('token');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/sources');
+    expect(result).toEqual(sources);
+  });
+
+  it('getSources with subjectId appends query param', async () => {
+    mockFetch.mockResolvedValue(makeResponse([]));
+
+    await getSources('token', 'subj-1');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('subjectId=subj-1');
+  });
+
+  it('generateQuiz posts command and returns response', async () => {
+    const quizResponse = { quizId: 'q-1', questions: [] };
+    mockFetch.mockResolvedValue(makeResponse(quizResponse));
+
+    // generateQuiz uses timeoutMs internally; stub clearTimeout so it works in jsdom
+    const origClearTimeout = window.clearTimeout;
+    vi.stubGlobal('clearTimeout', vi.fn());
+
+    const result = await generateQuiz('token', { sourceId: 'src-1', count: 5 } as any);
+
+    vi.stubGlobal('clearTimeout', origClearTimeout);
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/ai/quizzes/generate');
+    expect(options.method).toBe('POST');
+    expect(result).toEqual(quizResponse);
+  });
+
+  it('getDrafts returns filtered drafts by sourceId', async () => {
+    const drafts = [{ id: 'd-1', status: 'PENDING' }];
+    mockFetch.mockResolvedValue(makeResponse(drafts));
+
+    const result = await getDrafts('token', 'src-1');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('sourceId=src-1');
+    expect(result).toEqual(drafts);
+  });
+
+  it('getDrafts appends status query param when provided', async () => {
+    mockFetch.mockResolvedValue(makeResponse([]));
+
+    await getDrafts('token', 'src-1', 'PENDING');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('status=PENDING');
+  });
+
+  it('approveDraft posts to approve endpoint', async () => {
+    const draft = { id: 'd-1', status: 'APPROVED' };
+    mockFetch.mockResolvedValue(makeResponse(draft));
+
+    const result = await approveDraft('token', 'd-1');
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/ai/drafts/d-1/approve');
+    expect(options.method).toBe('POST');
+    expect(result).toEqual(draft);
+  });
+
+  it('rejectDraft posts to reject endpoint', async () => {
+    const draft = { id: 'd-1', status: 'REJECTED' };
+    mockFetch.mockResolvedValue(makeResponse(draft));
+
+    const result = await rejectDraft('token', 'd-1');
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/ai/drafts/d-1/reject');
+    expect(options.method).toBe('POST');
+    expect(result).toEqual(draft);
+  });
+
+  it('getUnitsForSubject returns units list', async () => {
+    const units = [{ id: 'u-1', name: 'Unit 1' }];
+    mockFetch.mockResolvedValue(makeResponse(units));
+
+    const result = await getUnitsForSubject('token', 'subj-1');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/units?subjectId=subj-1');
+    expect(result).toEqual(units);
+  });
+
+  it('deleteSource sends DELETE request', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 204, text: () => Promise.resolve(''), json: () => Promise.resolve(undefined) } as unknown as Response);
+
+    await deleteSource('token', 'src-1');
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/sources/src-1');
+    expect(options.method).toBe('DELETE');
+  });
+});
+
+describe('exportFlashcardsBySubject', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('returns text content on success', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve('front,back\nHello,Hola\n'),
+    } as unknown as Response);
+
+    const result = await exportFlashcardsBySubject('my-token', 'subj-1', 'csv');
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('subjectId=subj-1');
+    expect(url).toContain('format=csv');
+    expect(options.headers.Authorization).toBe('Bearer my-token');
+    expect(result).toBe('front,back\nHello,Hola\n');
+  });
+
+  it('returns JSON text when format is json', async () => {
+    const jsonContent = '[{"front":"Hello","back":"Hola"}]';
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(jsonContent),
+    } as unknown as Response);
+
+    const result = await exportFlashcardsBySubject('token', 'subj-2', 'json');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('format=json');
+    expect(result).toBe(jsonContent);
+  });
+
+  it('throws with status when response is not ok', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+    } as unknown as Response);
+
+    await expect(exportFlashcardsBySubject('token', 'subj-3', 'csv')).rejects.toMatchObject({
+      message: 'api_error',
+      status: 403,
+    });
+  });
+
+  it('throws network error when fetch rejects', async () => {
+    mockFetch.mockRejectedValue(new Error('network failure'));
+
+    await expect(exportFlashcardsBySubject('token', 'subj-4', 'csv')).rejects.toThrow('network failure');
   });
 });

--- a/frontend/src/__tests__/flashcards/FlashcardsExamineUnitPage.test.tsx
+++ b/frontend/src/__tests__/flashcards/FlashcardsExamineUnitPage.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import FlashcardsExamineUnitPage from '../../pages/FlashcardsExamineUnitPage';
+import * as api from '../../api';
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useSearchParams: () => [new URLSearchParams('unitId=unit-1')],
+}));
+
+vi.mock('../../api', async (importOriginal) => {
+  const actual = await importOriginal<typeof api>();
+  return {
+    ...actual,
+    apiAuthJson: vi.fn(),
+  };
+});
+
+const mockCards = [
+  { id: 'card-1', unitId: 'unit-1', front: '¿Qué es la derivada?', back: 'Tasa de cambio instantánea.' },
+  { id: 'card-2', unitId: 'unit-1', front: '¿Qué es la integral?', back: 'Área bajo la curva.' },
+];
+
+describe('FlashcardsExamineUnitPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.setItem('ak_token', 'test-token');
+  });
+
+  it('shows skeleton while loading', () => {
+    vi.mocked(api.apiAuthJson).mockReturnValue(new Promise(() => {}));
+
+    const { container } = render(<FlashcardsExamineUnitPage />);
+
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('renders cards when loaded', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state with Volver and import CTA when no cards', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No hay tarjetas en esta unidad.')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: /volver/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /importar flashcards/i })).toBeInTheDocument();
+  });
+
+  it('shows error state on API failure', async () => {
+    vi.mocked(api.apiAuthJson).mockRejectedValue(new Error('api_error'));
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No se pudieron cargar las tarjetas.')).toBeInTheDocument();
+    });
+  });
+
+  it('flips card when clicked to show back, and again to show front', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument());
+
+    // Initially shows front text
+    expect(screen.getByText('Toca para ver la respuesta')).toBeInTheDocument();
+
+    // Click card to flip
+    fireEvent.click(screen.getByText('¿Qué es la derivada?').closest('.cursor-pointer')!);
+
+    await waitFor(() => {
+      expect(screen.getByText('Tasa de cambio instantánea.')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Toca para ver la pregunta')).toBeInTheDocument();
+
+    // Click again to flip back
+    fireEvent.click(screen.getByText('Tasa de cambio instantánea.').closest('.cursor-pointer')!);
+
+    await waitFor(() => {
+      expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to next card when Siguiente is clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Siguiente →'));
+
+    await waitFor(() => {
+      expect(screen.getByText('¿Qué es la integral?')).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to previous card when Anterior is clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument());
+
+    // Go to second card
+    fireEvent.click(screen.getByText('Siguiente →'));
+    await waitFor(() => expect(screen.getByText('¿Qué es la integral?')).toBeInTheDocument());
+
+    // Go back
+    fireEvent.click(screen.getByText('← Anterior'));
+    await waitFor(() => expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument());
+  });
+
+  it('disables Anterior button on first card', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument());
+
+    const prevBtn = screen.getByText('← Anterior');
+    expect(prevBtn).toBeDisabled();
+  });
+
+  it('disables Siguiente button on last card', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Siguiente →'));
+    await waitFor(() => expect(screen.getByText('¿Qué es la integral?')).toBeInTheDocument());
+
+    expect(screen.getByText('Siguiente →')).toBeDisabled();
+  });
+
+  it('resets flip state when navigating to next card', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument());
+
+    // Flip current card
+    fireEvent.click(screen.getByText('¿Qué es la derivada?').closest('.cursor-pointer')!);
+    await waitFor(() => expect(screen.getByText('Tasa de cambio instantánea.')).toBeInTheDocument());
+
+    // Navigate to next — flip should reset
+    fireEvent.click(screen.getByText('Siguiente →'));
+    await waitFor(() => {
+      expect(screen.getByText('¿Qué es la integral?')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Toca para ver la respuesta')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/flashcards/FlashcardsPage.test.tsx
+++ b/frontend/src/__tests__/flashcards/FlashcardsPage.test.tsx
@@ -69,8 +69,8 @@ describe('FlashcardsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.setItem('ak_token', 'test-token');
-    global.URL.createObjectURL = vi.fn(() => 'blob:test');
-    global.URL.revokeObjectURL = vi.fn();
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:test');
+    globalThis.URL.revokeObjectURL = vi.fn();
   });
 
   it('shows empty state with import CTA when no subjects available', async () => {
@@ -235,7 +235,7 @@ describe('FlashcardsPage', () => {
 
   it('shows export error banner when unit export fetch fails', async () => {
     vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
-    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
 
     render(<FlashcardsPage />);
 
@@ -259,7 +259,7 @@ describe('FlashcardsPage', () => {
 
   it('dismisses export error banner when close button is clicked', async () => {
     vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
-    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
 
     render(<FlashcardsPage />);
 

--- a/frontend/src/__tests__/flashcards/FlashcardsPage.test.tsx
+++ b/frontend/src/__tests__/flashcards/FlashcardsPage.test.tsx
@@ -1,0 +1,373 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import FlashcardsPage from '../../pages/FlashcardsPage';
+import * as api from '../../api';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useSearchParams: () => [new URLSearchParams()],
+}));
+
+vi.mock('../../components/flashcards/FlashcardImportModal', () => ({
+  default: ({ onClose, onImported }: { onClose: () => void; onImported: () => void }) => (
+    <div data-testid="import-modal">
+      <button onClick={onClose}>Cerrar modal</button>
+      <button onClick={onImported}>Importado</button>
+    </div>
+  ),
+}));
+
+vi.mock('../../components/flashcards/FlashcardsTabs', () => ({
+  default: ({ onTab }: { onTab: (tab: string) => void }) => (
+    <div data-testid="flashcards-tabs">
+      <button onClick={() => onTab('estudio')}>Estudio</button>
+      <button onClick={() => onTab('examinar')}>Examinar</button>
+      <button onClick={() => onTab('historial')}>Historial</button>
+    </div>
+  ),
+}));
+
+vi.mock('../../components/flashcards/SearchInput', () => ({
+  default: ({ onChange }: { onChange: (v: string) => void }) => (
+    <input data-testid="search-input" onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+vi.mock('../../api', async (importOriginal) => {
+  const actual = await importOriginal<typeof api>();
+  return {
+    ...actual,
+    apiAuthJson: vi.fn(),
+    exportFlashcardsBySubject: vi.fn(),
+  };
+});
+
+const mockUnits = [
+  {
+    unitId: 'unit-1',
+    unitName: 'Álgebra',
+    subjectId: 'subj-1',
+    subjectName: 'Matemáticas',
+    newCount: 3,
+    reviewCount: 2,
+    dueCount: 1,
+  },
+  {
+    unitId: 'unit-2',
+    unitName: 'Trigonometría',
+    subjectId: 'subj-1',
+    subjectName: 'Matemáticas',
+    newCount: 1,
+    reviewCount: 0,
+    dueCount: 0,
+  },
+];
+
+describe('FlashcardsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.setItem('ak_token', 'test-token');
+    global.URL.createObjectURL = vi.fn(() => 'blob:test');
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  it('shows empty state with import CTA when no subjects available', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No hay materias disponibles.')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('button', { name: /importar flashcards/i })
+    ).toBeInTheDocument();
+  });
+
+  it('opens import modal when empty state CTA is clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No hay materias disponibles.')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /importar flashcards/i }));
+
+    expect(screen.getByTestId('import-modal')).toBeInTheDocument();
+  });
+
+  it('opens import modal when header Importar button is clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No hay materias disponibles.')).toBeInTheDocument();
+    });
+
+    const importButtons = screen.getAllByRole('button', { name: /importar/i });
+    fireEvent.click(importButtons[0]);
+
+    expect(screen.getByTestId('import-modal')).toBeInTheDocument();
+  });
+
+  it('closes import modal when close is clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('No hay materias disponibles.')).toBeInTheDocument());
+
+    fireEvent.click(screen.getAllByRole('button', { name: /importar/i })[0]);
+    expect(screen.getByTestId('import-modal')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Cerrar modal'));
+    expect(screen.queryByTestId('import-modal')).not.toBeInTheDocument();
+  });
+
+  it('reloads units when onImported is called from modal', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('No hay materias disponibles.')).toBeInTheDocument());
+
+    fireEvent.click(screen.getAllByRole('button', { name: /importar/i })[0]);
+    fireEvent.click(screen.getByText('Importado'));
+
+    // apiAuthJson should be called again (reload)
+    expect(vi.mocked(api.apiAuthJson).mock.calls.length).toBeGreaterThan(2);
+  });
+
+  it('shows subjects when data loads', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Matemáticas')).toBeInTheDocument();
+    });
+  });
+
+  it('shows unit list when subject is selected', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+
+    // We need SubjectCard to be real here — don't mock it
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+
+    // Click on the subject button (the main button inside SubjectCard)
+    fireEvent.click(screen.getByText('Matemáticas'));
+
+    // UnitList should now show the units for the selected subject
+    await waitFor(() => {
+      expect(screen.getByText('Álgebra')).toBeInTheDocument();
+    });
+  });
+
+  it('shows back button and navigates back when clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Matemáticas'));
+
+    await waitFor(() => expect(screen.getByText('Álgebra')).toBeInTheDocument());
+
+    const backButton = screen.getByRole('button', { name: /volver a materias/i });
+    fireEvent.click(backButton);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+    expect(screen.queryByText('Álgebra')).not.toBeInTheDocument();
+  });
+
+  it('navigates to study page when unit clicked in study mode', async () => {
+    vi.mock('react-router-dom', () => ({
+      useNavigate: () => mockNavigate,
+      useSearchParams: () => [new URLSearchParams('mode=study')],
+    }));
+
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+  });
+
+  it('navigates to study page tab when Estudio tab clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByTestId('flashcards-tabs')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Estudio'));
+    expect(mockNavigate).toHaveBeenCalledWith('/flashcards?mode=study');
+  });
+
+  it('navigates to flashcards when Examinar tab clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByTestId('flashcards-tabs')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Examinar'));
+    expect(mockNavigate).toHaveBeenCalledWith('/flashcards');
+  });
+
+  it('navigates to history when Historial tab clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByTestId('flashcards-tabs')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Historial'));
+    expect(mockNavigate).toHaveBeenCalledWith('/flashcards/history');
+  });
+
+  it('shows export error banner when unit export fetch fails', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+
+    // Select subject to show units
+    fireEvent.click(screen.getByText('Matemáticas'));
+
+    await waitFor(() => expect(screen.getByText('Álgebra')).toBeInTheDocument());
+
+    // Click CSV export button in UnitCard
+    const csvButtons = screen.getAllByTitle('Exportar CSV');
+    fireEvent.click(csvButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/no se pudo exportar/i);
+  });
+
+  it('dismisses export error banner when close button is clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Matemáticas'));
+    await waitFor(() => expect(screen.getByText('Álgebra')).toBeInTheDocument());
+
+    const csvButtons = screen.getAllByTitle('Exportar CSV');
+    fireEvent.click(csvButtons[0]);
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /cerrar error/i }));
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('calls exportFlashcardsBySubject and creates download link on success', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.exportFlashcardsBySubject).mockResolvedValue('front,back\nHello,Hola\n');
+
+    // Spy on link.click without mocking createElement globally
+    const realCreateElement = document.createElement.bind(document);
+    const clickSpy = vi.fn();
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string, ...args: any[]) => {
+      const el = realCreateElement(tag, ...args);
+      if (tag === 'a') {
+        vi.spyOn(el as HTMLAnchorElement, 'click').mockImplementation(clickSpy);
+      }
+      return el;
+    });
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+
+    // Click CSV export on the SubjectCard
+    const csvButtons = screen.getAllByTitle('Exportar CSV');
+    fireEvent.click(csvButtons[0]);
+
+    await waitFor(() => {
+      expect(api.exportFlashcardsBySubject).toHaveBeenCalledWith('test-token', 'subj-1', 'csv');
+    });
+
+    expect(clickSpy).toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it('shows subject export error banner when exportFlashcardsBySubject fails', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.exportFlashcardsBySubject).mockRejectedValue(new Error('api_error'));
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+
+    const csvButtons = screen.getAllByTitle('Exportar CSV');
+    fireEvent.click(csvButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/no se pudo exportar la materia/i);
+  });
+
+  it('filters subjects by search term', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([
+      ...mockUnits,
+      {
+        unitId: 'unit-3',
+        unitName: 'Historia Medieval',
+        subjectId: 'subj-2',
+        subjectName: 'Historia',
+        newCount: 0,
+        reviewCount: 0,
+        dueCount: 0,
+      },
+    ]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Matemáticas')).toBeInTheDocument();
+      expect(screen.getByText('Historia')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('search-input'), { target: { value: 'histo' } });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Matemáticas')).not.toBeInTheDocument();
+      expect(screen.getByText('Historia')).toBeInTheDocument();
+    });
+  });
+
+  it('filters units by search term when subject is selected', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Matemáticas'));
+    await waitFor(() => expect(screen.getByText('Álgebra')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('search-input'), { target: { value: 'álge' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Álgebra')).toBeInTheDocument();
+      expect(screen.queryByText('Trigonometría')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/__tests__/flashcards/FlashcardsStudyPage.test.tsx
+++ b/frontend/src/__tests__/flashcards/FlashcardsStudyPage.test.tsx
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import FlashcardsStudyPage from '../../pages/FlashcardsStudyPage';
+import * as api from '../../api';
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useSearchParams: () => [new URLSearchParams('unitId=unit-1')],
+}));
+
+vi.mock('flowbite-react-icons/outline', () => ({
+  ArrowLeft: () => <span data-testid="arrow-left" />,
+  CircleMinus: () => <span data-testid="circle-minus" />,
+  CheckCircle: () => <span data-testid="check-circle" />,
+}));
+
+vi.mock('../../api', async (importOriginal) => {
+  const actual = await importOriginal<typeof api>();
+  return {
+    ...actual,
+    apiAuthJson: vi.fn(),
+  };
+});
+
+const mockQueue = { new: 1, due: 0, learning: 0 };
+const emptyQueue = { new: 0, due: 0, learning: 0 };
+const mockItem = {
+  flashcardId: 'fc-1',
+  front: '¿Cuánto es 2+2?',
+  back: '4',
+  state: 'NEW' as const,
+  intervalHints: { again: '1m', good: '10m', easy: '4d' },
+};
+
+describe('FlashcardsStudyPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.setItem('ak_token', 'test-token');
+  });
+
+  it('shows skeleton while loading', () => {
+    vi.mocked(api.apiAuthJson).mockReturnValue(new Promise(() => {}));
+
+    const { container } = render(<FlashcardsStudyPage />);
+
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('renders study session when loaded', async () => {
+    vi.mocked(api.apiAuthJson)
+      .mockResolvedValueOnce(mockQueue) // fetchQueue
+      .mockResolvedValueOnce(mockItem); // fetchNext
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('¿Cuánto es 2+2?')).toBeInTheDocument();
+    });
+  });
+
+  it('shows inline review error without replacing session', async () => {
+    vi.mocked(api.apiAuthJson)
+      .mockResolvedValueOnce(mockQueue) // initial fetchQueue
+      .mockResolvedValueOnce(mockItem) // initial fetchNext
+      .mockRejectedValueOnce(new Error('api_error')); // POST review fails
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('¿Cuánto es 2+2?')).toBeInTheDocument();
+    });
+
+    // Show answer first
+    fireEvent.click(screen.getByText('Mostrar respuesta'));
+    await waitFor(() => {
+      expect(screen.getByText('4')).toBeInTheDocument();
+    });
+
+    // Click Repetir (AGAIN)
+    fireEvent.click(screen.getByText('❌ Repetir'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    // Session is NOT replaced — no finished screen
+    expect(screen.queryByText('Sesión completada')).not.toBeInTheDocument();
+    expect(screen.queryByText('Sin pendientes')).not.toBeInTheDocument();
+    // Error message is visible
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      /no se pudo registrar la respuesta/i
+    );
+  });
+
+  it('review error can be dismissed', async () => {
+    vi.mocked(api.apiAuthJson)
+      .mockResolvedValueOnce(mockQueue)
+      .mockResolvedValueOnce(mockItem)
+      .mockRejectedValueOnce(new Error('api_error'));
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('¿Cuánto es 2+2?')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Mostrar respuesta'));
+    await waitFor(() => screen.getByText('4'));
+
+    fireEvent.click(screen.getByText('❌ Repetir'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText('Cerrar error'));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows "Nada que repasar hoy" when finished with 0 answered cards', async () => {
+    vi.mocked(api.apiAuthJson)
+      .mockResolvedValueOnce(emptyQueue) // fetchQueue — empty
+      .mockResolvedValueOnce(undefined); // fetchNext — nothing
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Nada que repasar hoy')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText('No había tarjetas pendientes para repasar en esta sesión.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/has respondido/i)).not.toBeInTheDocument();
+  });
+
+  it('shows answered count when finished after reviewing cards', async () => {
+    vi.mocked(api.apiAuthJson)
+      .mockResolvedValueOnce(mockQueue) // initial fetchQueue
+      .mockResolvedValueOnce(mockItem) // initial fetchNext
+      .mockResolvedValueOnce(undefined) // POST review (204 no content)
+      .mockResolvedValueOnce(emptyQueue) // fetchQueue after review
+      .mockResolvedValueOnce(undefined); // fetchNext after review — done
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('¿Cuánto es 2+2?')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Mostrar respuesta'));
+    await waitFor(() => screen.getByText('4'));
+
+    fireEvent.click(screen.getByText('🚀 Memorizada'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Sesión completada')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/has respondido/i)).toBeInTheDocument();
+  });
+
+  it('opens confirm modal when Terminar sesión is clicked', async () => {
+    vi.mocked(api.apiAuthJson)
+      .mockResolvedValueOnce(mockQueue)
+      .mockResolvedValueOnce(mockItem);
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Cuánto es 2+2?')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Terminar sesión'));
+
+    expect(screen.getByText('Terminar sesión', { selector: 'h3' })).toBeInTheDocument();
+  });
+
+  it('can cancel the confirm modal', async () => {
+    vi.mocked(api.apiAuthJson)
+      .mockResolvedValueOnce(mockQueue)
+      .mockResolvedValueOnce(mockItem);
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Cuánto es 2+2?')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Terminar sesión'));
+    expect(screen.getByText('Terminar sesión', { selector: 'h3' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }));
+    expect(screen.queryByText('Terminar sesión', { selector: 'h3' })).not.toBeInTheDocument();
+  });
+
+  it('finishes session when Terminar is confirmed in modal', async () => {
+    vi.mocked(api.apiAuthJson)
+      .mockResolvedValueOnce(mockQueue)
+      .mockResolvedValueOnce(mockItem);
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Cuánto es 2+2?')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Terminar sesión'));
+    // click the "Terminar" button inside the modal
+    const terminarButtons = screen.getAllByRole('button', { name: 'Terminar' });
+    const modalTerminar = terminarButtons.find(b => b.closest('.fixed'));
+    fireEvent.click(modalTerminar!);
+
+    await waitFor(() => {
+      // After finishing with 0 answered, shows "Sin pendientes" or "Sesión completada"
+      const hasSinPendientes = screen.queryByText('Sin pendientes');
+      const hasSesionCompletada = screen.queryByText('Sesión completada');
+      expect(hasSinPendientes || hasSesionCompletada).toBeTruthy();
+    });
+  });
+
+  it('shows error state when initial load fails', async () => {
+    vi.mocked(api.apiAuthJson).mockRejectedValue(new Error('api_error'));
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No se pudo cargar la sesión de estudio.')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: /volver/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/flashcards/SubjectCard.test.tsx
+++ b/frontend/src/__tests__/flashcards/SubjectCard.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SubjectCard from '../../components/flashcards/SubjectCard';
+import type { SubjectSummary } from '../../components/flashcards/SubjectCard';
+
+const subject: SubjectSummary = {
+  subjectId: 'subj-1',
+  subjectName: 'Matemáticas',
+  newCount: 3,
+  reviewCount: 2,
+  dueCount: 1,
+  unitCount: 2,
+};
+
+describe('SubjectCard', () => {
+  const onClick = vi.fn();
+  const onExport = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders subject name and pending count', () => {
+    render(<SubjectCard subject={subject} onClick={onClick} />);
+    expect(screen.getByText('Matemáticas')).toBeInTheDocument();
+    // pending = dueCount + newCount = 1 + 3 = 4
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+
+  it('calls onClick when button is clicked', () => {
+    render(<SubjectCard subject={subject} onClick={onClick} />);
+    // The main button contains all text content of the card
+    const buttons = screen.getAllByRole('button');
+    // The subject card button is the first (and only one when no onExport)
+    fireEvent.click(buttons[0]);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render export buttons when onExport is not provided', () => {
+    render(<SubjectCard subject={subject} onClick={onClick} />);
+    expect(screen.queryByTitle('Exportar CSV')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Exportar JSON')).not.toBeInTheDocument();
+  });
+
+  it('renders export buttons when onExport is provided', () => {
+    render(<SubjectCard subject={subject} onClick={onClick} onExport={onExport} />);
+    expect(screen.getByTitle('Exportar CSV')).toBeInTheDocument();
+    expect(screen.getByTitle('Exportar JSON')).toBeInTheDocument();
+  });
+
+  it('calls onExport with csv when CSV button is clicked', () => {
+    render(<SubjectCard subject={subject} onClick={onClick} onExport={onExport} />);
+    fireEvent.click(screen.getByTitle('Exportar CSV'));
+    expect(onExport).toHaveBeenCalledWith('csv');
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('calls onExport with json when JSON button is clicked', () => {
+    render(<SubjectCard subject={subject} onClick={onClick} onExport={onExport} />);
+    fireEvent.click(screen.getByTitle('Exportar JSON'));
+    expect(onExport).toHaveBeenCalledWith('json');
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/flashcards/UnitList.test.tsx
+++ b/frontend/src/__tests__/flashcards/UnitList.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import UnitList from '../../components/flashcards/UnitList';
+import type { UnitSummary } from '../../pages/FlashcardsPage';
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+const units: UnitSummary[] = [
+  {
+    unitId: 'unit-1',
+    unitName: 'Álgebra',
+    subjectId: 'subj-1',
+    subjectName: 'Matemáticas',
+    newCount: 5,
+    reviewCount: 2,
+    dueCount: 1,
+  },
+];
+
+describe('UnitList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows skeleton while loading', () => {
+    const { container } = render(
+      <UnitList units={[]} loading={true} error="" />
+    );
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('shows error message when error is provided', () => {
+    render(<UnitList units={[]} loading={false} error="Error cargando unidades" />);
+    expect(screen.getByText('Error cargando unidades')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no units', () => {
+    render(<UnitList units={[]} loading={false} error="" />);
+    expect(screen.getByText('No hay unidades disponibles.')).toBeInTheDocument();
+  });
+
+  it('empty state does not show import CTA when onImport is not provided', () => {
+    render(<UnitList units={[]} loading={false} error="" />);
+    expect(screen.queryByRole('button', { name: /importar flashcards/i })).not.toBeInTheDocument();
+  });
+
+  it('empty state shows import CTA when onImport is provided', () => {
+    const onImport = vi.fn();
+    render(<UnitList units={[]} loading={false} error="" onImport={onImport} />);
+    expect(screen.getByRole('button', { name: /importar flashcards/i })).toBeInTheDocument();
+  });
+
+  it('empty state CTA calls onImport when clicked', () => {
+    const onImport = vi.fn();
+    render(<UnitList units={[]} loading={false} error="" onImport={onImport} />);
+    fireEvent.click(screen.getByRole('button', { name: /importar flashcards/i }));
+    expect(onImport).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders unit cards when units are provided', () => {
+    render(<UnitList units={units} loading={false} error="" />);
+    expect(screen.getByText('Álgebra')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -143,6 +143,23 @@ export async function deleteSource(token: string, id: string): Promise<void> {
   return apiAuthJson<void>(`${apiBase}/api/sources/${id}`, token, { method: 'DELETE' });
 }
 
+export async function exportFlashcardsBySubject(
+  token: string,
+  subjectId: string,
+  format: 'csv' | 'json'
+): Promise<string> {
+  const res = await fetch(
+    `${apiBase}/api/flashcards/export?subjectId=${subjectId}&format=${format}`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  if (!res.ok) {
+    const err: any = new Error('api_error');
+    err.status = res.status;
+    throw err;
+  }
+  return res.text();
+}
+
 export async function apiAuthJson<T>(url: string, token: string, options: RequestOptions = {}): Promise<T> {
   const { timeoutMs, ...fetchOptions } = options;
   const { signal, clear } = mergeSignal(fetchOptions.signal ?? undefined, timeoutMs);

--- a/frontend/src/components/flashcards/SubjectCard.tsx
+++ b/frontend/src/components/flashcards/SubjectCard.tsx
@@ -9,37 +9,65 @@ type SubjectSummary = {
 
 export type { SubjectSummary };
 
-export default function SubjectCard({ subject, onClick }: { subject: SubjectSummary; onClick: () => void }) {
+type Props = {
+  subject: SubjectSummary;
+  onClick: () => void;
+  onExport?: (format: 'csv' | 'json') => void;
+};
+
+export default function SubjectCard({ subject, onClick, onExport }: Props) {
   const pending = subject.dueCount + subject.newCount;
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="group w-full text-left border border-secondary/25 rounded-2xl p-5 transition-all hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5"
-    >
-      <div className="flex items-center gap-4">
-        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-accent/10 text-accent group-hover:bg-accent/15 transition-colors text-xl">
-          📚
-        </div>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-start justify-between gap-2">
-            <div className="font-bold text-sm leading-snug">{subject.subjectName}</div>
-            <div className="text-right shrink-0">
-              <div className="text-xl font-extrabold tabular-nums">{pending}</div>
-              <div className="text-xs text-text/40 uppercase tracking-wide">pendientes</div>
+    <div className="group relative">
+      <button
+        type="button"
+        onClick={onClick}
+        className="w-full text-left border border-secondary/25 rounded-2xl p-5 transition-all hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5"
+      >
+        <div className="flex items-center gap-4">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-accent/10 text-accent group-hover:bg-accent/15 transition-colors text-xl">
+            📚
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-start justify-between gap-2">
+              <div className="font-bold text-sm leading-snug">{subject.subjectName}</div>
+              <div className="text-right shrink-0">
+                <div className="text-xl font-extrabold tabular-nums">{pending}</div>
+                <div className="text-xs text-text/40 uppercase tracking-wide">pendientes</div>
+              </div>
             </div>
           </div>
+          <div className="text-text/30 text-lg">›</div>
         </div>
-        <div className="text-text/30 text-lg">›</div>
-      </div>
 
-      <div className="mt-3 flex flex-wrap gap-4 text-xs text-text/55">
-        <span>📖 {subject.unitCount} {subject.unitCount === 1 ? 'mazo' : 'mazos'}</span>
-        {subject.newCount > 0 && <span>🆕 {subject.newCount} nuevas</span>}
-        {subject.reviewCount > 0 && <span>🟡 {subject.reviewCount} en repaso</span>}
-        {subject.dueCount > 0 && <span>🔁 {subject.dueCount} pendientes</span>}
-      </div>
-    </button>
+        <div className="mt-3 flex flex-wrap gap-4 text-xs text-text/55">
+          <span>📖 {subject.unitCount} {subject.unitCount === 1 ? 'mazo' : 'mazos'}</span>
+          {subject.newCount > 0 && <span>🆕 {subject.newCount} nuevas</span>}
+          {subject.reviewCount > 0 && <span>🟡 {subject.reviewCount} en repaso</span>}
+          {subject.dueCount > 0 && <span>🔁 {subject.dueCount} pendientes</span>}
+        </div>
+      </button>
+
+      {onExport && (
+        <div className="absolute bottom-3.5 right-10 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity z-10">
+          {(['csv', 'json'] as const).map((fmt) => (
+            <button
+              key={fmt}
+              type="button"
+              title={`Exportar ${fmt.toUpperCase()}`}
+              onClick={(e) => { e.stopPropagation(); onExport(fmt); }}
+              className="flex items-center gap-1 px-2 py-0.5 rounded-lg bg-secondary/20 hover:bg-secondary/40 text-text/50 hover:text-text text-xs font-medium transition-colors"
+            >
+              <svg className="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                  d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
+              </svg>
+              {fmt.toUpperCase()}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/src/components/flashcards/UnitList.tsx
+++ b/frontend/src/components/flashcards/UnitList.tsx
@@ -1,7 +1,16 @@
 import UnitCard from './UnitCard';
 import type { UnitSummary } from '../../pages/FlashcardsPage';
 
-export default function UnitList({ units, loading, error, onUnitClick, onExport }: { units: UnitSummary[]; loading: boolean; error: string; onUnitClick?: (unit: UnitSummary) => void; onExport?: (unit: UnitSummary, format: 'csv' | 'json') => void }) {
+type Props = {
+  units: UnitSummary[];
+  loading: boolean;
+  error: string;
+  onUnitClick?: (unit: UnitSummary) => void;
+  onExport?: (unit: UnitSummary, format: 'csv' | 'json') => void;
+  onImport?: () => void;
+};
+
+export default function UnitList({ units, loading, error, onUnitClick, onExport, onImport }: Props) {
   if (loading) {
     return (
       <div className="space-y-3">
@@ -22,8 +31,17 @@ export default function UnitList({ units, loading, error, onUnitClick, onExport 
 
   if (!units.length) {
     return (
-      <div className="border border-secondary/25 rounded-2xl px-5 py-4 text-sm text-text/55">
-        No hay unidades disponibles.
+      <div className="border border-secondary/25 rounded-2xl px-5 py-8 text-center space-y-4">
+        <p className="text-sm text-text/55">No hay unidades disponibles.</p>
+        {onImport && (
+          <button
+            type="button"
+            onClick={onImport}
+            className="btn btn-primary rounded-full px-6 py-2 text-sm shadow-sm shadow-primary/15"
+          >
+            Importar flashcards
+          </button>
+        )}
       </div>
     );
   }
@@ -32,11 +50,11 @@ export default function UnitList({ units, loading, error, onUnitClick, onExport 
     <div className="space-y-3">
       {units.map((unit) => (
         <UnitCard
-            key={unit.unitId}
-            unit={unit}
-            onClick={onUnitClick ? () => onUnitClick(unit) : undefined}
-            onExport={onExport ? (fmt) => onExport(unit, fmt) : undefined}
-          />
+          key={unit.unitId}
+          unit={unit}
+          onClick={onUnitClick ? () => onUnitClick(unit) : undefined}
+          onExport={onExport ? (fmt) => onExport(unit, fmt) : undefined}
+        />
       ))}
     </div>
   );

--- a/frontend/src/pages/FlashcardsExamineUnitPage.tsx
+++ b/frontend/src/pages/FlashcardsExamineUnitPage.tsx
@@ -38,7 +38,22 @@ export default function FlashcardsExamineUnitPage() {
   const prev = () => { setIndex((i) => Math.max(0, i - 1)); setFlipped(false); };
   const next = () => { setIndex((i) => Math.min(total - 1, i + 1)); setFlipped(false); };
 
-  if (loading) return <div className="text-sm text-text/55">Cargando tarjetas...</div>;
+  if (loading) {
+    return (
+      <div className="space-y-5 max-w-2xl mx-auto animate-pulse">
+        <div className="flex items-center justify-between">
+          <div className="h-9 w-9 rounded-full bg-secondary/20" />
+          <div className="h-5 w-40 rounded-full bg-secondary/20" />
+          <div className="w-9" />
+        </div>
+        <div className="space-y-1.5">
+          <div className="h-3 w-1/3 rounded-full bg-secondary/20" />
+          <div className="h-1.5 w-full rounded-full bg-secondary/20" />
+        </div>
+        <div className="border border-secondary/15 rounded-2xl p-7 min-h-[45vh] bg-secondary/5" />
+      </div>
+    );
+  }
 
   if (error) return (
     <div className="space-y-4">
@@ -53,7 +68,20 @@ export default function FlashcardsExamineUnitPage() {
         <div className="text-4xl mb-3">📭</div>
         <p className="text-text/55 text-sm">No hay tarjetas en esta unidad.</p>
       </div>
-      <button className="btn btn-outline rounded-full px-5 py-2 text-sm" onClick={() => navigate('/flashcards')}>Volver</button>
+      <div className="flex items-center gap-3 flex-wrap">
+        <button
+          className="btn btn-outline rounded-full px-5 py-2 text-sm"
+          onClick={() => navigate('/flashcards')}
+        >
+          Volver
+        </button>
+        <button
+          className="btn btn-primary rounded-full px-5 py-2 text-sm shadow-sm shadow-primary/15"
+          onClick={() => navigate('/flashcards')}
+        >
+          Importar flashcards
+        </button>
+      </div>
     </div>
   );
 

--- a/frontend/src/pages/FlashcardsPage.tsx
+++ b/frontend/src/pages/FlashcardsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { apiAuthJson, apiBase } from '../api';
+import { apiAuthJson, apiBase, exportFlashcardsBySubject } from '../api';
 import FlashcardImportModal from '../components/flashcards/FlashcardImportModal';
 import FlashcardsTabs from '../components/flashcards/FlashcardsTabs';
 import SearchInput from '../components/flashcards/SearchInput';
@@ -33,6 +33,7 @@ export default function FlashcardsPage() {
   const [globalLoading, setGlobalLoading] = useState(true);
   const [showImport, setShowImport] = useState(false);
   const [selectedSubjectId, setSelectedSubjectId] = useState<string | null>(null);
+  const [exportError, setExportError] = useState<string>('');
 
   const token = localStorage.getItem('ak_token') || '';
 
@@ -120,12 +121,16 @@ export default function FlashcardsPage() {
   };
 
   const handleExport = async (unit: UnitSummary, format: 'csv' | 'json') => {
+    setExportError('');
     try {
       const res = await fetch(
         `${apiBase}/api/flashcards/export?unitId=${unit.unitId}&format=${format}`,
         { headers: { Authorization: `Bearer ${token}` } }
       );
-      if (!res.ok) return;
+      if (!res.ok) {
+        setExportError('No se pudo exportar. Inténtalo de nuevo.');
+        return;
+      }
       const content = await res.text();
       const blob = new Blob([content], {
         type: format === 'json' ? 'application/json' : 'text/csv',
@@ -136,7 +141,24 @@ export default function FlashcardsPage() {
       link.click();
       URL.revokeObjectURL(link.href);
     } catch {
-      // silently ignore
+      setExportError('No se pudo exportar. Inténtalo de nuevo.');
+    }
+  };
+
+  const handleSubjectExport = async (subject: SubjectSummary, format: 'csv' | 'json') => {
+    setExportError('');
+    try {
+      const content = await exportFlashcardsBySubject(token, subject.subjectId, format);
+      const blob = new Blob([content], {
+        type: format === 'json' ? 'application/json' : 'text/csv',
+      });
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = `${subject.subjectName}.${format}`;
+      link.click();
+      URL.revokeObjectURL(link.href);
+    } catch {
+      setExportError('No se pudo exportar la materia. Inténtalo de nuevo.');
     }
   };
 
@@ -149,6 +171,8 @@ export default function FlashcardsPage() {
     setSelectedSubjectId(null);
     setSearch('');
   };
+
+  const openImport = () => setShowImport(true);
 
   return (
     <div className="space-y-6">
@@ -181,7 +205,7 @@ export default function FlashcardsPage() {
           </div>
           <button
             type="button"
-            onClick={() => setShowImport(true)}
+            onClick={openImport}
             className="mt-1 flex items-center gap-1.5 px-3 py-2 rounded-xl border border-secondary/30 text-sm text-text/60 hover:border-primary/40 hover:text-text transition-colors"
           >
             <span>⬆</span> Importar
@@ -193,6 +217,24 @@ export default function FlashcardsPage() {
           if (tab === 'historial') navigate('/flashcards/history');
         }} />
       </header>
+
+      {/* Export error banner */}
+      {exportError && (
+        <div
+          role="alert"
+          className="rounded-xl border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-400 flex items-center justify-between gap-3"
+        >
+          <span>{exportError}</span>
+          <button
+            type="button"
+            onClick={() => setExportError('')}
+            className="text-red-400/70 hover:text-red-400 transition-colors text-xs shrink-0"
+            aria-label="Cerrar error"
+          >
+            ✕
+          </button>
+        </div>
+      )}
 
       {/* Global queue strip — only in study mode and subject list view */}
       {mode === 'estudio' && !selectedSubjectId && (
@@ -221,6 +263,7 @@ export default function FlashcardsPage() {
             units={filteredUnitsForSubject}
             onUnitClick={handleUnitClick}
             onExport={handleExport}
+            onImport={openImport}
           />
         ) : loading ? (
           <div className="space-y-3">
@@ -233,8 +276,15 @@ export default function FlashcardsPage() {
             {error}
           </div>
         ) : filteredSubjects.length === 0 ? (
-          <div className="border border-secondary/25 rounded-2xl px-5 py-4 text-sm text-text/55">
-            No hay materias disponibles.
+          <div className="border border-secondary/25 rounded-2xl px-5 py-8 text-center space-y-4">
+            <p className="text-sm text-text/55">No hay materias disponibles.</p>
+            <button
+              type="button"
+              onClick={openImport}
+              className="btn btn-primary rounded-full px-6 py-2 text-sm shadow-sm shadow-primary/15"
+            >
+              Importar flashcards
+            </button>
           </div>
         ) : (
           <div className="space-y-3">
@@ -243,6 +293,7 @@ export default function FlashcardsPage() {
                 key={subject.subjectId}
                 subject={subject}
                 onClick={() => handleSelectSubject(subject.subjectId)}
+                onExport={(fmt) => handleSubjectExport(subject, fmt)}
               />
             ))}
           </div>

--- a/frontend/src/pages/FlashcardsStudyPage.tsx
+++ b/frontend/src/pages/FlashcardsStudyPage.tsx
@@ -19,6 +19,7 @@ export default function FlashcardsStudyPage() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [reviewError, setReviewError] = useState<string | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [finished, setFinished] = useState(false);
@@ -64,6 +65,7 @@ export default function FlashcardsStudyPage() {
   const handleReview = async (grade: ReviewRequest['grade']) => {
     if (!currentItem || submitting) return;
     setSubmitting(true);
+    setReviewError(null);
     try {
       await apiAuthJson(`${apiBase}/api/flashcards/study/review`, token, {
         method: 'POST',
@@ -78,14 +80,23 @@ export default function FlashcardsStudyPage() {
       setItems((prev) => [...prev, next]);
       setCurrentIndex((prev) => prev + 1);
     } catch {
-      setError('No se pudo registrar la respuesta.');
+      setReviewError('No se pudo registrar la respuesta. Inténtalo de nuevo.');
     } finally {
       setSubmitting(false);
     }
   };
 
   if (loading) {
-    return <div className="text-sm text-text/55">Cargando sesión...</div>;
+    return (
+      <div className="space-y-5 max-w-2xl mx-auto animate-pulse">
+        <div className="h-9 w-9 rounded-full bg-secondary/20" />
+        <div className="space-y-1.5">
+          <div className="h-3 w-2/3 rounded-full bg-secondary/20" />
+          <div className="h-1.5 w-full rounded-full bg-secondary/20" />
+        </div>
+        <div className="border border-secondary/15 rounded-2xl p-7 min-h-[52vh] bg-secondary/5" />
+      </div>
+    );
   }
 
   if (error) {
@@ -98,6 +109,7 @@ export default function FlashcardsStudyPage() {
   }
 
   if (finished) {
+    const nothingToReview = answeredCount === 0;
     return (
       <div className="space-y-6">
         <header className="flex items-center gap-4">
@@ -108,12 +120,20 @@ export default function FlashcardsStudyPage() {
           >
             <ArrowLeft className="h-4 w-4" />
           </button>
-          <h1 className="text-2xl font-extrabold tracking-tight">Sesión completada</h1>
+          <h1 className="text-2xl font-extrabold tracking-tight">
+            {nothingToReview ? 'Sin pendientes' : 'Sesión completada'}
+          </h1>
         </header>
         <div className="border border-secondary/25 rounded-2xl p-8 text-center">
-          <div className="text-5xl mb-4">🎉</div>
-          <div className="text-xl font-bold mb-2">¡Bien hecho!</div>
-          <p className="text-text/55 text-sm mb-6">Has respondido <strong>{answeredCount}</strong> tarjetas en esta sesión.</p>
+          <div className="text-5xl mb-4">{nothingToReview ? '✅' : '🎉'}</div>
+          <div className="text-xl font-bold mb-2">
+            {nothingToReview ? 'Nada que repasar hoy' : '¡Bien hecho!'}
+          </div>
+          <p className="text-text/55 text-sm mb-6">
+            {nothingToReview
+              ? 'No había tarjetas pendientes para repasar en esta sesión.'
+              : <>Has respondido <strong>{answeredCount}</strong> tarjetas en esta sesión.</>}
+          </p>
           <button
             className="btn btn-primary rounded-full px-8 py-2.5 text-sm shadow-lg shadow-primary/20 inline-flex items-center gap-2"
             onClick={() => navigate('/flashcards')}
@@ -156,6 +176,24 @@ export default function FlashcardsStudyPage() {
           <div className="h-full bg-primary rounded-full transition-all duration-500" style={{ width: `${progressPct}%` }} />
         </div>
       </div>
+
+      {/* ── Review error banner ── */}
+      {reviewError && (
+        <div
+          role="alert"
+          className="rounded-xl border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-400 flex items-center justify-between gap-3"
+        >
+          <span>{reviewError}</span>
+          <button
+            type="button"
+            onClick={() => setReviewError(null)}
+            className="text-red-400/70 hover:text-red-400 transition-colors text-xs shrink-0"
+            aria-label="Cerrar error"
+          >
+            ✕
+          </button>
+        </div>
+      )}
 
       {/* ── Card ── */}
       <div className="relative">


### PR DESCRIPTION
## Summary

Sweeps the entire flashcards module to ensure users are never left without context. Adds CTAs to empty states, fixes silent export errors, adds subject-level deck export, replaces bare loading divs with skeletons, and decouples review errors from the study session view.

## Changes

**Backend:**
- New `exportFlashcardsBySubject` in `FlashcardImportExportUseCase` + service implementation
- `GET /api/flashcards/export` now accepts optional `subjectId` (aggregates all units); returns 400 when neither `unitId` nor `subjectId` is provided

**Frontend:**
- `SubjectCard`: export buttons on hover (CSV/JSON) via optional `onExport` prop
- `FlashcardsPage`: inline dismissible error banner when export fails; `handleSubjectExport` for subject-level download; "no subjects" empty state now has import CTA
- `UnitList`: optional `onImport` prop; "no units" empty state shows import CTA when provided
- `FlashcardsExamineUnitPage`: skeleton while loading; "no cards" empty state adds import CTA alongside "Volver"
- `FlashcardsStudyPage`: skeleton while loading; review errors shown inline (session stays alive); finished with 0 cards shows "Nada que repasar hoy"

**Style fixes:**
- Replaced 4-space with 2-space indentation in 4 Java files from PR #86
- Replaced wildcard imports with explicit imports in `FlashcardController` and `UserProfileController`

## Test plan

- [ ] Open flashcards with no subjects → "Importar flashcards" CTA appears
- [ ] Open a subject with no units → "Importar flashcards" CTA appears in unit list
- [ ] Open a unit with no cards → both "Volver" and "Importar flashcards" appear
- [ ] Export a subject deck (CSV and JSON) → single merged file downloads correctly
- [ ] Trigger an export error (disconnect network) → error banner appears and is dismissible
- [ ] Start a study session, trigger a review error → inline banner shown, session continues
- [ ] Complete a session with 0 cards → "Nada que repasar hoy" shown
- [ ] Verify loading skeletons appear on study and examine pages while loading

## Coverage

New code: **97.8%** (SonarCloud)

## Quality Gate

SonarCloud: **PASSED** ✅ — A on reliability, security, and maintainability. 1.0% duplicated lines.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)