### PR TITLE
♻️ refactor(api): centralize api routes in frontend constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ Thumbs.db
 **/.gradle/
 **/.idea/
 **/bin/
+**/.classpath
+**/.project
+**/.settings/
 
 # Coverage
 coverage/

--- a/PROCEDURE.md
+++ b/PROCEDURE.md
@@ -1,0 +1,71 @@
+# PROCEDURE.md — Akademia
+
+Procedimiento específico del repo **akdemya-mvp-auth**. Complementa al `PROCEDURE.md` global del workspace.
+
+---
+## 1) Contexto del proyecto
+
+### Jira
+- Base URL: `https://dbhlab.atlassian.net`
+- Board: `https://dbhlab.atlassian.net/jira/software/projects/AKDMIA/boards/1`
+- Proyecto: `AKDMIA`
+
+### GitHub
+- Repo: `guilu/akadem.ia`
+- Reviewer por defecto en PRs abiertas: `guilu` (cuando GitHub lo permita)
+
+### Entorno local
+- Dev compose: `/home/diegobarrioh/code/akdemya-mvp-auth/compose.yaml`
+- Pro compose: `/home/diegobarrioh/code/akdemya-mvp-auth/dist/compose.yaml`
+- Pro env: `/home/diegobarrioh/code/akdemya-mvp-auth/dist/.env`
+- Dev URL: `http://localhost:3000`
+- API local habitual: `http://localhost:8080`
+- Pro URL actual: `http://localhost:5173`
+
+---
+## 2) Reglas específicas de Akademia
+
+- Las PR abiertas deben asignarse a `guilu` como reviewer cuando sea posible.
+- El login/autenticación pública debe pensarse en torno al dominio configurado de Akademia, no a IPs privadas locales como solución final de producto.
+- El prefijo `/api` forma parte del flujo actual y debe tratarse de forma consistente en frontend, backend y proxy.
+
+---
+## 3) Flujo operativo por ticket en este repo
+
+### Preparación
+1. Crear rama desde `main`.
+2. Refinar ticket Jira antes de pasarlo a `In Progress`.
+3. Cuando la tarea esté lista para implementación, crear o enlazar la GitHub issue que servirá como prompt para Claude.
+
+### Implementación
+4. Implementar en rama de trabajo, nunca directamente en `main`.
+5. Formato de commit obligatorio en este proyecto: **gitmoji + clave Jira + conventional commit**.
+   - formato: `<gitmoji> <AKDMIA-XXX>: <tipo>: <mensaje>`
+   - ejemplo: `✨ AKDMIA-190: feat: integrate google users with internal roles`
+6. Ejecutar tests relevantes.
+7. Si toca backend/frontend de forma visible, validar el flujo manualmente en entorno dev.
+8. Si hay cambios de frontend significativos, acompañar la PR con evidencia visual cuando aporte valor.
+
+### Sync / entorno
+8. Para resincronizar rama actual y regenerar dev:
+   - `git pull --rebase origin <rama actual>`
+   - `docker compose down`
+   - `docker compose up --build -d`
+   - `docker compose ps`
+
+### PR / cierre
+9. La PR debe incluir Summary, Tests y Report.
+10. Enlazar la PR en Jira.
+11. Pasar ticket a `Reviewing` al terminar.
+12. Tras merge:
+   - cerrar ticket en Jira si procede
+   - volver a `main`
+   - `git pull`
+   - limpiar ramas locales/remotas si toca
+
+---
+## 4) Convenciones útiles del repo
+
+- Usar etiquetas de Jira y GitHub coherentes con la capa afectada (`frontend`, `backend`, `ia`, etc.).
+- Si una tarea es de investigación técnica, indicarlo claramente como **spike** en título o descripción.
+- Si una tarea afecta a IA/RAG, dejar explícito qué parte es exploración y qué parte es implementación cerrada.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ com.akdemya
 ### Seguridad
 - JWT stateless (HS256)
 - Filtro `JwtAuthFilter` valida `Authorization: Bearer <token>`
+- Autenticación con Google OAuth2 (flujo completo vía `/api/oauth2/authorization/google`)
 - Endpoints públicos:
   - `/api/auth/**`
+  - `/api/oauth2/**`
   - `/api/subjects/**`
   - `/api/units/**`
   - `/api/questions/**`
@@ -72,10 +74,12 @@ com.akdemya
 ### Auth
 - Registro y login con JWT
 - Hash de passwords con BCrypt
+- **Login con Google (OAuth2)**: los usuarios que acceden por primera vez con Google son creados automáticamente con rol STUDENT. La identidad se vincula por email, por lo que si un usuario ya tiene cuenta con contraseña puede continuar usando la misma cuenta.
 
 **Endpoints:**
 - `POST /api/auth/register` `{ email, password }` → `{ accessToken }`
 - `POST /api/auth/login` `{ email, password }` → `{ accessToken }`
+- `GET /api/oauth2/authorization/google` → redirige al flujo OAuth2 de Google
 
 ### Contenido
 - Subjects → Units → Questions → Answers
@@ -190,7 +194,7 @@ com.akdemya
 - **RAG** *(solo Admin)*: subida de PDFs, indexación y generación de preguntas IA
 
 ### Flujo principal
-1. Usuario se registra o inicia sesión → se guarda JWT en `localStorage` (`ak_token`)
+1. Usuario se registra, inicia sesión con email/contraseña o accede con Google → se guarda JWT en `localStorage` (`ak_token`)
 2. Selecciona una asignatura y configura el simulacro (unidades, dificultad, tiempo)
 3. Inicia examen → backend genera preguntas aleatorias
 4. Responde y envía resultados
@@ -263,7 +267,6 @@ com.akdemya
 - Cambiar secret JWT en producción
 - Añadir validaciones y manejo de errores más granulares
 - Añadir paginación en endpoints de contenido
-- Añadir tests y CI
 - Migrar búsqueda vectorial a **pgvector** en producción (actualmente en memoria)
 - Hacer el procesamiento de PDFs **asíncrono** para documentos grandes
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'idea'
     id 'jacoco'
-    id 'org.sonarqube' version '6.0.1.5171'
+    id 'org.sonarqube' version '7.2.3.7755'
     id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.6'
 }
@@ -71,7 +71,7 @@ jacocoTestCoverageVerification {
 sonar {
     properties {
         property "sonar.projectKey", "guilu_akadem.ia"
-        property "sonar.organization", "guilu"
+        property "sonar.organization", "dbhlab"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
     }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'java'
     id 'idea'
+    id 'jacoco'
+    id 'org.sonarqube' version '6.0.1.5171'
     id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.6'
 }
@@ -41,5 +43,37 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.85
+            }
+        }
+    }
+}
+
+sonar {
+    properties {
+        property "sonar.projectKey", "guilu_akadem.ia"
+        property "sonar.organization", "guilu"
+        property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
+    }
 }
 

--- a/backend/src/main/java/com/akdemya/adapter/inbound/web/FlashcardController.java
+++ b/backend/src/main/java/com/akdemya/adapter/inbound/web/FlashcardController.java
@@ -23,11 +23,22 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @RestController
@@ -218,11 +229,17 @@ public class FlashcardController {
 
   @GetMapping("/export")
   public ResponseEntity<String> exportFlashcards(
-      @RequestParam UUID unitId,
+      @RequestParam(required = false) UUID unitId,
+      @RequestParam(required = false) UUID subjectId,
       @RequestParam(defaultValue = "csv") String format,
       @AuthenticationPrincipal User principal) {
     requireUserId(principal);
-    String content = importExportUseCase.exportFlashcards(unitId, format);
+    if (unitId == null && subjectId == null) {
+      return ResponseEntity.badRequest().body("Se requiere unitId o subjectId");
+    }
+    String content = unitId != null
+        ? importExportUseCase.exportFlashcards(unitId, format)
+        : importExportUseCase.exportFlashcardsBySubject(subjectId, format);
     boolean isJson = "json".equalsIgnoreCase(format);
     String contentType = isJson ? "application/json; charset=UTF-8" : "text/csv; charset=UTF-8";
     String filename = isJson ? "flashcards.json" : "flashcards.csv";

--- a/backend/src/main/java/com/akdemya/adapter/inbound/web/UserProfileController.java
+++ b/backend/src/main/java/com/akdemya/adapter/inbound/web/UserProfileController.java
@@ -1,0 +1,59 @@
+package com.akdemya.adapter.inbound.web;
+
+import com.akdemya.domain.model.AppUser;
+import com.akdemya.domain.port.in.UserProfileUseCase;
+import com.akdemya.domain.port.out.UserRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/users/me")
+public class UserProfileController {
+
+    private final UserProfileUseCase userProfileUseCase;
+    private final UserRepository userRepo;
+
+    public UserProfileController(UserProfileUseCase userProfileUseCase, UserRepository userRepo) {
+        this.userProfileUseCase = userProfileUseCase;
+        this.userRepo = userRepo;
+    }
+
+    @GetMapping
+    public ResponseEntity<GetProfileResponse> getProfile(@AuthenticationPrincipal User principal) {
+        UUID userId = requireUserId(principal);
+        var result = userProfileUseCase.getProfile(userId);
+        return ResponseEntity.ok(toResponse(result));
+    }
+
+    @PatchMapping
+    public ResponseEntity<GetProfileResponse> updateProfile(@RequestBody UpdateProfileRequest req,
+                                                            @AuthenticationPrincipal User principal) {
+        UUID userId = requireUserId(principal);
+        var result = userProfileUseCase.updateProfile(userId,
+            new UserProfileUseCase.UpdateProfileCommand(req.firstName(), req.lastName()));
+        return ResponseEntity.ok(toResponse(result));
+    }
+
+    private UUID requireUserId(User principal) {
+        if (principal == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+        return userRepo.findByEmail(principal.getUsername())
+            .map(AppUser::getId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+    }
+
+    private GetProfileResponse toResponse(UserProfileUseCase.GetProfileResponse result) {
+        return new GetProfileResponse(result.id(), result.email(), result.firstName(), result.lastName());
+    }
+
+    record GetProfileResponse(UUID id, String email, String firstName, String lastName) {}
+
+    record UpdateProfileRequest(String firstName, String lastName) {}
+}

--- a/backend/src/main/java/com/akdemya/adapter/inbound/web/UserProfileController.java
+++ b/backend/src/main/java/com/akdemya/adapter/inbound/web/UserProfileController.java
@@ -7,7 +7,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.UUID;
@@ -16,44 +20,44 @@ import java.util.UUID;
 @RequestMapping("/api/v1/users/me")
 public class UserProfileController {
 
-    private final UserProfileUseCase userProfileUseCase;
-    private final UserRepository userRepo;
+  private final UserProfileUseCase userProfileUseCase;
+  private final UserRepository userRepo;
 
-    public UserProfileController(UserProfileUseCase userProfileUseCase, UserRepository userRepo) {
-        this.userProfileUseCase = userProfileUseCase;
-        this.userRepo = userRepo;
+  public UserProfileController(UserProfileUseCase userProfileUseCase, UserRepository userRepo) {
+    this.userProfileUseCase = userProfileUseCase;
+    this.userRepo = userRepo;
+  }
+
+  @GetMapping
+  public ResponseEntity<GetProfileResponse> getProfile(@AuthenticationPrincipal User principal) {
+    UUID userId = requireUserId(principal);
+    var result = userProfileUseCase.getProfile(userId);
+    return ResponseEntity.ok(toResponse(result));
+  }
+
+  @PatchMapping
+  public ResponseEntity<GetProfileResponse> updateProfile(@RequestBody UpdateProfileRequest req,
+      @AuthenticationPrincipal User principal) {
+    UUID userId = requireUserId(principal);
+    var result = userProfileUseCase.updateProfile(userId,
+        new UserProfileUseCase.UpdateProfileCommand(req.firstName(), req.lastName()));
+    return ResponseEntity.ok(toResponse(result));
+  }
+
+  private UUID requireUserId(User principal) {
+    if (principal == null) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
     }
+    return userRepo.findByEmail(principal.getUsername())
+        .map(AppUser::getId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+  }
 
-    @GetMapping
-    public ResponseEntity<GetProfileResponse> getProfile(@AuthenticationPrincipal User principal) {
-        UUID userId = requireUserId(principal);
-        var result = userProfileUseCase.getProfile(userId);
-        return ResponseEntity.ok(toResponse(result));
-    }
+  private GetProfileResponse toResponse(UserProfileUseCase.GetProfileResponse result) {
+    return new GetProfileResponse(result.id(), result.email(), result.firstName(), result.lastName());
+  }
 
-    @PatchMapping
-    public ResponseEntity<GetProfileResponse> updateProfile(@RequestBody UpdateProfileRequest req,
-                                                            @AuthenticationPrincipal User principal) {
-        UUID userId = requireUserId(principal);
-        var result = userProfileUseCase.updateProfile(userId,
-            new UserProfileUseCase.UpdateProfileCommand(req.firstName(), req.lastName()));
-        return ResponseEntity.ok(toResponse(result));
-    }
+  record GetProfileResponse(UUID id, String email, String firstName, String lastName) {}
 
-    private UUID requireUserId(User principal) {
-        if (principal == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
-        }
-        return userRepo.findByEmail(principal.getUsername())
-            .map(AppUser::getId)
-            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
-    }
-
-    private GetProfileResponse toResponse(UserProfileUseCase.GetProfileResponse result) {
-        return new GetProfileResponse(result.id(), result.email(), result.firstName(), result.lastName());
-    }
-
-    record GetProfileResponse(UUID id, String email, String firstName, String lastName) {}
-
-    record UpdateProfileRequest(String firstName, String lastName) {}
+  record UpdateProfileRequest(String firstName, String lastName) {}
 }

--- a/backend/src/main/java/com/akdemya/adapter/infrastructure/chunking/SemanticChunker.java
+++ b/backend/src/main/java/com/akdemya/adapter/infrastructure/chunking/SemanticChunker.java
@@ -2,6 +2,7 @@ package com.akdemya.adapter.infrastructure.chunking;
 
 import com.akdemya.application.config.RagProperties;
 import com.akdemya.domain.model.SourceChunk;
+import com.akdemya.domain.model.SourceDocument;
 import com.akdemya.domain.port.out.TextChunkerPort;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
@@ -58,7 +59,7 @@ public class SemanticChunker implements TextChunkerPort {
     }
 
     @Override
-    public List<SourceChunk> chunk(String text, UUID sourceDocumentId) {
+    public List<SourceChunk> chunk(String text, SourceDocument document) {
         List<Split> splits = findSemanticSplits(text);
 
         // Filter splits whose content block is too short (TOC remnants)
@@ -67,9 +68,9 @@ public class SemanticChunker implements TextChunkerPort {
         log.info("Found {} total splits, {} valid after short-content filter", splits.size(), validSplits.size());
 
         if (validSplits.size() >= MIN_SEMANTIC_SPLITS) {
-            return buildHierarchicalChunks(text, validSplits, sourceDocumentId);
+            return buildHierarchicalChunks(text, validSplits, document.getId());
         }
-        return buildSizeChunks(text, sourceDocumentId);
+        return buildSizeChunks(text, document);
     }
 
     // -------------------------------------------------------------------------
@@ -173,9 +174,13 @@ public class SemanticChunker implements TextChunkerPort {
     // Size-based fallback
     // -------------------------------------------------------------------------
 
-    private List<SourceChunk> buildSizeChunks(String text, UUID sourceDocumentId) {
-        log.info("Using size-based fallback chunking for document {}", sourceDocumentId);
-        return splitBySize(text, sourceDocumentId, 0, null, null, null);
+    private List<SourceChunk> buildSizeChunks(String text, SourceDocument document) {
+        log.info("Using size-based fallback chunking for document {}", document.getId());
+        String documentName = document.getName();
+        if (documentName != null && documentName.toLowerCase().endsWith(".pdf")) {
+            documentName = documentName.substring(0, documentName.length() - 4);
+        }
+        return splitBySize(text, document.getId(), 0, null, null, documentName);
     }
 
     private List<SourceChunk> splitBySize(String text, UUID sourceDocumentId,
@@ -207,6 +212,19 @@ public class SemanticChunker implements TextChunkerPort {
     }
 
     private int findSentenceBoundary(String text, int start, int end) {
+        // Try paragraph boundaries first (\n\n)
+        for (int i = end; i > start + 100; i--) {
+            if (text.charAt(i - 1) == '\n' && i < text.length() && text.charAt(i) == '\n') {
+                return i;
+            }
+        }
+        // Try line boundaries (\n)
+        for (int i = end; i > start + 100; i--) {
+            if (text.charAt(i - 1) == '\n') {
+                return i;
+            }
+        }
+        // Try sentence boundaries
         for (int i = end; i > start + 100; i--) {
             char c = text.charAt(i - 1);
             if ((c == '.' || c == '?' || c == '!') && i < text.length() &&

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/entity/AppUserEntity.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/entity/AppUserEntity.java
@@ -1,87 +1,91 @@
 package com.akdemya.adapter.outbound.persistence.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.util.UUID;
 
 @Entity
 @Table(name = "users")
 public class AppUserEntity {
-    @Id
-    private UUID id = UUID.randomUUID();
-    @Column(nullable = false, unique = true)
-    private String email;
-    @Column(nullable = false, name = "password_hash")
-    private String passwordHash;
-    @Column(nullable = false)
-    private String role = "STUDENT";
-    @Column(name = "first_name")
-    private String firstName;
-    @Column(name = "last_name")
-    private String lastName;
-    @Column
-    private String occupation;
 
-    public AppUserEntity() {
-    }
+  @Id
+  private UUID id = UUID.randomUUID();
+  @Column(nullable = false, unique = true)
+  private String email;
+  @Column(nullable = true, name = "password_hash")
+  private String passwordHash;
+  @Column(nullable = false)
+  private String role = "STUDENT";
+  @Column(name = "first_name")
+  private String firstName;
+  @Column(name = "last_name")
+  private String lastName;
+  @Column
+  private String occupation;
 
-    public AppUserEntity(String email, String passwordHash) {
-        this.email = email;
-        this.passwordHash = passwordHash;
-    }
+  public AppUserEntity() {
+  }
 
-    public UUID getId() {
-        return id;
-    }
+  public AppUserEntity(String email, String passwordHash) {
+    this.email = email;
+    this.passwordHash = passwordHash;
+  }
 
-    public void setId(UUID id) {
-        this.id = id;
-    }
+  public UUID getId() {
+    return id;
+  }
 
-    public String getEmail() {
-        return email;
-    }
+  public void setId(UUID id) {
+    this.id = id;
+  }
 
-    public String getPasswordHash() {
-        return passwordHash;
-    }
+  public String getEmail() {
+    return email;
+  }
 
-    public String getRole() {
-        return role;
-    }
+  public String getPasswordHash() {
+    return passwordHash;
+  }
 
-    public void setEmail(String e) {
-        this.email = e;
-    }
+  public String getRole() {
+    return role;
+  }
 
-    public void setPasswordHash(String p) {
-        this.passwordHash = p;
-    }
+  public void setEmail(String email) {
+    this.email = email;
+  }
 
-    public void setRole(String r) {
-        this.role = r;
-    }
+  public void setPasswordHash(String passwordHash) {
+    this.passwordHash = passwordHash;
+  }
 
-    public String getFirstName() {
-        return firstName;
-    }
+  public void setRole(String role) {
+    this.role = role;
+  }
 
-    public void setFirstName(String firstName) {
-        this.firstName = firstName;
-    }
+  public String getFirstName() {
+    return firstName;
+  }
 
-    public String getLastName() {
-        return lastName;
-    }
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
 
-    public void setLastName(String lastName) {
-        this.lastName = lastName;
-    }
+  public String getLastName() {
+    return lastName;
+  }
 
-    public String getOccupation() {
-        return occupation;
-    }
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
 
-    public void setOccupation(String occupation) {
-        this.occupation = occupation;
-    }
+  public String getOccupation() {
+    return occupation;
+  }
+
+  public void setOccupation(String occupation) {
+    this.occupation = occupation;
+  }
 }

--- a/backend/src/main/java/com/akdemya/application/service/FlashcardImportExportService.java
+++ b/backend/src/main/java/com/akdemya/application/service/FlashcardImportExportService.java
@@ -3,6 +3,7 @@ package com.akdemya.application.service;
 import com.akdemya.domain.model.Flashcard;
 import com.akdemya.domain.port.in.FlashcardImportExportUseCase;
 import com.akdemya.domain.port.in.FlashcardManagementUseCase;
+import com.akdemya.domain.port.out.UnitRepository;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
@@ -16,11 +17,14 @@ import java.util.UUID;
 public class FlashcardImportExportService implements FlashcardImportExportUseCase {
 
   private final FlashcardManagementUseCase managementUseCase;
+  private final UnitRepository unitRepository;
   private final ObjectMapper objectMapper;
 
   public FlashcardImportExportService(FlashcardManagementUseCase managementUseCase,
+                                      UnitRepository unitRepository,
                                       ObjectMapper objectMapper) {
     this.managementUseCase = managementUseCase;
+    this.unitRepository = unitRepository;
     this.objectMapper = objectMapper;
   }
 
@@ -74,6 +78,30 @@ public class FlashcardImportExportService implements FlashcardImportExportUseCas
   @Override
   public String exportFlashcards(UUID unitId, String format) {
     List<Flashcard> flashcards = managementUseCase.listByUnit(unitId);
+
+    if ("json".equalsIgnoreCase(format)) {
+      List<Map<String, String>> list = flashcards.stream()
+          .map(f -> Map.of("front", f.getFront(), "back", f.getBack()))
+          .toList();
+      try {
+        return objectMapper.writeValueAsString(list);
+      } catch (Exception e) {
+        throw new RuntimeException("Error al generar JSON", e);
+      }
+    }
+
+    StringBuilder sb = new StringBuilder("front,back\n");
+    for (Flashcard f : flashcards) {
+      sb.append(csvEscape(f.getFront())).append(',').append(csvEscape(f.getBack())).append('\n');
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public String exportFlashcardsBySubject(UUID subjectId, String format) {
+    List<Flashcard> flashcards = unitRepository.findBySubjectId(subjectId).stream()
+        .flatMap(unit -> managementUseCase.listByUnit(unit.getId()).stream())
+        .toList();
 
     if ("json".equalsIgnoreCase(format)) {
       List<Map<String, String>> list = flashcards.stream()

--- a/backend/src/main/java/com/akdemya/application/service/IndexDocumentService.java
+++ b/backend/src/main/java/com/akdemya/application/service/IndexDocumentService.java
@@ -80,7 +80,7 @@ public class IndexDocumentService implements IndexSourceUseCase {
             String rawText = extractor.extract(is, command.contentType());
             log.info("Extracted {} chars from document id={}", rawText.length(), doc.getId());
 
-            chunks = chunker.chunk(rawText, doc.getId());
+            chunks = chunker.chunk(rawText, doc);
             log.info("Created {} chunks for document id={}", chunks.size(), doc.getId());
 
             for (SourceChunk chunk : chunks) {

--- a/backend/src/main/java/com/akdemya/application/service/UserProfileService.java
+++ b/backend/src/main/java/com/akdemya/application/service/UserProfileService.java
@@ -13,54 +13,54 @@ import java.util.UUID;
 @Transactional
 public class UserProfileService implements UserProfileUseCase {
 
-    private final UserRepository userRepository;
+  private final UserRepository userRepository;
 
-    public UserProfileService(UserRepository userRepository) {
-        this.userRepository = userRepository;
+  public UserProfileService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public GetProfileResponse getProfile(UUID userId) {
+    AppUser user = userRepository.findById(userId)
+        .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
+    return toResponse(user);
+  }
+
+  @Override
+  public GetProfileResponse updateProfile(UUID userId, UpdateProfileCommand command) {
+    AppUser user = userRepository.findById(userId)
+        .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
+
+    validateName(command.firstName(), "firstName");
+    validateName(command.lastName(), "lastName");
+
+    AppUser updated = new AppUser(
+        user.getId(),
+        user.getEmail(),
+        user.getPasswordHash(),
+        user.getRole(),
+        command.firstName(),
+        command.lastName(),
+        user.getOccupation()
+    );
+
+    AppUser saved = userRepository.save(updated);
+    return toResponse(saved);
+  }
+
+  private void validateName(String value, String field) {
+    if (value != null && value.length() > 100) {
+      throw new IllegalArgumentException(field + "_too_long");
     }
+  }
 
-    @Override
-    @Transactional(readOnly = true)
-    public GetProfileResponse getProfile(UUID userId) {
-        AppUser user = userRepository.findById(userId)
-            .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
-        return toResponse(user);
-    }
-
-    @Override
-    public GetProfileResponse updateProfile(UUID userId, UpdateProfileCommand command) {
-        AppUser user = userRepository.findById(userId)
-            .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
-
-        validateName(command.firstName(), "firstName");
-        validateName(command.lastName(), "lastName");
-
-        AppUser updated = new AppUser(
-            user.getId(),
-            user.getEmail(),
-            user.getPasswordHash(),
-            user.getRole(),
-            command.firstName(),
-            command.lastName(),
-            user.getOccupation()
-        );
-
-        AppUser saved = userRepository.save(updated);
-        return toResponse(saved);
-    }
-
-    private void validateName(String value, String field) {
-        if (value != null && value.length() > 100) {
-            throw new IllegalArgumentException(field + "_too_long");
-        }
-    }
-
-    private GetProfileResponse toResponse(AppUser user) {
-        return new GetProfileResponse(
-            user.getId(),
-            user.getEmail(),
-            user.getFirstName(),
-            user.getLastName()
-        );
-    }
+  private GetProfileResponse toResponse(AppUser user) {
+    return new GetProfileResponse(
+        user.getId(),
+        user.getEmail(),
+        user.getFirstName(),
+        user.getLastName()
+    );
+  }
 }

--- a/backend/src/main/java/com/akdemya/application/service/UserProfileService.java
+++ b/backend/src/main/java/com/akdemya/application/service/UserProfileService.java
@@ -1,0 +1,66 @@
+package com.akdemya.application.service;
+
+import com.akdemya.domain.model.AppUser;
+import com.akdemya.domain.port.in.UserProfileUseCase;
+import com.akdemya.domain.port.out.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+@Transactional
+public class UserProfileService implements UserProfileUseCase {
+
+    private final UserRepository userRepository;
+
+    public UserProfileService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public GetProfileResponse getProfile(UUID userId) {
+        AppUser user = userRepository.findById(userId)
+            .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
+        return toResponse(user);
+    }
+
+    @Override
+    public GetProfileResponse updateProfile(UUID userId, UpdateProfileCommand command) {
+        AppUser user = userRepository.findById(userId)
+            .orElseThrow(() -> new NoSuchElementException("User not found: " + userId));
+
+        validateName(command.firstName(), "firstName");
+        validateName(command.lastName(), "lastName");
+
+        AppUser updated = new AppUser(
+            user.getId(),
+            user.getEmail(),
+            user.getPasswordHash(),
+            user.getRole(),
+            command.firstName(),
+            command.lastName(),
+            user.getOccupation()
+        );
+
+        AppUser saved = userRepository.save(updated);
+        return toResponse(saved);
+    }
+
+    private void validateName(String value, String field) {
+        if (value != null && value.length() > 100) {
+            throw new IllegalArgumentException(field + "_too_long");
+        }
+    }
+
+    private GetProfileResponse toResponse(AppUser user) {
+        return new GetProfileResponse(
+            user.getId(),
+            user.getEmail(),
+            user.getFirstName(),
+            user.getLastName()
+        );
+    }
+}

--- a/backend/src/main/java/com/akdemya/domain/port/in/FlashcardImportExportUseCase.java
+++ b/backend/src/main/java/com/akdemya/domain/port/in/FlashcardImportExportUseCase.java
@@ -9,5 +9,7 @@ public interface FlashcardImportExportUseCase {
 
   String exportFlashcards(UUID unitId, String format);
 
+  String exportFlashcardsBySubject(UUID subjectId, String format);
+
   record ImportResult(int imported, int skipped, List<String> errors) {}
 }

--- a/backend/src/main/java/com/akdemya/domain/port/in/UserProfileUseCase.java
+++ b/backend/src/main/java/com/akdemya/domain/port/in/UserProfileUseCase.java
@@ -1,0 +1,14 @@
+package com.akdemya.domain.port.in;
+
+import java.util.UUID;
+
+public interface UserProfileUseCase {
+
+    GetProfileResponse getProfile(UUID userId);
+
+    GetProfileResponse updateProfile(UUID userId, UpdateProfileCommand command);
+
+    record GetProfileResponse(UUID id, String email, String firstName, String lastName) {}
+
+    record UpdateProfileCommand(String firstName, String lastName) {}
+}

--- a/backend/src/main/java/com/akdemya/domain/port/out/TextChunkerPort.java
+++ b/backend/src/main/java/com/akdemya/domain/port/out/TextChunkerPort.java
@@ -1,9 +1,9 @@
 package com.akdemya.domain.port.out;
 
 import com.akdemya.domain.model.SourceChunk;
+import com.akdemya.domain.model.SourceDocument;
 
 import java.util.List;
-import java.util.UUID;
 
 /**
  * Splits raw document text into semantic chunks with metadata.
@@ -11,5 +11,5 @@ import java.util.UUID;
  * fall back to size-based chunking with overlap when no structure is found.
  */
 public interface TextChunkerPort {
-    List<SourceChunk> chunk(String text, UUID sourceDocumentId);
+    List<SourceChunk> chunk(String text, SourceDocument document);
 }

--- a/backend/src/test/java/com/akdemya/adapter/inbound/web/FlashcardControllerTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/inbound/web/FlashcardControllerTest.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -152,6 +153,72 @@ class FlashcardControllerTest {
     verify(reviewLogRepo).findRecentByUserId(userId, 20);
   }
 
+  // --- export endpoint ---
+
+  @Test
+  void exportBySubjectIdCsvReturnsContent() {
+    UUID userId = UUID.randomUUID();
+    UUID subjectId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+    when(importExportUseCase.exportFlashcardsBySubject(subjectId, "csv"))
+        .thenReturn("front,back\nHello,Hola\n");
+
+    ResponseEntity<String> response = controller.exportFlashcards(null, subjectId, "csv", principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    org.junit.jupiter.api.Assertions.assertTrue(response.getBody().contains("Hello,Hola"));
+    verify(importExportUseCase).exportFlashcardsBySubject(subjectId, "csv");
+  }
+
+  @Test
+  void exportBySubjectIdJsonReturnsContent() {
+    UUID userId = UUID.randomUUID();
+    UUID subjectId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+    when(importExportUseCase.exportFlashcardsBySubject(subjectId, "json"))
+        .thenReturn("[{\"front\":\"Hello\",\"back\":\"Hola\"}]");
+
+    ResponseEntity<String> response = controller.exportFlashcards(null, subjectId, "json", principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    org.junit.jupiter.api.Assertions.assertTrue(response.getBody().contains("Hello"));
+    verify(importExportUseCase).exportFlashcardsBySubject(subjectId, "json");
+  }
+
+  @Test
+  void exportWithNeitherParamReturns400() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    ResponseEntity<String> response = controller.exportFlashcards(null, null, "csv", principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  @Test
+  void exportByUnitIdStillWorksWhenUnitIdProvided() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+    when(importExportUseCase.exportFlashcards(unitId, "csv"))
+        .thenReturn("front,back\nQ,A\n");
+
+    ResponseEntity<String> response = controller.exportFlashcards(unitId, null, "csv", principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    verify(importExportUseCase).exportFlashcards(unitId, "csv");
+  }
+
   @Test
   void createWithoutAuthReturns401() {
     var req = new FlashcardDto.CreateRequest(UUID.randomUUID(), "front", "back");
@@ -167,5 +234,348 @@ class FlashcardControllerTest {
   @Test
   void deleteWithoutAuthReturns401() {
     assertThrows(ResponseStatusException.class, () -> controller.delete(UUID.randomUUID(), null));
+  }
+
+  // --- create ---
+
+  @Test
+  void createReturnsSavedFlashcard() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    UUID flashcardId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    Flashcard saved = new Flashcard(flashcardId, unitId, "front", "back",
+        LocalDateTime.now(), LocalDateTime.now());
+    when(managementUseCase.createFlashcard(any())).thenReturn(saved);
+
+    var req = new FlashcardDto.CreateRequest(unitId, "front", "back");
+    ResponseEntity<FlashcardDto.FlashcardResponse> response = controller.create(req, principal);
+
+    assertEquals(201, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertEquals(flashcardId, response.getBody().id());
+  }
+
+  @Test
+  void createWithNullUnitIdReturns400() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    var req = new FlashcardDto.CreateRequest(null, "front", "back");
+    ResponseEntity<FlashcardDto.FlashcardResponse> response = controller.create(req, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  @Test
+  void createWithIllegalArgumentReturns400() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+    when(managementUseCase.createFlashcard(any())).thenThrow(new IllegalArgumentException("invalid"));
+
+    var req = new FlashcardDto.CreateRequest(UUID.randomUUID(), "front", "back");
+    ResponseEntity<FlashcardDto.FlashcardResponse> response = controller.create(req, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  // --- update ---
+
+  @Test
+  void updateReturnsUpdatedFlashcard() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    UUID flashcardId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    Flashcard updated = new Flashcard(flashcardId, unitId, "front2", "back2",
+        LocalDateTime.now(), LocalDateTime.now());
+    when(managementUseCase.updateFlashcard(any())).thenReturn(updated);
+
+    var req = new FlashcardDto.UpdateRequest(unitId, "front2", "back2");
+    ResponseEntity<FlashcardDto.FlashcardResponse> response = controller.update(flashcardId, req, principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertEquals(flashcardId, response.getBody().id());
+  }
+
+  @Test
+  void updateWithNullRequestReturns400() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    ResponseEntity<FlashcardDto.FlashcardResponse> response = controller.update(UUID.randomUUID(), null, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  @Test
+  void updateNotFoundReturns404() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+    when(managementUseCase.updateFlashcard(any())).thenThrow(new java.util.NoSuchElementException());
+
+    var req = new FlashcardDto.UpdateRequest(UUID.randomUUID(), "front", "back");
+    ResponseEntity<FlashcardDto.FlashcardResponse> response = controller.update(UUID.randomUUID(), req, principal);
+
+    assertEquals(404, response.getStatusCodeValue());
+  }
+
+  @Test
+  void updateWithIllegalArgumentReturns400() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+    when(managementUseCase.updateFlashcard(any())).thenThrow(new IllegalArgumentException("invalid"));
+
+    var req = new FlashcardDto.UpdateRequest(UUID.randomUUID(), "front", "back");
+    ResponseEntity<FlashcardDto.FlashcardResponse> response = controller.update(UUID.randomUUID(), req, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  // --- delete ---
+
+  @Test
+  void deleteReturns204() {
+    UUID userId = UUID.randomUUID();
+    UUID flashcardId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+    doNothing().when(managementUseCase).deleteFlashcard(flashcardId);
+
+    ResponseEntity<Void> response = controller.delete(flashcardId, principal);
+
+    assertEquals(204, response.getStatusCodeValue());
+    verify(managementUseCase).deleteFlashcard(flashcardId);
+  }
+
+  // --- listByUnit ---
+
+  @Test
+  void listByUnitReturnsFlashcards() {
+    UUID unitId = UUID.randomUUID();
+    Flashcard card = new Flashcard(UUID.randomUUID(), unitId, "front", "back",
+        LocalDateTime.now(), LocalDateTime.now());
+    when(managementUseCase.listByUnit(unitId)).thenReturn(List.of(card));
+
+    List<FlashcardDto.FlashcardResponse> response = controller.listByUnit(unitId);
+
+    assertEquals(1, response.size());
+    assertEquals("front", response.get(0).front());
+  }
+
+  // --- getStudyNext ---
+
+  @Test
+  void studyNextReturnsFlashcard() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    UUID flashcardId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    when(studyUseCase.getStudyNext(any()))
+        .thenReturn(new FlashcardStudyUseCase.StudyNextResponse(
+            flashcardId, unitId, "front", "back", ReviewState.NEW, null,
+            new FlashcardStudyUseCase.IntervalHints("1m", "10m", "4d")));
+
+    ResponseEntity<FlashcardDto.StudyNextResponse> response = controller.getStudyNext(unitId, principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertEquals(flashcardId, response.getBody().flashcardId());
+    assertNotNull(response.getBody().intervalHints());
+  }
+
+  @Test
+  void studyNextReturns204WhenNoCards() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+    when(studyUseCase.getStudyNext(any())).thenReturn(null);
+
+    ResponseEntity<FlashcardDto.StudyNextResponse> response = controller.getStudyNext(unitId, principal);
+
+    assertEquals(204, response.getStatusCodeValue());
+  }
+
+  @Test
+  void studyNextWithNullIntervalHintsStillReturns200() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    UUID flashcardId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    when(studyUseCase.getStudyNext(any()))
+        .thenReturn(new FlashcardStudyUseCase.StudyNextResponse(
+            flashcardId, unitId, "front", "back", ReviewState.NEW, null, null));
+
+    ResponseEntity<FlashcardDto.StudyNextResponse> response = controller.getStudyNext(unitId, principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertNull(response.getBody().intervalHints());
+  }
+
+  // --- getDashboard ---
+
+  @Test
+  void dashboardReturnsAggregatedData() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    when(studyUseCase.getDashboard(any()))
+        .thenReturn(new FlashcardStudyUseCase.DashboardResponse(3, 2, 1, 0, 5, 6));
+
+    ResponseEntity<FlashcardDto.DashboardResponse> response = controller.getDashboard(unitId, principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertEquals(3, response.getBody().dueToday());
+    assertEquals(5, response.getBody().newCards());
+  }
+
+  // --- importFlashcards ---
+
+  @Test
+  void importFlashcardsReturnsImportResult() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    when(importExportUseCase.importFlashcards(unitId, "csv", "front,back\nHello,Hola\n"))
+        .thenReturn(new com.akdemya.domain.port.in.FlashcardImportExportUseCase.ImportResult(1, 0, List.of()));
+
+    ResponseEntity<FlashcardDto.ImportResult> response =
+        controller.importFlashcards(unitId, "csv", "front,back\nHello,Hola\n", principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertEquals(1, response.getBody().imported());
+    assertEquals(0, response.getBody().skipped());
+  }
+
+  // --- studyQueue edge cases ---
+
+  @Test
+  void studyQueueReturns400WhenLimitIsNegative() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    ResponseEntity<FlashcardDto.StudyQueueResponse> response =
+        controller.getStudyQueue(unitId, -1, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  @Test
+  void studyQueueReturns400WhenLimitExceedsMax() {
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    ResponseEntity<FlashcardDto.StudyQueueResponse> response =
+        controller.getStudyQueue(unitId, 101, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  // --- history edge cases ---
+
+  @Test
+  void historyReturns400WhenLimitIsNegative() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    ResponseEntity<List<FlashcardDto.HistoryItem>> response = controller.getHistory(-1, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  @Test
+  void historyWithNullFlashcardInMapReturnsNullFrontAndBack() {
+    UUID userId = UUID.randomUUID();
+    UUID flashcardId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", null, null, null)));
+
+    FlashcardReviewLog log = FlashcardReviewLog.create(userId, flashcardId, ReviewGrade.GOOD,
+        LocalDateTime.now(), 1, 3, 2.5, 2.6);
+    when(reviewLogRepo.findRecentByUserId(eq(userId), eq(20))).thenReturn(List.of(log));
+    when(flashcardRepo.findByIds(any())).thenReturn(List.of()); // no matching flashcard
+
+    ResponseEntity<List<FlashcardDto.HistoryItem>> response = controller.getHistory(null, principal);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertEquals(1, response.getBody().size());
+    assertNull(response.getBody().get(0).front());
+    assertNull(response.getBody().get(0).back());
+  }
+
+  // --- reviewRequest edge cases ---
+
+  @Test
+  void registerReviewWithNullRequestReturns400() {
+    var principal = new User("user@example.com", "", List.of());
+
+    ResponseEntity<FlashcardDto.ReviewResponse> response = controller.registerReview(null, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  @Test
+  void registerReviewWithNullFlashcardIdReturns400() {
+    var principal = new User("user@example.com", "", List.of());
+
+    var req = new FlashcardDto.ReviewRequest(null, ReviewGrade.GOOD, LocalDateTime.now());
+    ResponseEntity<FlashcardDto.ReviewResponse> response = controller.registerReview(req, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
+  }
+
+  @Test
+  void registerReviewWithNullGradeReturns400() {
+    var principal = new User("user@example.com", "", List.of());
+
+    var req = new FlashcardDto.ReviewRequest(UUID.randomUUID(), null, LocalDateTime.now());
+    ResponseEntity<FlashcardDto.ReviewResponse> response = controller.registerReview(req, principal);
+
+    assertEquals(400, response.getStatusCodeValue());
   }
 }

--- a/backend/src/test/java/com/akdemya/adapter/inbound/web/UserProfileControllerTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/inbound/web/UserProfileControllerTest.java
@@ -12,69 +12,73 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class UserProfileControllerTest {
 
-    private final UserProfileUseCase userProfileUseCase = mock(UserProfileUseCase.class);
-    private final UserRepository userRepo = mock(UserRepository.class);
+  private final UserProfileUseCase userProfileUseCase = mock(UserProfileUseCase.class);
+  private final UserRepository userRepo = mock(UserRepository.class);
 
-    private final UserProfileController controller =
-        new UserProfileController(userProfileUseCase, userRepo);
+  private final UserProfileController controller =
+      new UserProfileController(userProfileUseCase, userRepo);
 
-    @Test
-    void getProfile_authenticated_returns200WithProfile() {
-        UUID userId = UUID.randomUUID();
-        var principal = new User("user@example.com", "", List.of());
-        when(userRepo.findByEmail("user@example.com"))
-            .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", "John", "Doe", null)));
-        when(userProfileUseCase.getProfile(userId))
-            .thenReturn(new UserProfileUseCase.GetProfileResponse(userId, "user@example.com", "John", "Doe"));
+  @Test
+  void getProfile_authenticated_returns200WithProfile() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", "John", "Doe", null)));
+    when(userProfileUseCase.getProfile(userId))
+        .thenReturn(new UserProfileUseCase.GetProfileResponse(userId, "user@example.com", "John", "Doe"));
 
-        ResponseEntity<UserProfileController.GetProfileResponse> response = controller.getProfile(principal);
+    ResponseEntity<UserProfileController.GetProfileResponse> response = controller.getProfile(principal);
 
-        assertEquals(200, response.getStatusCodeValue());
-        assertNotNull(response.getBody());
-        assertEquals("John", response.getBody().firstName());
-        assertEquals("Doe", response.getBody().lastName());
-        assertEquals("user@example.com", response.getBody().email());
-    }
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertEquals("John", response.getBody().firstName());
+    assertEquals("Doe", response.getBody().lastName());
+    assertEquals("user@example.com", response.getBody().email());
+  }
 
-    @Test
-    void getProfile_unauthenticated_throws401() {
-        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-            () -> controller.getProfile(null));
-        assertEquals(401, ex.getStatusCode().value());
-    }
+  @Test
+  void getProfile_unauthenticated_throws401() {
+    ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+        () -> controller.getProfile(null));
+    assertEquals(401, ex.getStatusCode().value());
+  }
 
-    @Test
-    void updateProfile_validBody_returns200WithUpdatedProfile() {
-        UUID userId = UUID.randomUUID();
-        var principal = new User("user@example.com", "", List.of());
-        when(userRepo.findByEmail("user@example.com"))
-            .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", "Old", "Name", null)));
-        when(userProfileUseCase.updateProfile(eq(userId), any()))
-            .thenReturn(new UserProfileUseCase.GetProfileResponse(userId, "user@example.com", "Jane", "Smith"));
+  @Test
+  void updateProfile_validBody_returns200WithUpdatedProfile() {
+    UUID userId = UUID.randomUUID();
+    var principal = new User("user@example.com", "", List.of());
+    when(userRepo.findByEmail("user@example.com"))
+        .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", "Old", "Name", null)));
+    when(userProfileUseCase.updateProfile(eq(userId), any()))
+        .thenReturn(new UserProfileUseCase.GetProfileResponse(userId, "user@example.com", "Jane", "Smith"));
 
-        var req = new UserProfileController.UpdateProfileRequest("Jane", "Smith");
-        ResponseEntity<UserProfileController.GetProfileResponse> response = controller.updateProfile(req, principal);
+    var req = new UserProfileController.UpdateProfileRequest("Jane", "Smith");
+    ResponseEntity<UserProfileController.GetProfileResponse> response = controller.updateProfile(req, principal);
 
-        assertEquals(200, response.getStatusCodeValue());
-        assertNotNull(response.getBody());
-        assertEquals("Jane", response.getBody().firstName());
-        assertEquals("Smith", response.getBody().lastName());
-        verify(userProfileUseCase).updateProfile(eq(userId),
-            eq(new UserProfileUseCase.UpdateProfileCommand("Jane", "Smith")));
-    }
+    assertEquals(200, response.getStatusCodeValue());
+    assertNotNull(response.getBody());
+    assertEquals("Jane", response.getBody().firstName());
+    assertEquals("Smith", response.getBody().lastName());
+    verify(userProfileUseCase).updateProfile(eq(userId),
+        eq(new UserProfileUseCase.UpdateProfileCommand("Jane", "Smith")));
+  }
 
-    @Test
-    void updateProfile_unauthenticated_throws401() {
-        var req = new UserProfileController.UpdateProfileRequest("Jane", "Smith");
-        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-            () -> controller.updateProfile(req, null));
-        assertEquals(401, ex.getStatusCode().value());
-    }
+  @Test
+  void updateProfile_unauthenticated_throws401() {
+    var req = new UserProfileController.UpdateProfileRequest("Jane", "Smith");
+    ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+        () -> controller.updateProfile(req, null));
+    assertEquals(401, ex.getStatusCode().value());
+  }
 }

--- a/backend/src/test/java/com/akdemya/adapter/inbound/web/UserProfileControllerTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/inbound/web/UserProfileControllerTest.java
@@ -1,0 +1,80 @@
+package com.akdemya.adapter.inbound.web;
+
+import com.akdemya.domain.model.AppUser;
+import com.akdemya.domain.port.in.UserProfileUseCase;
+import com.akdemya.domain.port.out.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class UserProfileControllerTest {
+
+    private final UserProfileUseCase userProfileUseCase = mock(UserProfileUseCase.class);
+    private final UserRepository userRepo = mock(UserRepository.class);
+
+    private final UserProfileController controller =
+        new UserProfileController(userProfileUseCase, userRepo);
+
+    @Test
+    void getProfile_authenticated_returns200WithProfile() {
+        UUID userId = UUID.randomUUID();
+        var principal = new User("user@example.com", "", List.of());
+        when(userRepo.findByEmail("user@example.com"))
+            .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", "John", "Doe", null)));
+        when(userProfileUseCase.getProfile(userId))
+            .thenReturn(new UserProfileUseCase.GetProfileResponse(userId, "user@example.com", "John", "Doe"));
+
+        ResponseEntity<UserProfileController.GetProfileResponse> response = controller.getProfile(principal);
+
+        assertEquals(200, response.getStatusCodeValue());
+        assertNotNull(response.getBody());
+        assertEquals("John", response.getBody().firstName());
+        assertEquals("Doe", response.getBody().lastName());
+        assertEquals("user@example.com", response.getBody().email());
+    }
+
+    @Test
+    void getProfile_unauthenticated_throws401() {
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+            () -> controller.getProfile(null));
+        assertEquals(401, ex.getStatusCode().value());
+    }
+
+    @Test
+    void updateProfile_validBody_returns200WithUpdatedProfile() {
+        UUID userId = UUID.randomUUID();
+        var principal = new User("user@example.com", "", List.of());
+        when(userRepo.findByEmail("user@example.com"))
+            .thenReturn(Optional.of(new AppUser(userId, "user@example.com", "", "USER", "Old", "Name", null)));
+        when(userProfileUseCase.updateProfile(eq(userId), any()))
+            .thenReturn(new UserProfileUseCase.GetProfileResponse(userId, "user@example.com", "Jane", "Smith"));
+
+        var req = new UserProfileController.UpdateProfileRequest("Jane", "Smith");
+        ResponseEntity<UserProfileController.GetProfileResponse> response = controller.updateProfile(req, principal);
+
+        assertEquals(200, response.getStatusCodeValue());
+        assertNotNull(response.getBody());
+        assertEquals("Jane", response.getBody().firstName());
+        assertEquals("Smith", response.getBody().lastName());
+        verify(userProfileUseCase).updateProfile(eq(userId),
+            eq(new UserProfileUseCase.UpdateProfileCommand("Jane", "Smith")));
+    }
+
+    @Test
+    void updateProfile_unauthenticated_throws401() {
+        var req = new UserProfileController.UpdateProfileRequest("Jane", "Smith");
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+            () -> controller.updateProfile(req, null));
+        assertEquals(401, ex.getStatusCode().value());
+    }
+}

--- a/backend/src/test/java/com/akdemya/adapter/infrastructure/chunking/SemanticChunkerTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/infrastructure/chunking/SemanticChunkerTest.java
@@ -2,9 +2,11 @@ package com.akdemya.adapter.infrastructure.chunking;
 
 import com.akdemya.application.config.RagProperties;
 import com.akdemya.domain.model.SourceChunk;
+import com.akdemya.domain.model.SourceDocument;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -14,6 +16,7 @@ class SemanticChunkerTest {
 
     private SemanticChunker chunker;
     private final UUID docId = UUID.randomUUID();
+    private SourceDocument doc;
 
     @BeforeEach
     void setUp() {
@@ -21,6 +24,7 @@ class SemanticChunkerTest {
         props.setChunkSize(500);
         props.setChunkOverlap(100);
         chunker = new SemanticChunker(props);
+        doc = new SourceDocument(docId, UUID.randomUUID(), "TestDoc.pdf", "PDF", "1", "hash", LocalDateTime.now(), SourceDocument.Status.PROCESSED, "path");
     }
 
     @Test
@@ -38,7 +42,7 @@ class SemanticChunkerTest {
                 Todos los españoles tienen el deber de conocerla y el derecho a usarla.
                 """;
 
-        List<SourceChunk> chunks = chunker.chunk(text, docId);
+        List<SourceChunk> chunks = chunker.chunk(text, doc);
 
         assertTrue(chunks.size() >= 3, "Should produce at least 3 chunks for 3 articles");
         assertTrue(chunks.stream().anyMatch(c -> c.getContent().contains("Artículo 1")));
@@ -49,7 +53,7 @@ class SemanticChunkerTest {
     @Test
     void fallbackToSizeChunkingWhenNoStructure() {
         String text = "a".repeat(2000);
-        List<SourceChunk> chunks = chunker.chunk(text, docId);
+        List<SourceChunk> chunks = chunker.chunk(text, doc);
         assertTrue(chunks.size() >= 2, "Should produce multiple size-based chunks");
         for (SourceChunk c : chunks) {
             assertFalse(c.getContent().isBlank());
@@ -63,7 +67,7 @@ class SemanticChunkerTest {
                 Artículo 2. Dos.
                 Artículo 3. Tres.
                 """;
-        List<SourceChunk> chunks = chunker.chunk(text, docId);
+        List<SourceChunk> chunks = chunker.chunk(text, doc);
         for (SourceChunk c : chunks) {
             assertEquals(docId, c.getSourceDocumentId());
         }
@@ -76,7 +80,7 @@ class SemanticChunkerTest {
                 Artículo 2. Dos.
                 Artículo 3. Tres.
                 """;
-        List<SourceChunk> chunks = chunker.chunk(text, docId);
+        List<SourceChunk> chunks = chunker.chunk(text, doc);
         for (int i = 0; i < chunks.size(); i++) {
             assertEquals(i, chunks.get(i).getChunkIndex());
         }
@@ -89,7 +93,7 @@ class SemanticChunkerTest {
                 Artículo 11. Contenido del artículo once.
                 Artículo 12. Contenido del artículo doce.
                 """;
-        List<SourceChunk> chunks = chunker.chunk(text, docId);
+        List<SourceChunk> chunks = chunker.chunk(text, doc);
         for (SourceChunk c : chunks) {
             assertNotNull(c.getMetadata());
             assertTrue(c.getMetadata().contains(docId.toString()));
@@ -98,14 +102,14 @@ class SemanticChunkerTest {
 
     @Test
     void emptyTextProducesNoChunks() {
-        List<SourceChunk> chunks = chunker.chunk("", docId);
+        List<SourceChunk> chunks = chunker.chunk("", doc);
         assertTrue(chunks.isEmpty());
     }
 
     @Test
     void shortTextProducesOneChunk() {
         String text = "Texto corto sin artículos.";
-        List<SourceChunk> chunks = chunker.chunk(text, docId);
+        List<SourceChunk> chunks = chunker.chunk(text, doc);
         assertEquals(1, chunks.size());
         assertEquals(text, chunks.get(0).getContent());
     }

--- a/backend/src/test/java/com/akdemya/adapter/outbound/persistence/entity/AppUserEntityTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/outbound/persistence/entity/AppUserEntityTest.java
@@ -1,0 +1,66 @@
+package com.akdemya.adapter.outbound.persistence.entity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class AppUserEntityTest {
+
+  @Test
+  void defaultConstructor_assignsRandomId() {
+    AppUserEntity entity = new AppUserEntity();
+
+    assertNotNull(entity.getId());
+  }
+
+  @Test
+  void emailPasswordConstructor_setsEmailAndPasswordHash() {
+    AppUserEntity entity = new AppUserEntity("user@example.com", "hashed_password");
+
+    assertEquals("user@example.com", entity.getEmail());
+    assertEquals("hashed_password", entity.getPasswordHash());
+  }
+
+  @Test
+  void defaultRole_isStudent() {
+    AppUserEntity entity = new AppUserEntity();
+
+    assertEquals("STUDENT", entity.getRole());
+  }
+
+  @Test
+  void setters_updateAllFields() {
+    AppUserEntity entity = new AppUserEntity();
+    UUID id = UUID.randomUUID();
+
+    entity.setId(id);
+    entity.setEmail("test@example.com");
+    entity.setPasswordHash("new_hash");
+    entity.setRole("ADMIN");
+    entity.setFirstName("John");
+    entity.setLastName("Doe");
+    entity.setOccupation("Developer");
+
+    assertEquals(id, entity.getId());
+    assertEquals("test@example.com", entity.getEmail());
+    assertEquals("new_hash", entity.getPasswordHash());
+    assertEquals("ADMIN", entity.getRole());
+    assertEquals("John", entity.getFirstName());
+    assertEquals("Doe", entity.getLastName());
+    assertEquals("Developer", entity.getOccupation());
+  }
+
+  @Test
+  void optionalFields_areNullByDefault() {
+    AppUserEntity entity = new AppUserEntity();
+
+    assertNull(entity.getFirstName());
+    assertNull(entity.getLastName());
+    assertNull(entity.getOccupation());
+    assertNull(entity.getPasswordHash());
+  }
+}

--- a/backend/src/test/java/com/akdemya/application/service/AuthManagerTest.java
+++ b/backend/src/test/java/com/akdemya/application/service/AuthManagerTest.java
@@ -1,0 +1,320 @@
+package com.akdemya.application.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.akdemya.domain.model.AppUser;
+import com.akdemya.domain.port.in.AuthUseCase.AuthResponse;
+import com.akdemya.domain.port.in.AuthUseCase.LoginCommand;
+import com.akdemya.domain.port.in.AuthUseCase.RegisterCommand;
+import com.akdemya.domain.port.out.PasswordHasher;
+import com.akdemya.domain.port.out.TokenProvider;
+import com.akdemya.domain.port.out.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+class AuthManagerTest {
+
+  private InMemoryUserRepository userRepo;
+  private FakePasswordHasher passwordHasher;
+  private FakeTokenProvider tokenProvider;
+  private AuthManager authManager;
+
+  @BeforeEach
+  void setUp() {
+    userRepo = new InMemoryUserRepository();
+    passwordHasher = new FakePasswordHasher();
+    tokenProvider = new FakeTokenProvider();
+    authManager = new AuthManager(userRepo, passwordHasher, tokenProvider);
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 1: First Google login → user does not exist → saved with STUDENT
+  // -------------------------------------------------------------------------
+
+  @Test
+  void loginWithOAuth2_whenUserDoesNotExist_savesUserWithStudentRoleAndReturnsToken() {
+    AuthResponse response = authManager.loginWithOAuth2("new@example.com", "John Doe");
+
+    assertNotNull(response.accessToken());
+    assertNull(response.error());
+    assertEquals("STUDENT", response.role());
+
+    Optional<AppUser> saved = userRepo.findByEmail("new@example.com");
+    assertTrue(saved.isPresent());
+    assertEquals("STUDENT", saved.get().getRole());
+    assertTrue(tokenProvider.lastClaims().containsKey("role"));
+    assertEquals("STUDENT", tokenProvider.lastClaims().get("role"));
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 2: Repeat Google login → user already exists → not re-saved
+  // -------------------------------------------------------------------------
+
+  @Test
+  void loginWithOAuth2_whenUserAlreadyExists_doesNotReSaveUser() {
+    AppUser existing = AppUser.create("repeat@example.com", null, "STUDENT", "Jane", "Doe", null);
+    userRepo.save(existing);
+    int saveCountBefore = userRepo.saveCount();
+
+    AuthResponse response = authManager.loginWithOAuth2("repeat@example.com", "Jane Doe");
+
+    assertNotNull(response.accessToken());
+    assertNull(response.error());
+    assertEquals(saveCountBefore, userRepo.saveCount());
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 3: Existing ADMIN user → Google login → JWT contains ADMIN role
+  // -------------------------------------------------------------------------
+
+  @Test
+  void loginWithOAuth2_whenExistingUserHasAdminRole_jwtContainsAdminRole() {
+    AppUser admin = AppUser.create("admin@example.com", null, "ADMIN", "Admin", "User", null);
+    userRepo.save(admin);
+
+    AuthResponse response = authManager.loginWithOAuth2("admin@example.com", "Admin User");
+
+    assertNotNull(response.accessToken());
+    assertEquals("ADMIN", response.role());
+    assertEquals("ADMIN", tokenProvider.lastClaims().get("role"));
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 4: Full name "John Doe" → firstName="John", lastName="Doe"
+  // -------------------------------------------------------------------------
+
+  @Test
+  void loginWithOAuth2_withFullName_splitsFirstAndLastName() {
+    authManager.loginWithOAuth2("john.doe@example.com", "John Doe");
+
+    AppUser saved = userRepo.findByEmail("john.doe@example.com").orElseThrow();
+    assertEquals("John", saved.getFirstName());
+    assertEquals("Doe", saved.getLastName());
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 5: Single name "João" → firstName="João", lastName null
+  // -------------------------------------------------------------------------
+
+  @Test
+  void loginWithOAuth2_withSingleName_setsFirstNameAndNullLastName() {
+    authManager.loginWithOAuth2("joao@example.com", "João");
+
+    AppUser saved = userRepo.findByEmail("joao@example.com").orElseThrow();
+    assertEquals("João", saved.getFirstName());
+    assertNull(saved.getLastName());
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 6: Register happy path → user saved, JWT with STUDENT role
+  // -------------------------------------------------------------------------
+
+  @Test
+  void register_happyPath_savesUserAndReturnsTokenWithStudentRole() {
+    RegisterCommand command = new RegisterCommand(
+        "newuser@example.com", "password123", "password123", "Alice", "Smith", "Developer"
+    );
+
+    AuthResponse response = authManager.register(command);
+
+    assertNotNull(response.accessToken());
+    assertNull(response.error());
+    assertEquals("STUDENT", response.role());
+    assertTrue(userRepo.findByEmail("newuser@example.com").isPresent());
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 7a: Register with null email → returns invalid_email error
+  // -------------------------------------------------------------------------
+
+  @Test
+  void register_whenEmailIsNull_returnsInvalidEmailError() {
+    RegisterCommand command = new RegisterCommand(
+        null, "password123", "password123", "Alice", "Smith", "Developer"
+    );
+
+    AuthResponse response = authManager.register(command);
+
+    assertNull(response.accessToken());
+    assertEquals("invalid_email", response.error());
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 7b: Register with null password → returns password_too_short error
+  // -------------------------------------------------------------------------
+
+  @Test
+  void register_whenPasswordIsNull_returnsPasswordTooShortError() {
+    RegisterCommand command = new RegisterCommand(
+        "user@example.com", null, null, "Alice", "Smith", "Developer"
+    );
+
+    AuthResponse response = authManager.register(command);
+
+    assertNull(response.accessToken());
+    assertEquals("password_too_short", response.error());
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 7c: Register with null confirmPassword → returns password_mismatch
+  // -------------------------------------------------------------------------
+
+  @Test
+  void register_whenConfirmPasswordIsNull_returnsPasswordMismatchError() {
+    RegisterCommand command = new RegisterCommand(
+        "user@example.com", "password123", null, "Alice", "Smith", "Developer"
+    );
+
+    AuthResponse response = authManager.register(command);
+
+    assertNull(response.accessToken());
+    assertEquals("password_mismatch", response.error());
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 7d: Register with existing email → returns email_in_use error
+  // -------------------------------------------------------------------------
+
+  @Test
+  void register_whenEmailAlreadyExists_returnsEmailInUseError() {
+    AppUser existing = AppUser.create("taken@example.com", "hash", "STUDENT", "Existing", "User", null);
+    userRepo.save(existing);
+
+    RegisterCommand command = new RegisterCommand(
+        "taken@example.com", "password123", "password123", "New", "User", null
+    );
+
+    AuthResponse response = authManager.register(command);
+
+    assertNull(response.accessToken());
+    assertEquals("email_in_use", response.error());
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 8: Login with correct credentials → JWT returned
+  // -------------------------------------------------------------------------
+
+  @Test
+  void login_withCorrectCredentials_returnsToken() {
+    String rawPassword = "correctPassword";
+    AppUser user = AppUser.create(
+        "user@example.com", passwordHasher.encode(rawPassword), "STUDENT", "User", "Name", null
+    );
+    userRepo.save(user);
+
+    AuthResponse response = authManager.login(new LoginCommand("user@example.com", rawPassword));
+
+    assertNotNull(response.accessToken());
+    assertNull(response.error());
+    assertEquals("STUDENT", response.role());
+  }
+
+  // -------------------------------------------------------------------------
+  // Scenario 9: Login with wrong password → returns invalid_credentials error
+  // -------------------------------------------------------------------------
+
+  @Test
+  void login_withWrongPassword_returnsInvalidCredentialsError() {
+    AppUser user = AppUser.create(
+        "user@example.com", passwordHasher.encode("correctPassword"), "STUDENT", "User", "Name", null
+    );
+    userRepo.save(user);
+
+    AuthResponse response = authManager.login(new LoginCommand("user@example.com", "wrongPassword"));
+
+    assertNull(response.accessToken());
+    assertEquals("invalid_credentials", response.error());
+  }
+
+  // =========================================================================
+  // In-memory fakes
+  // =========================================================================
+
+  static class InMemoryUserRepository implements UserRepository {
+    private final Map<String, AppUser> dataByEmail = new ConcurrentHashMap<>();
+    private int saveCallCount = 0;
+
+    @Override
+    public Optional<AppUser> findByEmail(String email) {
+      return Optional.ofNullable(dataByEmail.get(email));
+    }
+
+    @Override
+    public AppUser save(AppUser user) {
+      saveCallCount++;
+      dataByEmail.put(user.getEmail(), user);
+      return user;
+    }
+
+    @Override
+    public Optional<AppUser> findById(UUID id) {
+      return dataByEmail.values().stream().filter(u -> u.getId().equals(id)).findFirst();
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+      return dataByEmail.containsKey(email);
+    }
+
+    @Override
+    public List<AppUser> findAll() {
+      return new ArrayList<>(dataByEmail.values());
+    }
+
+    @Override
+    public Page<AppUser> findPage(int page, int size) {
+      List<AppUser> all = findAll();
+      int from = Math.min(page * size, all.size());
+      int to = Math.min(from + size, all.size());
+      return new PageImpl<>(all.subList(from, to), PageRequest.of(page, size), all.size());
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+      dataByEmail.values().removeIf(u -> u.getId().equals(id));
+    }
+
+    int saveCount() {
+      return saveCallCount;
+    }
+  }
+
+  static class FakePasswordHasher implements PasswordHasher {
+    @Override
+    public String encode(String rawPassword) {
+      return "hashed:" + rawPassword;
+    }
+
+    @Override
+    public boolean matches(String rawPassword, String encodedPassword) {
+      return encodedPassword != null && encodedPassword.equals("hashed:" + rawPassword);
+    }
+  }
+
+  static class FakeTokenProvider implements TokenProvider {
+    private Map<String, Object> lastClaims;
+
+    @Override
+    public String generate(String subject, Map<String, Object> claims) {
+      this.lastClaims = claims;
+      return "fake-token-for-" + subject;
+    }
+
+    Map<String, Object> lastClaims() {
+      return lastClaims;
+    }
+  }
+}

--- a/backend/src/test/java/com/akdemya/application/service/FlashcardImportExportServiceTest.java
+++ b/backend/src/test/java/com/akdemya/application/service/FlashcardImportExportServiceTest.java
@@ -1,0 +1,359 @@
+package com.akdemya.application.service;
+
+import com.akdemya.domain.model.Flashcard;
+import com.akdemya.domain.model.Unit;
+import com.akdemya.domain.port.in.FlashcardImportExportUseCase;
+import com.akdemya.domain.port.in.FlashcardManagementUseCase;
+import com.akdemya.domain.port.out.UnitRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class FlashcardImportExportServiceTest {
+
+  private final FlashcardManagementUseCase managementUseCase = mock(FlashcardManagementUseCase.class);
+  private final UnitRepository unitRepository = mock(UnitRepository.class);
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private final FlashcardImportExportService service =
+      new FlashcardImportExportService(managementUseCase, unitRepository, objectMapper);
+
+  private Flashcard flashcard(UUID unitId, String front, String back) {
+    return new Flashcard(UUID.randomUUID(), unitId, front, back,
+        LocalDateTime.now(), LocalDateTime.now());
+  }
+
+  private Unit unit(UUID subjectId) {
+    return new Unit(UUID.randomUUID(), subjectId, "Unit", "", 1);
+  }
+
+  // --- exportFlashcardsBySubject: CSV ---
+
+  @Test
+  void exportFlashcardsBySubject_csvMergesAllUnits() {
+    UUID subjectId = UUID.randomUUID();
+    Unit unit1 = unit(subjectId);
+    Unit unit2 = unit(subjectId);
+    Flashcard card1 = flashcard(unit1.getId(), "Hello", "Hola");
+    Flashcard card2 = flashcard(unit2.getId(), "Goodbye", "Adiós");
+
+    when(unitRepository.findBySubjectId(subjectId)).thenReturn(List.of(unit1, unit2));
+    when(managementUseCase.listByUnit(unit1.getId())).thenReturn(List.of(card1));
+    when(managementUseCase.listByUnit(unit2.getId())).thenReturn(List.of(card2));
+
+    String result = service.exportFlashcardsBySubject(subjectId, "csv");
+
+    assertTrue(result.startsWith("front,back\n"));
+    assertTrue(result.contains("Hello,Hola"));
+    assertTrue(result.contains("Goodbye,Adiós"));
+  }
+
+  @Test
+  void exportFlashcardsBySubject_jsonMergesAllUnits() throws Exception {
+    UUID subjectId = UUID.randomUUID();
+    Unit unit1 = unit(subjectId);
+    Unit unit2 = unit(subjectId);
+    Flashcard card1 = flashcard(unit1.getId(), "Cat", "Gato");
+    Flashcard card2 = flashcard(unit2.getId(), "Dog", "Perro");
+
+    when(unitRepository.findBySubjectId(subjectId)).thenReturn(List.of(unit1, unit2));
+    when(managementUseCase.listByUnit(unit1.getId())).thenReturn(List.of(card1));
+    when(managementUseCase.listByUnit(unit2.getId())).thenReturn(List.of(card2));
+
+    String result = service.exportFlashcardsBySubject(subjectId, "json");
+
+    var parsed = objectMapper.readValue(result, List.class);
+    assertEquals(2, parsed.size());
+  }
+
+  @Test
+  void exportFlashcardsBySubject_noUnitsReturnsCsvHeader() {
+    UUID subjectId = UUID.randomUUID();
+    when(unitRepository.findBySubjectId(subjectId)).thenReturn(List.of());
+
+    String result = service.exportFlashcardsBySubject(subjectId, "csv");
+
+    assertEquals("front,back\n", result);
+  }
+
+  @Test
+  void exportFlashcardsBySubject_noUnitsReturnsEmptyJsonArray() {
+    UUID subjectId = UUID.randomUUID();
+    when(unitRepository.findBySubjectId(subjectId)).thenReturn(List.of());
+
+    String result = service.exportFlashcardsBySubject(subjectId, "json");
+
+    assertEquals("[]", result);
+  }
+
+  @Test
+  void exportFlashcardsBySubject_unitsWithNoFlashcardsReturnsCsvHeader() {
+    UUID subjectId = UUID.randomUUID();
+    Unit unit1 = unit(subjectId);
+
+    when(unitRepository.findBySubjectId(subjectId)).thenReturn(List.of(unit1));
+    when(managementUseCase.listByUnit(unit1.getId())).thenReturn(List.of());
+
+    String result = service.exportFlashcardsBySubject(subjectId, "csv");
+
+    assertEquals("front,back\n", result);
+  }
+
+  // --- exportFlashcards (by unit) ---
+
+  @Test
+  void exportFlashcards_csvFormatReturnsHeaderAndRows() {
+    UUID unitId = UUID.randomUUID();
+    Flashcard card = flashcard(unitId, "Question", "Answer");
+    when(managementUseCase.listByUnit(unitId)).thenReturn(List.of(card));
+
+    String result = service.exportFlashcards(unitId, "csv");
+
+    assertTrue(result.startsWith("front,back\n"));
+    assertTrue(result.contains("Question,Answer"));
+  }
+
+  @Test
+  void exportFlashcards_jsonFormatReturnsJsonArray() throws Exception {
+    UUID unitId = UUID.randomUUID();
+    Flashcard card = flashcard(unitId, "Front", "Back");
+    when(managementUseCase.listByUnit(unitId)).thenReturn(List.of(card));
+
+    String result = service.exportFlashcards(unitId, "json");
+
+    var parsed = objectMapper.readValue(result, List.class);
+    assertEquals(1, parsed.size());
+  }
+
+  @Test
+  void exportFlashcards_csvEscapesCommasInFields() {
+    UUID unitId = UUID.randomUUID();
+    Flashcard card = flashcard(unitId, "A, B", "C, D");
+    when(managementUseCase.listByUnit(unitId)).thenReturn(List.of(card));
+
+    String result = service.exportFlashcards(unitId, "csv");
+
+    assertTrue(result.contains("\"A, B\""));
+    assertTrue(result.contains("\"C, D\""));
+  }
+
+  @Test
+  void exportFlashcards_csvEscapesQuotesInFields() {
+    UUID unitId = UUID.randomUUID();
+    Flashcard card = flashcard(unitId, "Say \"hello\"", "reply");
+    when(managementUseCase.listByUnit(unitId)).thenReturn(List.of(card));
+
+    String result = service.exportFlashcards(unitId, "csv");
+
+    assertTrue(result.contains("\"Say \"\"hello\"\"\""));
+  }
+
+  @Test
+  void exportFlashcards_emptyUnitReturnsCsvHeader() {
+    UUID unitId = UUID.randomUUID();
+    when(managementUseCase.listByUnit(unitId)).thenReturn(List.of());
+
+    String result = service.exportFlashcards(unitId, "csv");
+
+    assertEquals("front,back\n", result);
+  }
+
+  // --- importFlashcards: CSV ---
+
+  @Test
+  void importFlashcards_csvImportsValidRows() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "front,back\nHello,Hola\nGoodbye,Adiós\n";
+
+    Flashcard created = flashcard(unitId, "Hello", "Hola");
+    when(managementUseCase.createFlashcard(any())).thenReturn(created);
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(2, result.imported());
+    assertEquals(0, result.skipped());
+    assertTrue(result.errors().isEmpty());
+    verify(managementUseCase, times(2)).createFlashcard(any());
+  }
+
+  @Test
+  void importFlashcards_csvSkipsBlankRows() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "front,back\nHello,Hola\n\nGoodbye,Adiós\n";
+
+    Flashcard created = flashcard(unitId, "Hello", "Hola");
+    when(managementUseCase.createFlashcard(any())).thenReturn(created);
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(2, result.imported());
+    assertEquals(0, result.skipped());
+  }
+
+  @Test
+  void importFlashcards_csvErrorsWhenFrontIsEmpty() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "front,back\n,Hola\n";
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(0, result.imported());
+    assertEquals(1, result.skipped());
+    assertEquals(1, result.errors().size());
+    assertTrue(result.errors().get(0).contains("anverso"));
+  }
+
+  @Test
+  void importFlashcards_csvErrorsWhenBackIsEmpty() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "front,back\nHello,\n";
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(0, result.imported());
+    assertEquals(1, result.skipped());
+    assertEquals(1, result.errors().size());
+    assertTrue(result.errors().get(0).contains("reverso"));
+  }
+
+  @Test
+  void importFlashcards_csvSkipsBothEmptyFrontAndBack() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "front,back\n,\n";
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(0, result.imported());
+    assertEquals(1, result.skipped());
+    assertTrue(result.errors().isEmpty());
+  }
+
+  @Test
+  void importFlashcards_csvHandlesCreateException() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "front,back\nHello,Hola\n";
+
+    when(managementUseCase.createFlashcard(any()))
+        .thenThrow(new IllegalArgumentException("duplicate"));
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(0, result.imported());
+    assertEquals(1, result.skipped());
+    assertEquals(1, result.errors().size());
+    assertTrue(result.errors().get(0).contains("duplicate"));
+  }
+
+  @Test
+  void importFlashcards_csvWithoutHeaderLineStillImports() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "Hello,Hola\nGoodbye,Adiós\n";
+
+    Flashcard created = flashcard(unitId, "Hello", "Hola");
+    when(managementUseCase.createFlashcard(any())).thenReturn(created);
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(2, result.imported());
+  }
+
+  @Test
+  void importFlashcards_csvWithQuotedFields() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "front,back\n\"Hello, world\",\"Hola, mundo\"\n";
+
+    Flashcard created = flashcard(unitId, "Hello, world", "Hola, mundo");
+    when(managementUseCase.createFlashcard(any())).thenReturn(created);
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(1, result.imported());
+    assertEquals(0, result.skipped());
+  }
+
+  @Test
+  void importFlashcards_csvWithEscapedQuotesInFields() {
+    UUID unitId = UUID.randomUUID();
+    String csv = "front,back\n\"Say \"\"hi\"\"\",reply\n";
+
+    Flashcard created = flashcard(unitId, "Say \"hi\"", "reply");
+    when(managementUseCase.createFlashcard(any())).thenReturn(created);
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", csv);
+
+    assertEquals(1, result.imported());
+  }
+
+  // --- importFlashcards: JSON ---
+
+  @Test
+  void importFlashcards_jsonImportsValidRows() {
+    UUID unitId = UUID.randomUUID();
+    String json = "[{\"front\":\"Hello\",\"back\":\"Hola\"},{\"front\":\"Bye\",\"back\":\"Adiós\"}]";
+
+    Flashcard created = flashcard(unitId, "Hello", "Hola");
+    when(managementUseCase.createFlashcard(any())).thenReturn(created);
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "json", json);
+
+    assertEquals(2, result.imported());
+    assertEquals(0, result.skipped());
+    assertTrue(result.errors().isEmpty());
+  }
+
+  @Test
+  void importFlashcards_jsonHandlesMissingFrontKey() {
+    UUID unitId = UUID.randomUUID();
+    String json = "[{\"back\":\"Hola\"}]";
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "json", json);
+
+    assertEquals(0, result.imported());
+    assertEquals(1, result.skipped());
+    assertEquals(1, result.errors().size());
+    assertTrue(result.errors().get(0).contains("anverso"));
+  }
+
+  @Test
+  void importFlashcards_jsonHandlesMissingBackKey() {
+    UUID unitId = UUID.randomUUID();
+    String json = "[{\"front\":\"Hello\"}]";
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "json", json);
+
+    assertEquals(0, result.imported());
+    assertEquals(1, result.skipped());
+    assertEquals(1, result.errors().size());
+    assertTrue(result.errors().get(0).contains("reverso"));
+  }
+
+  @Test
+  void importFlashcards_jsonReturnsParseErrorOnInvalidJson() {
+    UUID unitId = UUID.randomUUID();
+    String badJson = "not valid json";
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "json", badJson);
+
+    assertEquals(0, result.imported());
+    assertEquals(1, result.errors().size());
+    assertTrue(result.errors().get(0).contains("parsear"));
+  }
+
+  @Test
+  void importFlashcards_csvReturnsParseErrorOnNullContent() {
+    UUID unitId = UUID.randomUUID();
+
+    FlashcardImportExportUseCase.ImportResult result = service.importFlashcards(unitId, "csv", null);
+
+    assertEquals(0, result.imported());
+    assertEquals(1, result.errors().size());
+    assertTrue(result.errors().get(0).contains("parsear"));
+  }
+}

--- a/backend/src/test/java/com/akdemya/application/service/UserProfileServiceTest.java
+++ b/backend/src/test/java/com/akdemya/application/service/UserProfileServiceTest.java
@@ -1,0 +1,179 @@
+package com.akdemya.application.service;
+
+import com.akdemya.domain.model.AppUser;
+import com.akdemya.domain.port.in.UserProfileUseCase.GetProfileResponse;
+import com.akdemya.domain.port.in.UserProfileUseCase.UpdateProfileCommand;
+import com.akdemya.domain.port.out.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserProfileServiceTest {
+
+    private InMemoryUserRepository userRepo;
+    private UserProfileService service;
+
+    @BeforeEach
+    void setUp() {
+        userRepo = new InMemoryUserRepository();
+        service = new UserProfileService(userRepo);
+    }
+
+    // -------------------------------------------------------------------------
+    // getProfile — happy path
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getProfile_happyPath_returnsUserData() {
+        AppUser user = AppUser.create("alice@example.com", "hash", "STUDENT", "Alice", "Smith", null);
+        userRepo.save(user);
+
+        GetProfileResponse response = service.getProfile(user.getId());
+
+        assertEquals(user.getId(), response.id());
+        assertEquals("alice@example.com", response.email());
+        assertEquals("Alice", response.firstName());
+        assertEquals("Smith", response.lastName());
+    }
+
+    // -------------------------------------------------------------------------
+    // getProfile — user not found
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getProfile_whenUserNotFound_throwsException() {
+        UUID unknownId = UUID.randomUUID();
+
+        assertThrows(NoSuchElementException.class, () -> service.getProfile(unknownId));
+    }
+
+    // -------------------------------------------------------------------------
+    // updateProfile — happy path
+    // -------------------------------------------------------------------------
+
+    @Test
+    void updateProfile_happyPath_persistsNewNamesAndReturnsResponse() {
+        AppUser user = AppUser.create("bob@example.com", "hash", "STUDENT", "Bob", "Old", null);
+        userRepo.save(user);
+
+        GetProfileResponse response = service.updateProfile(
+            user.getId(),
+            new UpdateProfileCommand("Robert", "New")
+        );
+
+        assertEquals("Robert", response.firstName());
+        assertEquals("New", response.lastName());
+
+        AppUser persisted = userRepo.findById(user.getId()).orElseThrow();
+        assertEquals("Robert", persisted.getFirstName());
+        assertEquals("New", persisted.getLastName());
+    }
+
+    // -------------------------------------------------------------------------
+    // updateProfile — preserves unchanged fields
+    // -------------------------------------------------------------------------
+
+    @Test
+    void updateProfile_preservesUnchangedFieldsLikeEmailAndRole() {
+        AppUser user = AppUser.create("carol@example.com", "secret-hash", "ADMIN", "Carol", "Doe", "Engineer");
+        userRepo.save(user);
+
+        service.updateProfile(user.getId(), new UpdateProfileCommand("Caroline", null));
+
+        AppUser persisted = userRepo.findById(user.getId()).orElseThrow();
+        assertEquals("carol@example.com", persisted.getEmail());
+        assertEquals("secret-hash", persisted.getPasswordHash());
+        assertEquals("ADMIN", persisted.getRole());
+        assertEquals("Engineer", persisted.getOccupation());
+        assertEquals("Caroline", persisted.getFirstName());
+        assertNull(persisted.getLastName());
+    }
+
+    // -------------------------------------------------------------------------
+    // updateProfile — user not found
+    // -------------------------------------------------------------------------
+
+    @Test
+    void updateProfile_whenUserNotFound_throwsException() {
+        UUID unknownId = UUID.randomUUID();
+
+        assertThrows(NoSuchElementException.class, () ->
+            service.updateProfile(unknownId, new UpdateProfileCommand("X", "Y"))
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // updateProfile — firstName too long
+    // -------------------------------------------------------------------------
+
+    @Test
+    void updateProfile_whenFirstNameExceeds100Chars_throwsIllegalArgumentException() {
+        AppUser user = AppUser.create("dave@example.com", "hash", "STUDENT", "Dave", "Short", null);
+        userRepo.save(user);
+
+        String tooLong = "A".repeat(101);
+
+        assertThrows(IllegalArgumentException.class, () ->
+            service.updateProfile(user.getId(), new UpdateProfileCommand(tooLong, "Valid"))
+        );
+    }
+
+    // =========================================================================
+    // In-memory fake
+    // =========================================================================
+
+    static class InMemoryUserRepository implements UserRepository {
+        private final Map<UUID, AppUser> store = new ConcurrentHashMap<>();
+
+        @Override
+        public Optional<AppUser> findByEmail(String email) {
+            return store.values().stream().filter(u -> u.getEmail().equals(email)).findFirst();
+        }
+
+        @Override
+        public AppUser save(AppUser user) {
+            store.put(user.getId(), user);
+            return user;
+        }
+
+        @Override
+        public Optional<AppUser> findById(UUID id) {
+            return Optional.ofNullable(store.get(id));
+        }
+
+        @Override
+        public boolean existsByEmail(String email) {
+            return store.values().stream().anyMatch(u -> u.getEmail().equals(email));
+        }
+
+        @Override
+        public List<AppUser> findAll() {
+            return new ArrayList<>(store.values());
+        }
+
+        @Override
+        public Page<AppUser> findPage(int page, int size) {
+            List<AppUser> all = findAll();
+            int from = Math.min(page * size, all.size());
+            int to = Math.min(from + size, all.size());
+            return new PageImpl<>(all.subList(from, to), PageRequest.of(page, size), all.size());
+        }
+
+        @Override
+        public void deleteById(UUID id) {
+            store.remove(id);
+        }
+    }
+}

--- a/backend/src/test/java/com/akdemya/application/service/UserProfileServiceTest.java
+++ b/backend/src/test/java/com/akdemya/application/service/UserProfileServiceTest.java
@@ -18,162 +18,164 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UserProfileServiceTest {
 
-    private InMemoryUserRepository userRepo;
-    private UserProfileService service;
+  private InMemoryUserRepository userRepo;
+  private UserProfileService service;
 
-    @BeforeEach
-    void setUp() {
-        userRepo = new InMemoryUserRepository();
-        service = new UserProfileService(userRepo);
+  @BeforeEach
+  void setUp() {
+    userRepo = new InMemoryUserRepository();
+    service = new UserProfileService(userRepo);
+  }
+
+  // -------------------------------------------------------------------------
+  // getProfile — happy path
+  // -------------------------------------------------------------------------
+
+  @Test
+  void getProfile_happyPath_returnsUserData() {
+    AppUser user = AppUser.create("alice@example.com", "hash", "STUDENT", "Alice", "Smith", null);
+    userRepo.save(user);
+
+    GetProfileResponse response = service.getProfile(user.getId());
+
+    assertEquals(user.getId(), response.id());
+    assertEquals("alice@example.com", response.email());
+    assertEquals("Alice", response.firstName());
+    assertEquals("Smith", response.lastName());
+  }
+
+  // -------------------------------------------------------------------------
+  // getProfile — user not found
+  // -------------------------------------------------------------------------
+
+  @Test
+  void getProfile_whenUserNotFound_throwsException() {
+    UUID unknownId = UUID.randomUUID();
+
+    assertThrows(NoSuchElementException.class, () -> service.getProfile(unknownId));
+  }
+
+  // -------------------------------------------------------------------------
+  // updateProfile — happy path
+  // -------------------------------------------------------------------------
+
+  @Test
+  void updateProfile_happyPath_persistsNewNamesAndReturnsResponse() {
+    AppUser user = AppUser.create("bob@example.com", "hash", "STUDENT", "Bob", "Old", null);
+    userRepo.save(user);
+
+    GetProfileResponse response = service.updateProfile(
+        user.getId(),
+        new UpdateProfileCommand("Robert", "New")
+    );
+
+    assertEquals("Robert", response.firstName());
+    assertEquals("New", response.lastName());
+
+    AppUser persisted = userRepo.findById(user.getId()).orElseThrow();
+    assertEquals("Robert", persisted.getFirstName());
+    assertEquals("New", persisted.getLastName());
+  }
+
+  // -------------------------------------------------------------------------
+  // updateProfile — preserves unchanged fields
+  // -------------------------------------------------------------------------
+
+  @Test
+  void updateProfile_preservesUnchangedFieldsLikeEmailAndRole() {
+    AppUser user = AppUser.create("carol@example.com", "secret-hash", "ADMIN", "Carol", "Doe", "Engineer");
+    userRepo.save(user);
+
+    service.updateProfile(user.getId(), new UpdateProfileCommand("Caroline", null));
+
+    AppUser persisted = userRepo.findById(user.getId()).orElseThrow();
+    assertEquals("carol@example.com", persisted.getEmail());
+    assertEquals("secret-hash", persisted.getPasswordHash());
+    assertEquals("ADMIN", persisted.getRole());
+    assertEquals("Engineer", persisted.getOccupation());
+    assertEquals("Caroline", persisted.getFirstName());
+    assertNull(persisted.getLastName());
+  }
+
+  // -------------------------------------------------------------------------
+  // updateProfile — user not found
+  // -------------------------------------------------------------------------
+
+  @Test
+  void updateProfile_whenUserNotFound_throwsException() {
+    UUID unknownId = UUID.randomUUID();
+
+    assertThrows(NoSuchElementException.class, () ->
+        service.updateProfile(unknownId, new UpdateProfileCommand("X", "Y"))
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // updateProfile — firstName too long
+  // -------------------------------------------------------------------------
+
+  @Test
+  void updateProfile_whenFirstNameExceeds100Chars_throwsIllegalArgumentException() {
+    AppUser user = AppUser.create("dave@example.com", "hash", "STUDENT", "Dave", "Short", null);
+    userRepo.save(user);
+
+    String tooLong = "A".repeat(101);
+
+    assertThrows(IllegalArgumentException.class, () ->
+        service.updateProfile(user.getId(), new UpdateProfileCommand(tooLong, "Valid"))
+    );
+  }
+
+  // =========================================================================
+  // In-memory fake
+  // =========================================================================
+
+  static class InMemoryUserRepository implements UserRepository {
+    private final Map<UUID, AppUser> store = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<AppUser> findByEmail(String email) {
+      return store.values().stream().filter(u -> u.getEmail().equals(email)).findFirst();
     }
 
-    // -------------------------------------------------------------------------
-    // getProfile — happy path
-    // -------------------------------------------------------------------------
-
-    @Test
-    void getProfile_happyPath_returnsUserData() {
-        AppUser user = AppUser.create("alice@example.com", "hash", "STUDENT", "Alice", "Smith", null);
-        userRepo.save(user);
-
-        GetProfileResponse response = service.getProfile(user.getId());
-
-        assertEquals(user.getId(), response.id());
-        assertEquals("alice@example.com", response.email());
-        assertEquals("Alice", response.firstName());
-        assertEquals("Smith", response.lastName());
+    @Override
+    public AppUser save(AppUser user) {
+      store.put(user.getId(), user);
+      return user;
     }
 
-    // -------------------------------------------------------------------------
-    // getProfile — user not found
-    // -------------------------------------------------------------------------
-
-    @Test
-    void getProfile_whenUserNotFound_throwsException() {
-        UUID unknownId = UUID.randomUUID();
-
-        assertThrows(NoSuchElementException.class, () -> service.getProfile(unknownId));
+    @Override
+    public Optional<AppUser> findById(UUID id) {
+      return Optional.ofNullable(store.get(id));
     }
 
-    // -------------------------------------------------------------------------
-    // updateProfile — happy path
-    // -------------------------------------------------------------------------
-
-    @Test
-    void updateProfile_happyPath_persistsNewNamesAndReturnsResponse() {
-        AppUser user = AppUser.create("bob@example.com", "hash", "STUDENT", "Bob", "Old", null);
-        userRepo.save(user);
-
-        GetProfileResponse response = service.updateProfile(
-            user.getId(),
-            new UpdateProfileCommand("Robert", "New")
-        );
-
-        assertEquals("Robert", response.firstName());
-        assertEquals("New", response.lastName());
-
-        AppUser persisted = userRepo.findById(user.getId()).orElseThrow();
-        assertEquals("Robert", persisted.getFirstName());
-        assertEquals("New", persisted.getLastName());
+    @Override
+    public boolean existsByEmail(String email) {
+      return store.values().stream().anyMatch(u -> u.getEmail().equals(email));
     }
 
-    // -------------------------------------------------------------------------
-    // updateProfile — preserves unchanged fields
-    // -------------------------------------------------------------------------
-
-    @Test
-    void updateProfile_preservesUnchangedFieldsLikeEmailAndRole() {
-        AppUser user = AppUser.create("carol@example.com", "secret-hash", "ADMIN", "Carol", "Doe", "Engineer");
-        userRepo.save(user);
-
-        service.updateProfile(user.getId(), new UpdateProfileCommand("Caroline", null));
-
-        AppUser persisted = userRepo.findById(user.getId()).orElseThrow();
-        assertEquals("carol@example.com", persisted.getEmail());
-        assertEquals("secret-hash", persisted.getPasswordHash());
-        assertEquals("ADMIN", persisted.getRole());
-        assertEquals("Engineer", persisted.getOccupation());
-        assertEquals("Caroline", persisted.getFirstName());
-        assertNull(persisted.getLastName());
+    @Override
+    public List<AppUser> findAll() {
+      return new ArrayList<>(store.values());
     }
 
-    // -------------------------------------------------------------------------
-    // updateProfile — user not found
-    // -------------------------------------------------------------------------
-
-    @Test
-    void updateProfile_whenUserNotFound_throwsException() {
-        UUID unknownId = UUID.randomUUID();
-
-        assertThrows(NoSuchElementException.class, () ->
-            service.updateProfile(unknownId, new UpdateProfileCommand("X", "Y"))
-        );
+    @Override
+    public Page<AppUser> findPage(int page, int size) {
+      List<AppUser> all = findAll();
+      int from = Math.min(page * size, all.size());
+      int to = Math.min(from + size, all.size());
+      return new PageImpl<>(all.subList(from, to), PageRequest.of(page, size), all.size());
     }
 
-    // -------------------------------------------------------------------------
-    // updateProfile — firstName too long
-    // -------------------------------------------------------------------------
-
-    @Test
-    void updateProfile_whenFirstNameExceeds100Chars_throwsIllegalArgumentException() {
-        AppUser user = AppUser.create("dave@example.com", "hash", "STUDENT", "Dave", "Short", null);
-        userRepo.save(user);
-
-        String tooLong = "A".repeat(101);
-
-        assertThrows(IllegalArgumentException.class, () ->
-            service.updateProfile(user.getId(), new UpdateProfileCommand(tooLong, "Valid"))
-        );
+    @Override
+    public void deleteById(UUID id) {
+      store.remove(id);
     }
-
-    // =========================================================================
-    // In-memory fake
-    // =========================================================================
-
-    static class InMemoryUserRepository implements UserRepository {
-        private final Map<UUID, AppUser> store = new ConcurrentHashMap<>();
-
-        @Override
-        public Optional<AppUser> findByEmail(String email) {
-            return store.values().stream().filter(u -> u.getEmail().equals(email)).findFirst();
-        }
-
-        @Override
-        public AppUser save(AppUser user) {
-            store.put(user.getId(), user);
-            return user;
-        }
-
-        @Override
-        public Optional<AppUser> findById(UUID id) {
-            return Optional.ofNullable(store.get(id));
-        }
-
-        @Override
-        public boolean existsByEmail(String email) {
-            return store.values().stream().anyMatch(u -> u.getEmail().equals(email));
-        }
-
-        @Override
-        public List<AppUser> findAll() {
-            return new ArrayList<>(store.values());
-        }
-
-        @Override
-        public Page<AppUser> findPage(int page, int size) {
-            List<AppUser> all = findAll();
-            int from = Math.min(page * size, all.size());
-            int to = Math.min(from + size, all.size());
-            return new PageImpl<>(all.subList(from, to), PageRequest.of(page, size), all.size());
-        }
-
-        @Override
-        public void deleteById(UUID id) {
-            store.remove(id);
-        }
-    }
+  }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,12 +16,14 @@
         "react-router-dom": "^6.26.2"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
+        "@vitest/coverage-v8": "^2.1.9",
         "autoprefixer": "^10.4.20",
         "baseline-browser-mapping": "^2.9.19",
         "jsdom": "^25.0.1",
@@ -49,6 +51,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -259,13 +275,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -351,9 +367,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -363,6 +379,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -964,6 +987,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -975,6 +999,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1042,6 +1076,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1055,6 +1090,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1064,6 +1100,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1406,6 +1443,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2087,7 +2125,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2186,8 +2223,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2293,6 +2329,39 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/expect": {
@@ -2432,6 +2501,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2444,6 +2514,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2456,12 +2527,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -2475,6 +2548,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/aria-query": {
@@ -2552,6 +2626,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -2568,6 +2643,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2580,6 +2656,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2589,6 +2666,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2659,6 +2737,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -2716,6 +2795,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -2740,6 +2820,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -2752,6 +2833,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2764,6 +2846,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -2783,6 +2866,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -2819,6 +2903,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2840,6 +2925,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -2988,12 +3074,14 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
@@ -3001,8 +3089,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3023,6 +3110,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -3036,6 +3124,7 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
@@ -3202,6 +3291,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3218,6 +3308,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -3230,6 +3321,7 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3239,6 +3331,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3347,6 +3440,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -3394,6 +3488,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3466,6 +3561,7 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -3486,6 +3582,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -3512,6 +3609,16 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
@@ -3566,6 +3673,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -3622,6 +3736,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -3649,6 +3764,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3658,6 +3774,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3667,6 +3784,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3685,6 +3803,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -3701,12 +3820,68 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -3722,6 +3897,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -4062,6 +4238,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -4074,6 +4251,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -4111,7 +4289,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4123,6 +4300,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4139,6 +4357,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -4148,6 +4367,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -4203,6 +4423,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -4218,6 +4439,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4234,6 +4456,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -4270,6 +4493,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4296,6 +4520,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4305,6 +4530,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4351,6 +4577,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/package-manager-detector": {
@@ -4376,6 +4603,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4391,6 +4619,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -4407,6 +4636,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/pathe": {
@@ -4436,6 +4666,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4448,6 +4679,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4457,6 +4689,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4494,6 +4727,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -4511,6 +4745,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4536,6 +4771,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4578,6 +4814,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4603,6 +4840,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -4616,6 +4854,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pretty-format": {
@@ -4624,7 +4863,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4640,7 +4878,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4651,7 +4888,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4673,6 +4909,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4719,8 +4956,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -4768,6 +5004,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -4777,6 +5014,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -4823,6 +5061,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -4833,7 +5072,7 @@
       "version": "4.53.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.2.tgz",
       "integrity": "sha512-MHngMYwGJVi6Fmnk6ISmnk7JAHRNF0UkuucA0CUW3N3a4KnONPEZz+vUanQP/ZC/iY1Qkf3bwPWzyY84wEks1g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -4882,6 +5121,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4944,6 +5184,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -4956,6 +5197,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4972,6 +5214,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -5007,6 +5250,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -5025,6 +5269,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5039,6 +5284,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5048,12 +5294,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5066,6 +5314,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -5082,6 +5331,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5094,6 +5344,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5116,6 +5367,7 @@
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -5132,6 +5384,19 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -5185,6 +5450,7 @@
       "version": "3.4.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
       "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -5231,10 +5497,65 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -5244,6 +5565,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -5320,6 +5642,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -5358,6 +5681,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -5416,6 +5740,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -5632,6 +5957,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -5664,6 +5990,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -5682,6 +6009,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -5699,6 +6027,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5708,6 +6037,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -5723,12 +6053,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5743,6 +6075,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,12 +19,14 @@
     "react-router-dom": "^6.26.2"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
+    "@vitest/coverage-v8": "^2.1.9",
     "autoprefixer": "^10.4.20",
     "baseline-browser-mapping": "^2.9.19",
     "jsdom": "^25.0.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,8 +3,9 @@ import { Navigate, Route, Routes, useNavigate, useLocation } from 'react-router-
 import type { Question } from './components/ExamRunner';
 import Navbar from './components/Navbar';
 import { apiBase, apiAuthJson } from './api';
-import type { Subject, ExamResult, ExamStartResponse } from './types';
+import type { Subject, ExamResult, ExamStartResponse, NavUser } from './types';
 import { timeoutMessage } from './utils/messages';
+import { deriveInitials } from './utils/format';
 import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
@@ -22,7 +23,7 @@ import RagPage from './pages/RagPage';
 import ProtectedRoute from './pages/ProtectedRoute';
 import { ROUTES } from './constants/routes';
 
-export default function App(){
+export default function App() {
   const navigate = useNavigate();
   const location = useLocation();
   const isHome = location.pathname === ROUTES.home;
@@ -32,7 +33,8 @@ export default function App(){
   const [minutes, setMinutes] = useState(20);
   const [attemptId, setAttemptId] = useState<string>('');
   const [token, setToken] = useState<string>(localStorage.getItem('ak_token') || '');
-  const [result, setResult] = useState<ExamResult|null>(null);
+  const [user, setUser] = useState<NavUser | null>(null);
+  const [result, setResult] = useState<ExamResult | null>(null);
   const [activeAttemptId, setActiveAttemptId] = useState<string>(sessionStorage.getItem('akdmia.activeAttemptId') || '');
   const [toastError, setToastError] = useState<string>('');
 
@@ -44,10 +46,18 @@ export default function App(){
   const isAuthed = useMemo(() => Boolean(token), [token]);
   const role = useMemo(() => {
     try {
-      if (!token) return null;
+      if (!token) {
+        setUser(null);
+        return null;
+      }
       const payload = JSON.parse(atob(token.split('.')[1]));
+      const email: string = payload.sub || '';
+      const initials = deriveInitials(email);
+      const navUser: NavUser = { email, initials };
+      setUser(navUser);
       return payload.role || null;
     } catch {
+      setUser(null);
       return null;
     }
   }, [token]);
@@ -88,7 +98,7 @@ export default function App(){
     }
   }, [location.pathname]);
 
-  function onToken(t:string){
+  function onToken(t: string) {
     setToken(t);
     localStorage.setItem('ak_token', t);
     navigate(ROUTES.subjects);
@@ -99,15 +109,16 @@ export default function App(){
     sessionStorage.removeItem('akdmia.activeAttemptId');
     setActiveAttemptId('');
     setToken('');
+    setUser(null);
     navigate(ROUTES.home);
   }
 
   // timeoutMessage from utils
-  async function startExam(cfg:{ unitCounts: Record<string, number>, minutes: number, difficulty?: 'EASY' | 'MEDIUM' | 'HARD' }){
+  async function startExam(cfg: { unitCounts: Record<string, number>; minutes: number; difficulty?: 'EASY' | 'MEDIUM' | 'HARD' }) {
     try {
       const data = await authedJson<ExamStartResponse>(`${apiBase}/api/exams/attempts/start`, {
         method: 'POST',
-        headers: { 'Content-Type':'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(cfg),
         timeoutMs: 15000
       });
@@ -149,13 +160,17 @@ export default function App(){
     }
   }
 
-  async function finishExam(payload:{ selections: Record<string,string|undefined> }){
-    const selections: Record<string,string> = {};
-    Object.entries(payload.selections).forEach(([q, a]) => { if(a) selections[q] = a; });
+  async function finishExam(payload: { selections: Record<string, string | undefined> }) {
+    const selections: Record<string, string> = {};
+    Object.entries(payload.selections).forEach(([q, a]) => {
+      if (a) {
+        selections[q] = a;
+      }
+    });
     try {
       const data = await authedJson<ExamResult>(`${apiBase}/api/exams/attempts/${attemptId}/submit`, {
         method: 'POST',
-        headers: { 'Content-Type':'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ selections }),
         timeoutMs: 15000
       });
@@ -176,7 +191,7 @@ export default function App(){
     try {
       const data = await authedJson<ExamResult>(`${apiBase}/api/exams/attempts/${attempt}/submit`, {
         method: 'POST',
-        headers: { 'Content-Type':'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ selections: {} }),
         timeoutMs: 15000
       });
@@ -206,7 +221,9 @@ export default function App(){
       <Navbar
         isAuthed={isAuthed}
         isAdmin={role === 'ADMIN'}
+        user={user}
         onLogout={onLogout}
+        onSettings={() => navigate(ROUTES.settings)}
       />
 
       {toastError && (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,7 +33,6 @@ export default function App() {
   const [minutes, setMinutes] = useState(20);
   const [attemptId, setAttemptId] = useState<string>('');
   const [token, setToken] = useState<string>(localStorage.getItem('ak_token') || '');
-  const [user, setUser] = useState<NavUser | null>(null);
   const [result, setResult] = useState<ExamResult | null>(null);
   const [activeAttemptId, setActiveAttemptId] = useState<string>(sessionStorage.getItem('akdmia.activeAttemptId') || '');
   const [toastError, setToastError] = useState<string>('');
@@ -44,21 +43,15 @@ export default function App() {
   }
 
   const isAuthed = useMemo(() => Boolean(token), [token]);
-  const role = useMemo(() => {
+  const { role, user } = useMemo<{ role: string | null; user: NavUser | null }>(() => {
     try {
-      if (!token) {
-        setUser(null);
-        return null;
-      }
+      if (!token) return { role: null, user: null };
       const payload = JSON.parse(atob(token.split('.')[1]));
       const email: string = payload.sub || '';
       const initials = deriveInitials(email);
-      const navUser: NavUser = { email, initials };
-      setUser(navUser);
-      return payload.role || null;
+      return { role: payload.role || null, user: { email, initials } };
     } catch {
-      setUser(null);
-      return null;
+      return { role: null, user: null };
     }
   }, [token]);
 
@@ -109,7 +102,6 @@ export default function App() {
     sessionStorage.removeItem('akdmia.activeAttemptId');
     setActiveAttemptId('');
     setToken('');
-    setUser(null);
     navigate(ROUTES.home);
   }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Navigate, Route, Routes, useNavigate, useLocation } from 'react-router-dom';
 import type { Question } from './components/ExamRunner';
 import Navbar from './components/Navbar';
-import { apiBase, apiAuthJson } from './api';
+import { apiAuthJson, getSubjects, startExam as apiStartExam, startRandomExam as apiStartRandomExam, submitExam } from './api';
 import type { Subject, ExamResult, ExamStartResponse, NavUser } from './types';
 import { timeoutMessage } from './utils/messages';
 import { deriveInitials } from './utils/format';
@@ -70,14 +70,14 @@ export default function App() {
       setSubjects([]);
       return Promise.resolve();
     }
-    return authedJson<Subject[]>(`${apiBase}/api/subjects`)
+    return getSubjects(token)
       .then(setSubjects)
       .catch(() => setSubjects([]));
   };
 
   useEffect(() => {
     refreshSubjects();
-  }, [token, apiBase]);
+  }, [token]);
 
   // Handle OAuth2 callback: extract token from URL query param
   useEffect(() => {
@@ -109,12 +109,7 @@ export default function App() {
   // timeoutMessage from utils
   async function startExam(cfg: { unitCounts: Record<string, number>; minutes: number; difficulty?: 'EASY' | 'MEDIUM' | 'HARD' }) {
     try {
-      const data = await authedJson<ExamStartResponse>(`${apiBase}/api/exams/attempts/start`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(cfg),
-        timeoutMs: 15000
-      });
+      const data = await apiStartExam(token, cfg);
       setAttemptId(data.attemptId);
       setMinutes(Math.round(data.totalTimeSeconds / 60));
       setQuestions(data.questions);
@@ -132,12 +127,7 @@ export default function App() {
 
   async function startRandomExam(cfg: { subjectId: string; count: number; minutes: number; difficulty?: 'EASY' | 'MEDIUM' | 'HARD' }) {
     try {
-      const data = await authedJson<ExamStartResponse>(`${apiBase}/api/exams/attempts/start-random`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(cfg),
-        timeoutMs: 15000
-      });
+      const data = await apiStartRandomExam(token, cfg);
       setAttemptId(data.attemptId);
       setMinutes(Math.round(data.totalTimeSeconds / 60));
       setQuestions(data.questions);
@@ -161,12 +151,7 @@ export default function App() {
       }
     });
     try {
-      const data = await authedJson<ExamResult>(`${apiBase}/api/exams/attempts/${attemptId}/submit`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ selections }),
-        timeoutMs: 15000
-      });
+      const data = await submitExam(token, attemptId, selections);
       sessionStorage.removeItem('akdmia.activeAttemptId');
       setActiveAttemptId('');
       setResult(data);
@@ -182,12 +167,7 @@ export default function App() {
 
   async function viewResult(attempt: string) {
     try {
-      const data = await authedJson<ExamResult>(`${apiBase}/api/exams/attempts/${attempt}/submit`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ selections: {} }),
-        timeoutMs: 15000
-      });
+      const data = await submitExam(token, attempt, {});
       if (activeAttemptId === attempt) {
         sessionStorage.removeItem('akdmia.activeAttemptId');
         setActiveAttemptId('');

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import FlashcardsStudyPage from './pages/FlashcardsStudyPage';
 import FlashcardsHistoryPage from './pages/FlashcardsHistoryPage';
 import FlashcardsExamineUnitPage from './pages/FlashcardsExamineUnitPage';
 import RagPage from './pages/RagPage';
+import ProfilePage from './pages/ProfilePage';
 import ProtectedRoute from './pages/ProtectedRoute';
 import { ROUTES } from './constants/routes';
 
@@ -215,6 +216,7 @@ export default function App() {
         isAdmin={role === 'ADMIN'}
         user={user}
         onLogout={onLogout}
+        onProfile={() => navigate(ROUTES.profile)}
         onSettings={() => navigate(ROUTES.settings)}
       />
 
@@ -292,6 +294,11 @@ export default function App() {
           <Route path={ROUTES.rag} element={
             <ProtectedRoute allow={isAuthed && role === 'ADMIN'}>
               <RagPage token={token} subjects={subjects} />
+            </ProtectedRoute>
+          } />
+          <Route path={ROUTES.profile} element={
+            <ProtectedRoute allow={isAuthed}>
+              <ProfilePage token={token} />
             </ProtectedRoute>
           } />
           <Route path={ROUTES.oauth2Callback} element={null} />

--- a/frontend/src/__tests__/Login.test.tsx
+++ b/frontend/src/__tests__/Login.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Login from '../components/Login';
+import { API_ROUTES } from '../constants/apiRoutes';
+
+vi.mock('react-router-dom', () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function makeResponse(body: unknown, status = 200, ok = true): Response {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe('Login component', () => {
+  const onToken = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it('renders the login form', () => {
+    render(<Login onToken={onToken} />);
+    expect(screen.getByPlaceholderText('tu@email.com')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('••••••••')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /entrar/i })).toBeInTheDocument();
+  });
+
+  it('shows validation error when email is empty', async () => {
+    render(<Login onToken={onToken} />);
+    fireEvent.click(screen.getByRole('button', { name: /entrar/i }));
+    await waitFor(() => {
+      expect(screen.getByText('El email es obligatorio')).toBeInTheDocument();
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error for invalid email', async () => {
+    render(<Login onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('tu@email.com'), {
+      target: { value: 'not-an-email' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /entrar/i }));
+    await waitFor(() => {
+      expect(screen.getByText('El email no es válido')).toBeInTheDocument();
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error when password is empty', async () => {
+    render(<Login onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('tu@email.com'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /entrar/i }));
+    await waitFor(() => {
+      expect(screen.getByText('La contraseña es obligatoria')).toBeInTheDocument();
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('calls onToken with accessToken on successful login', async () => {
+    mockFetch.mockResolvedValue(makeResponse({ accessToken: 'tok-123' }));
+
+    render(<Login onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('tu@email.com'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /entrar/i }));
+
+    await waitFor(() => {
+      expect(onToken).toHaveBeenCalledWith('tok-123');
+    });
+  });
+
+  it('uses API_ROUTES.auth.login endpoint', async () => {
+    mockFetch.mockResolvedValue(makeResponse({ accessToken: 'tok' }));
+
+    render(<Login onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('tu@email.com'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), {
+      target: { value: 'pass1234' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /entrar/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain(API_ROUTES.auth.login);
+    });
+  });
+
+  it('shows error message from server on failed login', async () => {
+    mockFetch.mockResolvedValue(makeResponse({ error: 'Credenciales incorrectas' }, 401, false));
+
+    render(<Login onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('tu@email.com'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), {
+      target: { value: 'wrongpass' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /entrar/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Credenciales incorrectas')).toBeInTheDocument();
+    });
+  });
+
+  it('shows default error when server returns no error message', async () => {
+    mockFetch.mockResolvedValue(makeResponse({}, 401, false));
+
+    render(<Login onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('tu@email.com'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), {
+      target: { value: 'wrongpass' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /entrar/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Credenciales inválidas')).toBeInTheDocument();
+    });
+  });
+
+  it('shows network error on fetch failure', async () => {
+    mockFetch.mockRejectedValue(new Error('network failure'));
+
+    render(<Login onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('tu@email.com'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), {
+      target: { value: 'pass1234' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /entrar/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('No se pudo conectar con el servidor')).toBeInTheDocument();
+    });
+  });
+
+  it('triggers login on Enter key in email field', async () => {
+    mockFetch.mockResolvedValue(makeResponse({ accessToken: 'tok' }));
+
+    render(<Login onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('tu@email.com'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), {
+      target: { value: 'pass1234' },
+    });
+    fireEvent.keyDown(screen.getByPlaceholderText('tu@email.com'), { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('triggers login on Enter key in password field', async () => {
+    mockFetch.mockResolvedValue(makeResponse({ accessToken: 'tok' }));
+
+    render(<Login onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('tu@email.com'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), {
+      target: { value: 'pass1234' },
+    });
+    fireEvent.keyDown(screen.getByPlaceholderText('••••••••'), { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('renders Google OAuth link with correct URL', () => {
+    render(<Login onToken={onToken} />);
+    const googleLink = screen.getByText('Continuar con Google').closest('a');
+    expect(googleLink).toHaveAttribute('href');
+    expect(googleLink?.getAttribute('href')).toContain(API_ROUTES.auth.oauthGoogle);
+  });
+
+  it('renders link to register page', () => {
+    render(<Login onToken={onToken} />);
+    expect(screen.getByText('Regístrate gratis')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/Navbar.test.tsx
+++ b/frontend/src/__tests__/Navbar.test.tsx
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import NavbarComponent from '../components/Navbar';
+import type { NavUser } from '../types';
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/' }),
+}));
+
+const mockUser: NavUser = {
+  email: 'user@example.com',
+  initials: 'US',
+};
+
+describe('Navbar — Desktop', () => {
+  const onLogout = vi.fn();
+  const onSettings = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows user menu trigger when isAuthed=true and user provided', () => {
+    render(
+      <NavbarComponent
+        isAuthed={true}
+        isAdmin={false}
+        user={mockUser}
+        onLogout={onLogout}
+        onSettings={onSettings}
+      />
+    );
+    expect(screen.getByRole('button', { name: /user menu/i })).toBeInTheDocument();
+  });
+
+  it('shows Login and Registro links when isAuthed=false', () => {
+    render(
+      <NavbarComponent
+        isAuthed={false}
+        isAdmin={false}
+        user={null}
+        onLogout={onLogout}
+        onSettings={onSettings}
+      />
+    );
+    // Both desktop and mobile render the links, so multiple elements are expected
+    expect(screen.getAllByText('Login').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Registro').length).toBeGreaterThan(0);
+  });
+
+  it('IA link is hidden for non-admin users', () => {
+    render(
+      <NavbarComponent
+        isAuthed={true}
+        isAdmin={false}
+        user={mockUser}
+        onLogout={onLogout}
+        onSettings={onSettings}
+      />
+    );
+    expect(screen.queryByText('IA')).not.toBeInTheDocument();
+  });
+
+  it('IA link is visible for admin users', () => {
+    render(
+      <NavbarComponent
+        isAuthed={true}
+        isAdmin={true}
+        user={mockUser}
+        onLogout={onLogout}
+        onSettings={onSettings}
+      />
+    );
+    expect(screen.getAllByText('IA').length).toBeGreaterThan(0);
+  });
+
+  it('desktop nav area does not contain standalone "Ajustes" or "Salir" buttons', () => {
+    const { container } = render(
+      <NavbarComponent
+        isAuthed={true}
+        isAdmin={false}
+        user={mockUser}
+        onLogout={onLogout}
+        onSettings={onSettings}
+      />
+    );
+    // Desktop nav links are inside the "hidden md:flex" div
+    const desktopNav = container.querySelector('.hidden.md\\:flex');
+    expect(desktopNav).not.toBeNull();
+    // "Ajustes" and "Salir" must NOT appear in the desktop nav area
+    expect(desktopNav!.textContent).not.toContain('Ajustes');
+    expect(desktopNav!.textContent).not.toContain('Salir');
+  });
+});
+
+describe('Navbar — theme toggle', () => {
+  const onLogout = vi.fn();
+  const onSettings = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('toggles dark class on documentElement when theme button is clicked', () => {
+    render(
+      <NavbarComponent
+        isAuthed={false}
+        isAdmin={false}
+        user={null}
+        onLogout={onLogout}
+        onSettings={onSettings}
+      />
+    );
+    const themeBtn = screen.getByRole('button', { name: /cambiar tema/i });
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    fireEvent.click(themeBtn);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    fireEvent.click(themeBtn);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+});
+
+describe('Navbar — navigation (go)', () => {
+  const onLogout = vi.fn();
+  const onSettings = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('clicking a nav link does not throw (exercises go function)', () => {
+    render(
+      <NavbarComponent
+        isAuthed={false}
+        isAdmin={false}
+        user={null}
+        onLogout={onLogout}
+        onSettings={onSettings}
+      />
+    );
+    // Click a Login button (which calls go(ROUTES.login) → navigate + setMenuOpen)
+    const loginBtns = screen.getAllByText('Login');
+    fireEvent.click(loginBtns[0]);
+    expect(loginBtns[0]).toBeInTheDocument();
+  });
+});
+
+describe('Navbar — Mobile', () => {
+  const onLogout = vi.fn();
+  const onSettings = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('divider between nav zone and user zone is present in the DOM when authed', () => {
+    const { container } = render(
+      <NavbarComponent
+        isAuthed={true}
+        isAdmin={false}
+        user={mockUser}
+        onLogout={onLogout}
+        onSettings={onSettings}
+      />
+    );
+    // The divider separating navigation and user zone in the mobile menu
+    const dividers = container.querySelectorAll('.border-t.border-secondary\\/15');
+    expect(dividers.length).toBeGreaterThan(0);
+  });
+
+  it('user email is displayed in the mobile user zone when authed', () => {
+    render(
+      <NavbarComponent
+        isAuthed={true}
+        isAdmin={false}
+        user={mockUser}
+        onLogout={onLogout}
+        onSettings={onSettings}
+      />
+    );
+    // Email appears in the mobile user zone (rendered in DOM even when menu closed)
+    expect(screen.getByText('user@example.com')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/Navbar.test.tsx
+++ b/frontend/src/__tests__/Navbar.test.tsx
@@ -15,6 +15,7 @@ const mockUser: NavUser = {
 
 describe('Navbar — Desktop', () => {
   const onLogout = vi.fn();
+  const onProfile = vi.fn();
   const onSettings = vi.fn();
 
   beforeEach(() => {
@@ -28,6 +29,7 @@ describe('Navbar — Desktop', () => {
         isAdmin={false}
         user={mockUser}
         onLogout={onLogout}
+        onProfile={onProfile}
         onSettings={onSettings}
       />
     );
@@ -41,6 +43,7 @@ describe('Navbar — Desktop', () => {
         isAdmin={false}
         user={null}
         onLogout={onLogout}
+        onProfile={onProfile}
         onSettings={onSettings}
       />
     );
@@ -56,6 +59,7 @@ describe('Navbar — Desktop', () => {
         isAdmin={false}
         user={mockUser}
         onLogout={onLogout}
+        onProfile={onProfile}
         onSettings={onSettings}
       />
     );
@@ -69,6 +73,7 @@ describe('Navbar — Desktop', () => {
         isAdmin={true}
         user={mockUser}
         onLogout={onLogout}
+        onProfile={onProfile}
         onSettings={onSettings}
       />
     );
@@ -82,6 +87,7 @@ describe('Navbar — Desktop', () => {
         isAdmin={false}
         user={mockUser}
         onLogout={onLogout}
+        onProfile={onProfile}
         onSettings={onSettings}
       />
     );
@@ -96,6 +102,7 @@ describe('Navbar — Desktop', () => {
 
 describe('Navbar — theme toggle', () => {
   const onLogout = vi.fn();
+  const onProfile = vi.fn();
   const onSettings = vi.fn();
 
   beforeEach(() => {
@@ -110,6 +117,7 @@ describe('Navbar — theme toggle', () => {
         isAdmin={false}
         user={null}
         onLogout={onLogout}
+        onProfile={onProfile}
         onSettings={onSettings}
       />
     );
@@ -124,6 +132,7 @@ describe('Navbar — theme toggle', () => {
 
 describe('Navbar — navigation (go)', () => {
   const onLogout = vi.fn();
+  const onProfile = vi.fn();
   const onSettings = vi.fn();
 
   beforeEach(() => {
@@ -137,6 +146,7 @@ describe('Navbar — navigation (go)', () => {
         isAdmin={false}
         user={null}
         onLogout={onLogout}
+        onProfile={onProfile}
         onSettings={onSettings}
       />
     );
@@ -149,6 +159,7 @@ describe('Navbar — navigation (go)', () => {
 
 describe('Navbar — Mobile', () => {
   const onLogout = vi.fn();
+  const onProfile = vi.fn();
   const onSettings = vi.fn();
 
   beforeEach(() => {
@@ -162,6 +173,7 @@ describe('Navbar — Mobile', () => {
         isAdmin={false}
         user={mockUser}
         onLogout={onLogout}
+        onProfile={onProfile}
         onSettings={onSettings}
       />
     );
@@ -177,6 +189,7 @@ describe('Navbar — Mobile', () => {
         isAdmin={false}
         user={mockUser}
         onLogout={onLogout}
+        onProfile={onProfile}
         onSettings={onSettings}
       />
     );

--- a/frontend/src/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ProfilePage from '../pages/ProfilePage';
+import * as api from '../api';
+import type { UserProfile } from '../types';
+
+vi.mock('../api', () => ({
+  getMyProfile: vi.fn(),
+  updateMyProfile: vi.fn(),
+}));
+
+const mockProfile: UserProfile = {
+  id: 'user-1',
+  email: 'test@example.com',
+  firstName: 'Ana',
+  lastName: 'García',
+};
+
+describe('ProfilePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders form with email, firstName and lastName fields', async () => {
+    vi.mocked(api.getMyProfile).mockResolvedValue(mockProfile);
+
+    render(<ProfilePage token="tok" />);
+
+    expect(screen.getByLabelText(/correo electrónico/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/nombre/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/apellidos/i)).toBeInTheDocument();
+  });
+
+  it('on mount calls getMyProfile and populates fields', async () => {
+    vi.mocked(api.getMyProfile).mockResolvedValue(mockProfile);
+
+    render(<ProfilePage token="tok" />);
+
+    await waitFor(() => {
+      expect(api.getMyProfile).toHaveBeenCalledWith('tok');
+    });
+
+    expect(screen.getByLabelText(/correo electrónico/i)).toHaveValue('test@example.com');
+    expect(screen.getByLabelText(/nombre/i)).toHaveValue('Ana');
+    expect(screen.getByLabelText(/apellidos/i)).toHaveValue('García');
+  });
+
+  it('submitting valid data calls updateMyProfile and shows success message', async () => {
+    vi.mocked(api.getMyProfile).mockResolvedValue(mockProfile);
+    vi.mocked(api.updateMyProfile).mockResolvedValue({ ...mockProfile, firstName: 'Ana', lastName: 'García' });
+
+    render(<ProfilePage token="tok" />);
+
+    await waitFor(() => expect(screen.getByLabelText(/nombre/i)).toHaveValue('Ana'));
+
+    fireEvent.change(screen.getByLabelText(/nombre/i), { target: { value: 'María' } });
+    fireEvent.submit(screen.getByRole('button', { name: /guardar cambios/i }).closest('form')!);
+
+    await waitFor(() => {
+      expect(api.updateMyProfile).toHaveBeenCalledWith('tok', {
+        firstName: 'María',
+        lastName: 'García',
+      });
+    });
+
+    expect(await screen.findByRole('status')).toHaveTextContent(/cambios guardados/i);
+  });
+
+  it('on API error from updateMyProfile shows error message', async () => {
+    vi.mocked(api.getMyProfile).mockResolvedValue(mockProfile);
+    vi.mocked(api.updateMyProfile).mockRejectedValue(new Error('api_error'));
+
+    render(<ProfilePage token="tok" />);
+
+    await waitFor(() => expect(screen.getByLabelText(/nombre/i)).toHaveValue('Ana'));
+
+    fireEvent.submit(screen.getByRole('button', { name: /guardar cambios/i }).closest('form')!);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/no se pudieron guardar/i);
+  });
+
+  it('on API error from getMyProfile shows error message', async () => {
+    vi.mocked(api.getMyProfile).mockRejectedValue(new Error('api_error'));
+
+    render(<ProfilePage token="tok" />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/no se pudo cargar el perfil/i);
+  });
+
+  it('button is disabled while loading', async () => {
+    // Never resolves so loading stays true
+    vi.mocked(api.getMyProfile).mockReturnValue(new Promise(() => {}));
+
+    render(<ProfilePage token="tok" />);
+
+    const btn = screen.getByRole('button', { name: /guardando/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('handles null firstName and lastName gracefully', async () => {
+    vi.mocked(api.getMyProfile).mockResolvedValue({ ...mockProfile, firstName: null, lastName: null });
+
+    render(<ProfilePage token="tok" />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/nombre/i)).toHaveValue('');
+      expect(screen.getByLabelText(/apellidos/i)).toHaveValue('');
+    });
+  });
+});

--- a/frontend/src/__tests__/Register.test.tsx
+++ b/frontend/src/__tests__/Register.test.tsx
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Register from '../components/Register';
+import { API_ROUTES } from '../constants/apiRoutes';
+
+vi.mock('react-router-dom', () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function makeResponse(body: unknown, status = 200, ok = true): Response {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe('Register component', () => {
+  const onToken = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it('renders the registration form', () => {
+    render(<Register onToken={onToken} />);
+    expect(screen.getByPlaceholderText('Email *')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Contraseña *')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Confirmar *')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /crear cuenta/i })).toBeInTheDocument();
+  });
+
+  it('shows error when email is empty', async () => {
+    render(<Register onToken={onToken} />);
+    fireEvent.click(screen.getByRole('button', { name: /crear cuenta/i }));
+    await waitFor(() => {
+      expect(screen.getByText('El email es obligatorio')).toBeInTheDocument();
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('shows error for invalid email format', async () => {
+    render(<Register onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('Email *'), {
+      target: { value: 'not-valid' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /crear cuenta/i }));
+    await waitFor(() => {
+      expect(screen.getByText('El email no es válido')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when password is empty', async () => {
+    render(<Register onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('Email *'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /crear cuenta/i }));
+    await waitFor(() => {
+      expect(screen.getByText('La contraseña es obligatoria')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when password is too short', async () => {
+    render(<Register onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('Email *'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Contraseña *'), {
+      target: { value: 'abc' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /crear cuenta/i }));
+    await waitFor(() => {
+      expect(screen.getByText('La contraseña debe tener al menos 8 caracteres')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when confirm password is empty', async () => {
+    render(<Register onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('Email *'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Contraseña *'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /crear cuenta/i }));
+    await waitFor(() => {
+      expect(screen.getByText('La confirmación de contraseña es obligatoria')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when passwords do not match', async () => {
+    render(<Register onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('Email *'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Contraseña *'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Confirmar *'), {
+      target: { value: 'different456' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /crear cuenta/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Las contraseñas no coinciden')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onToken on successful registration', async () => {
+    mockFetch.mockResolvedValue(makeResponse({ accessToken: 'new-tok' }));
+
+    render(<Register onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('Email *'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Contraseña *'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Confirmar *'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /crear cuenta/i }));
+
+    await waitFor(() => {
+      expect(onToken).toHaveBeenCalledWith('new-tok');
+    });
+  });
+
+  it('uses API_ROUTES.auth.register endpoint', async () => {
+    mockFetch.mockResolvedValue(makeResponse({ accessToken: 'tok' }));
+
+    render(<Register onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('Email *'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Contraseña *'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Confirmar *'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /crear cuenta/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain(API_ROUTES.auth.register);
+    });
+  });
+
+  it('shows server error message on failed registration', async () => {
+    mockFetch.mockResolvedValue(makeResponse({ error: 'Email ya registrado' }, 409, false));
+
+    render(<Register onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('Email *'), {
+      target: { value: 'existing@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Contraseña *'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Confirmar *'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /crear cuenta/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Email ya registrado')).toBeInTheDocument();
+    });
+  });
+
+  it('shows default error when server returns no error message', async () => {
+    mockFetch.mockResolvedValue(makeResponse({}, 500, false));
+
+    render(<Register onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('Email *'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Contraseña *'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Confirmar *'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /crear cuenta/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('No se pudo registrar')).toBeInTheDocument();
+    });
+  });
+
+  it('shows network error on fetch failure', async () => {
+    mockFetch.mockRejectedValue(new Error('network failure'));
+
+    render(<Register onToken={onToken} />);
+    fireEvent.change(screen.getByPlaceholderText('Email *'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Contraseña *'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Confirmar *'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /crear cuenta/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('No se pudo conectar con el servidor')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Google OAuth link with correct URL', () => {
+    render(<Register onToken={onToken} />);
+    const googleLink = screen.getByText('Continuar con Google').closest('a');
+    expect(googleLink?.getAttribute('href')).toContain(API_ROUTES.auth.oauthGoogle);
+  });
+
+  it('renders link to login page', () => {
+    render(<Register onToken={onToken} />);
+    expect(screen.getByText('Inicia sesión')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/UserMenuDropdown.test.tsx
+++ b/frontend/src/__tests__/UserMenuDropdown.test.tsx
@@ -15,6 +15,7 @@ const userWithAvatar: NavUser = {
 };
 
 describe('UserMenuDropdown', () => {
+  const onProfile = vi.fn();
   const onSettings = vi.fn();
   const onLogout = vi.fn();
 
@@ -27,6 +28,7 @@ describe('UserMenuDropdown', () => {
       <UserMenuDropdown
         user={baseUser}
         isAdmin={false}
+        onProfile={onProfile}
         onSettings={onSettings}
         onLogout={onLogout}
       />
@@ -41,6 +43,7 @@ describe('UserMenuDropdown', () => {
       <UserMenuDropdown
         user={userWithAvatar}
         isAdmin={false}
+        onProfile={onProfile}
         onSettings={onSettings}
         onLogout={onLogout}
       />
@@ -55,11 +58,13 @@ describe('UserMenuDropdown', () => {
       <UserMenuDropdown
         user={baseUser}
         isAdmin={false}
+        onProfile={onProfile}
         onSettings={onSettings}
         onLogout={onLogout}
       />
     );
     expect(screen.queryByText('Ajustes')).not.toBeInTheDocument();
+    expect(screen.queryByText('Mi perfil')).not.toBeInTheDocument();
     expect(screen.queryByText('Cerrar sesión')).not.toBeInTheDocument();
   });
 
@@ -68,11 +73,13 @@ describe('UserMenuDropdown', () => {
       <UserMenuDropdown
         user={baseUser}
         isAdmin={false}
+        onProfile={onProfile}
         onSettings={onSettings}
         onLogout={onLogout}
       />
     );
     fireEvent.click(screen.getByRole('button', { name: /user menu/i }));
+    expect(screen.getByText('Mi perfil')).toBeInTheDocument();
     expect(screen.getByText('Ajustes')).toBeInTheDocument();
     expect(screen.getByText('Cerrar sesión')).toBeInTheDocument();
     expect(screen.getByText('test@example.com')).toBeInTheDocument();
@@ -85,6 +92,7 @@ describe('UserMenuDropdown', () => {
         <UserMenuDropdown
           user={baseUser}
           isAdmin={false}
+          onProfile={onProfile}
           onSettings={onSettings}
           onLogout={onLogout}
         />
@@ -102,6 +110,7 @@ describe('UserMenuDropdown', () => {
       <UserMenuDropdown
         user={baseUser}
         isAdmin={false}
+        onProfile={onProfile}
         onSettings={onSettings}
         onLogout={onLogout}
       />
@@ -113,11 +122,29 @@ describe('UserMenuDropdown', () => {
     expect(screen.queryByText('Ajustes')).not.toBeInTheDocument();
   });
 
+  it('clicking "Mi perfil" calls onProfile and closes the panel', () => {
+    render(
+      <UserMenuDropdown
+        user={baseUser}
+        isAdmin={false}
+        onProfile={onProfile}
+        onSettings={onSettings}
+        onLogout={onLogout}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /user menu/i }));
+    fireEvent.click(screen.getByText('Mi perfil'));
+
+    expect(onProfile).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Mi perfil')).not.toBeInTheDocument();
+  });
+
   it('clicking "Ajustes" calls onSettings and closes the panel', () => {
     render(
       <UserMenuDropdown
         user={baseUser}
         isAdmin={false}
+        onProfile={onProfile}
         onSettings={onSettings}
         onLogout={onLogout}
       />
@@ -134,6 +161,7 @@ describe('UserMenuDropdown', () => {
       <UserMenuDropdown
         user={baseUser}
         isAdmin={false}
+        onProfile={onProfile}
         onSettings={onSettings}
         onLogout={onLogout}
       />

--- a/frontend/src/__tests__/UserMenuDropdown.test.tsx
+++ b/frontend/src/__tests__/UserMenuDropdown.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { UserMenuDropdown } from '../components/UserMenuDropdown';
+import type { NavUser } from '../types';
+
+const baseUser: NavUser = {
+  email: 'test@example.com',
+  initials: 'TE',
+};
+
+const userWithAvatar: NavUser = {
+  email: 'avatar@example.com',
+  initials: 'AV',
+  avatarUrl: 'https://example.com/avatar.png',
+};
+
+describe('UserMenuDropdown', () => {
+  const onSettings = vi.fn();
+  const onLogout = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders avatar initials when no avatarUrl provided', () => {
+    render(
+      <UserMenuDropdown
+        user={baseUser}
+        isAdmin={false}
+        onSettings={onSettings}
+        onLogout={onLogout}
+      />
+    );
+    const trigger = screen.getByRole('button', { name: /user menu/i });
+    expect(trigger).toHaveTextContent('TE');
+    expect(trigger.querySelector('img')).toBeNull();
+  });
+
+  it('renders <img> when avatarUrl is provided with correct alt attribute', () => {
+    render(
+      <UserMenuDropdown
+        user={userWithAvatar}
+        isAdmin={false}
+        onSettings={onSettings}
+        onLogout={onLogout}
+      />
+    );
+    const img = screen.getByRole('img', { name: 'AV' });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', 'https://example.com/avatar.png');
+  });
+
+  it('dropdown panel is NOT visible initially', () => {
+    render(
+      <UserMenuDropdown
+        user={baseUser}
+        isAdmin={false}
+        onSettings={onSettings}
+        onLogout={onLogout}
+      />
+    );
+    expect(screen.queryByText('Ajustes')).not.toBeInTheDocument();
+    expect(screen.queryByText('Cerrar sesión')).not.toBeInTheDocument();
+  });
+
+  it('clicking the trigger opens the panel', () => {
+    render(
+      <UserMenuDropdown
+        user={baseUser}
+        isAdmin={false}
+        onSettings={onSettings}
+        onLogout={onLogout}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /user menu/i }));
+    expect(screen.getByText('Ajustes')).toBeInTheDocument();
+    expect(screen.getByText('Cerrar sesión')).toBeInTheDocument();
+    expect(screen.getByText('test@example.com')).toBeInTheDocument();
+  });
+
+  it('clicking outside the dropdown closes it', () => {
+    render(
+      <div>
+        <div data-testid="outside">Outside</div>
+        <UserMenuDropdown
+          user={baseUser}
+          isAdmin={false}
+          onSettings={onSettings}
+          onLogout={onLogout}
+        />
+      </div>
+    );
+    fireEvent.click(screen.getByRole('button', { name: /user menu/i }));
+    expect(screen.getByText('Ajustes')).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+    expect(screen.queryByText('Ajustes')).not.toBeInTheDocument();
+  });
+
+  it('pressing Escape closes the panel', () => {
+    render(
+      <UserMenuDropdown
+        user={baseUser}
+        isAdmin={false}
+        onSettings={onSettings}
+        onLogout={onLogout}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /user menu/i }));
+    expect(screen.getByText('Ajustes')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByText('Ajustes')).not.toBeInTheDocument();
+  });
+
+  it('clicking "Ajustes" calls onSettings and closes the panel', () => {
+    render(
+      <UserMenuDropdown
+        user={baseUser}
+        isAdmin={false}
+        onSettings={onSettings}
+        onLogout={onLogout}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /user menu/i }));
+    fireEvent.click(screen.getByText('Ajustes'));
+
+    expect(onSettings).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Ajustes')).not.toBeInTheDocument();
+  });
+
+  it('clicking "Cerrar sesión" calls onLogout and closes the panel', () => {
+    render(
+      <UserMenuDropdown
+        user={baseUser}
+        isAdmin={false}
+        onSettings={onSettings}
+        onLogout={onLogout}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /user menu/i }));
+    fireEvent.click(screen.getByText('Cerrar sesión'));
+
+    expect(onLogout).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Cerrar sesión')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getMyProfile, updateMyProfile, apiAuthJson, apiJson } from '../api';
+import {
+  getMyProfile, updateMyProfile, apiAuthJson, apiJson, exportFlashcardsBySubject,
+  uploadSource, confirmIndex, getSources, generateQuiz, getDrafts, approveDraft,
+  rejectDraft, getUnitsForSubject, deleteSource
+} from '../api';
 
 // Mock global fetch
 const mockFetch = vi.fn();
@@ -147,5 +151,226 @@ describe('apiJson', () => {
     mockFetch.mockRejectedValue(abortErr);
 
     await expect(apiJson('http://localhost/data')).rejects.toMatchObject({ message: 'timeout', code: 'timeout' });
+  });
+});
+
+describe('apiAuthJson with timeoutMs', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clears timeout after successful response', async () => {
+    vi.useFakeTimers();
+    const clearSpy = vi.spyOn(window, 'clearTimeout');
+    mockFetch.mockResolvedValue(makeResponse({ data: 'ok' }));
+
+    const result = await apiAuthJson<{ data: string }>('http://localhost/test', 'token', { timeoutMs: 5000 });
+
+    expect(result).toEqual({ data: 'ok' });
+    expect(clearSpy).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});
+
+describe('RAG API functions', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('uploadSource posts FormData and returns IndexPreview', async () => {
+    const preview = { documentId: 'doc-1', units: [] };
+    mockFetch.mockResolvedValue(makeResponse(preview));
+
+    const file = new File(['content'], 'test.pdf', { type: 'application/pdf' });
+    const result = await uploadSource('token', file, 'subj-1');
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/sources');
+    expect(options.method).toBe('POST');
+    expect(options.headers.Authorization).toBe('Bearer token');
+    expect(result).toEqual(preview);
+  });
+
+  it('uploadSource throws api_error on failure', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 400, json: () => Promise.resolve({}) } as unknown as Response);
+
+    const file = new File([''], 'test.pdf');
+    await expect(uploadSource('token', file, 'subj-1')).rejects.toMatchObject({ message: 'api_error', status: 400 });
+  });
+
+  it('confirmIndex posts to confirm endpoint and returns result', async () => {
+    const result = { document: { id: 'doc-1' }, savedUnits: [] };
+    mockFetch.mockResolvedValue(makeResponse(result));
+
+    const res = await confirmIndex('token', 'doc-1', []);
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/sources/doc-1/confirm');
+    expect(options.method).toBe('POST');
+    expect(res).toEqual(result);
+  });
+
+  it('getSources returns list of sources', async () => {
+    const sources = [{ id: 'src-1', name: 'Document' }];
+    mockFetch.mockResolvedValue(makeResponse(sources));
+
+    const result = await getSources('token');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/sources');
+    expect(result).toEqual(sources);
+  });
+
+  it('getSources with subjectId appends query param', async () => {
+    mockFetch.mockResolvedValue(makeResponse([]));
+
+    await getSources('token', 'subj-1');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('subjectId=subj-1');
+  });
+
+  it('generateQuiz posts command and returns response', async () => {
+    const quizResponse = { quizId: 'q-1', questions: [] };
+    mockFetch.mockResolvedValue(makeResponse(quizResponse));
+
+    // generateQuiz uses timeoutMs internally; stub clearTimeout so it works in jsdom
+    const origClearTimeout = window.clearTimeout;
+    vi.stubGlobal('clearTimeout', vi.fn());
+
+    const result = await generateQuiz('token', { sourceId: 'src-1', count: 5 } as any);
+
+    vi.stubGlobal('clearTimeout', origClearTimeout);
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/ai/quizzes/generate');
+    expect(options.method).toBe('POST');
+    expect(result).toEqual(quizResponse);
+  });
+
+  it('getDrafts returns filtered drafts by sourceId', async () => {
+    const drafts = [{ id: 'd-1', status: 'PENDING' }];
+    mockFetch.mockResolvedValue(makeResponse(drafts));
+
+    const result = await getDrafts('token', 'src-1');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('sourceId=src-1');
+    expect(result).toEqual(drafts);
+  });
+
+  it('getDrafts appends status query param when provided', async () => {
+    mockFetch.mockResolvedValue(makeResponse([]));
+
+    await getDrafts('token', 'src-1', 'PENDING');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('status=PENDING');
+  });
+
+  it('approveDraft posts to approve endpoint', async () => {
+    const draft = { id: 'd-1', status: 'APPROVED' };
+    mockFetch.mockResolvedValue(makeResponse(draft));
+
+    const result = await approveDraft('token', 'd-1');
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/ai/drafts/d-1/approve');
+    expect(options.method).toBe('POST');
+    expect(result).toEqual(draft);
+  });
+
+  it('rejectDraft posts to reject endpoint', async () => {
+    const draft = { id: 'd-1', status: 'REJECTED' };
+    mockFetch.mockResolvedValue(makeResponse(draft));
+
+    const result = await rejectDraft('token', 'd-1');
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/ai/drafts/d-1/reject');
+    expect(options.method).toBe('POST');
+    expect(result).toEqual(draft);
+  });
+
+  it('getUnitsForSubject returns units list', async () => {
+    const units = [{ id: 'u-1', name: 'Unit 1' }];
+    mockFetch.mockResolvedValue(makeResponse(units));
+
+    const result = await getUnitsForSubject('token', 'subj-1');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/units?subjectId=subj-1');
+    expect(result).toEqual(units);
+  });
+
+  it('deleteSource sends DELETE request', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 204, text: () => Promise.resolve(''), json: () => Promise.resolve(undefined) } as unknown as Response);
+
+    await deleteSource('token', 'src-1');
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/sources/src-1');
+    expect(options.method).toBe('DELETE');
+  });
+});
+
+describe('exportFlashcardsBySubject', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('returns text content on success', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve('front,back\nHello,Hola\n'),
+    } as unknown as Response);
+
+    const result = await exportFlashcardsBySubject('my-token', 'subj-1', 'csv');
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('subjectId=subj-1');
+    expect(url).toContain('format=csv');
+    expect(options.headers.Authorization).toBe('Bearer my-token');
+    expect(result).toBe('front,back\nHello,Hola\n');
+  });
+
+  it('returns JSON text when format is json', async () => {
+    const jsonContent = '[{"front":"Hello","back":"Hola"}]';
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(jsonContent),
+    } as unknown as Response);
+
+    const result = await exportFlashcardsBySubject('token', 'subj-2', 'json');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('format=json');
+    expect(result).toBe(jsonContent);
+  });
+
+  it('throws with status when response is not ok', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+    } as unknown as Response);
+
+    await expect(exportFlashcardsBySubject('token', 'subj-3', 'csv')).rejects.toMatchObject({
+      message: 'api_error',
+      status: 403,
+    });
+  });
+
+  it('throws network error when fetch rejects', async () => {
+    mockFetch.mockRejectedValue(new Error('network failure'));
+
+    await expect(exportFlashcardsBySubject('token', 'subj-4', 'csv')).rejects.toThrow('network failure');
   });
 });

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getMyProfile, updateMyProfile, apiAuthJson, apiJson } from '../api';
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function makeResponse(body: unknown, status = 200, ok = true): Response {
+  return {
+    ok,
+    status,
+    text: () => Promise.resolve(body !== undefined ? JSON.stringify(body) : ''),
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe('getMyProfile', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('calls the correct endpoint with Authorization header and returns parsed profile', async () => {
+    const profile = { id: 'u1', email: 'a@b.com', firstName: 'Ana', lastName: 'García' };
+    mockFetch.mockResolvedValue(makeResponse(profile));
+
+    const result = await getMyProfile('my-token');
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/v1/users/me');
+    expect(options.headers.Authorization).toBe('Bearer my-token');
+    expect(result).toEqual(profile);
+  });
+
+  it('throws api_error when response is not ok', async () => {
+    mockFetch.mockResolvedValue(makeResponse({ message: 'Unauthorized' }, 401, false));
+
+    await expect(getMyProfile('bad-token')).rejects.toMatchObject({ message: 'api_error', status: 401 });
+  });
+});
+
+describe('updateMyProfile', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('sends PATCH with JSON body and returns updated profile', async () => {
+    const updated = { id: 'u1', email: 'a@b.com', firstName: 'María', lastName: 'García' };
+    mockFetch.mockResolvedValue(makeResponse(updated));
+
+    const result = await updateMyProfile('tok', { firstName: 'María', lastName: 'García' });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/v1/users/me');
+    expect(options.method).toBe('PATCH');
+    expect(options.headers['Content-Type']).toBe('application/json');
+    expect(options.headers.Authorization).toBe('Bearer tok');
+    expect(JSON.parse(options.body)).toEqual({ firstName: 'María', lastName: 'García' });
+    expect(result).toEqual(updated);
+  });
+
+  it('sends null values when firstName and lastName are null', async () => {
+    const updated = { id: 'u1', email: 'a@b.com', firstName: null, lastName: null };
+    mockFetch.mockResolvedValue(makeResponse(updated));
+
+    await updateMyProfile('tok', { firstName: null, lastName: null });
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(JSON.parse(options.body)).toEqual({ firstName: null, lastName: null });
+  });
+
+  it('throws api_error on non-ok response', async () => {
+    mockFetch.mockResolvedValue(makeResponse({ message: 'Bad Request' }, 400, false));
+
+    await expect(updateMyProfile('tok', { firstName: null, lastName: null })).rejects.toMatchObject({
+      message: 'api_error',
+      status: 400,
+    });
+  });
+});
+
+describe('apiAuthJson', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('returns undefined for 204 response', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 204, text: () => Promise.resolve(''), json: () => Promise.resolve(undefined) } as unknown as Response);
+
+    const result = await apiAuthJson<void>('http://localhost/test', 'token');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when response body is empty', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve(''), json: () => Promise.resolve(undefined) } as unknown as Response);
+
+    const result = await apiAuthJson<void>('http://localhost/test', 'token');
+    expect(result).toBeUndefined();
+  });
+
+  it('rethrows non-AbortError errors', async () => {
+    mockFetch.mockRejectedValue(new Error('network failure'));
+
+    await expect(apiAuthJson('http://localhost/test', 'token')).rejects.toThrow('network failure');
+  });
+
+  it('converts AbortError to timeout error', async () => {
+    const abortErr = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    mockFetch.mockRejectedValue(abortErr);
+
+    await expect(apiAuthJson('http://localhost/test', 'token')).rejects.toMatchObject({
+      message: 'timeout',
+      code: 'timeout',
+    });
+  });
+});
+
+describe('apiJson', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('fetches and returns parsed JSON', async () => {
+    const data = { foo: 'bar' };
+    mockFetch.mockResolvedValue(makeResponse(data));
+
+    const result = await apiJson<{ foo: string }>('http://localhost/data');
+    expect(result).toEqual(data);
+  });
+
+  it('throws api_error on non-ok response', async () => {
+    mockFetch.mockResolvedValue(makeResponse({ error: 'not found' }, 404, false));
+
+    await expect(apiJson('http://localhost/data')).rejects.toMatchObject({ message: 'api_error', status: 404 });
+  });
+
+  it('returns undefined for 204 response', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 204, text: () => Promise.resolve(''), json: () => Promise.resolve(undefined) } as unknown as Response);
+
+    const result = await apiJson<void>('http://localhost/data');
+    expect(result).toBeUndefined();
+  });
+
+  it('converts AbortError to timeout error', async () => {
+    const abortErr = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    mockFetch.mockRejectedValue(abortErr);
+
+    await expect(apiJson('http://localhost/data')).rejects.toMatchObject({ message: 'timeout', code: 'timeout' });
+  });
+});

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -4,6 +4,7 @@ import {
   uploadSource, confirmIndex, getSources, generateQuiz, getDrafts, approveDraft,
   rejectDraft, getUnitsForSubject, deleteSource
 } from '../api';
+import { API_ROUTES } from '../constants/apiRoutes';
 
 // Mock global fetch
 const mockFetch = vi.fn();
@@ -31,7 +32,7 @@ describe('getMyProfile', () => {
 
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, options] = mockFetch.mock.calls[0];
-    expect(url).toContain('/api/v1/users/me');
+    expect(url).toContain(API_ROUTES.users.me);
     expect(options.headers.Authorization).toBe('Bearer my-token');
     expect(result).toEqual(profile);
   });
@@ -56,7 +57,7 @@ describe('updateMyProfile', () => {
 
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, options] = mockFetch.mock.calls[0];
-    expect(url).toContain('/api/v1/users/me');
+    expect(url).toContain(API_ROUTES.users.me);
     expect(options.method).toBe('PATCH');
     expect(options.headers['Content-Type']).toBe('application/json');
     expect(options.headers.Authorization).toBe('Bearer tok');
@@ -190,7 +191,7 @@ describe('RAG API functions', () => {
 
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, options] = mockFetch.mock.calls[0];
-    expect(url).toContain('/api/sources');
+    expect(url).toContain(API_ROUTES.sources.root);
     expect(options.method).toBe('POST');
     expect(options.headers.Authorization).toBe('Bearer token');
     expect(result).toEqual(preview);
@@ -210,7 +211,7 @@ describe('RAG API functions', () => {
     const res = await confirmIndex('token', 'doc-1', []);
 
     const [url, options] = mockFetch.mock.calls[0];
-    expect(url).toContain('/api/sources/doc-1/confirm');
+    expect(url).toContain(API_ROUTES.sources.confirm('doc-1'));
     expect(options.method).toBe('POST');
     expect(res).toEqual(result);
   });
@@ -222,7 +223,7 @@ describe('RAG API functions', () => {
     const result = await getSources('token');
 
     const [url] = mockFetch.mock.calls[0];
-    expect(url).toContain('/api/sources');
+    expect(url).toContain(API_ROUTES.sources.root);
     expect(result).toEqual(sources);
   });
 
@@ -248,7 +249,7 @@ describe('RAG API functions', () => {
     vi.stubGlobal('clearTimeout', origClearTimeout);
 
     const [url, options] = mockFetch.mock.calls[0];
-    expect(url).toContain('/api/ai/quizzes/generate');
+    expect(url).toContain(API_ROUTES.ai.quizzesGenerate);
     expect(options.method).toBe('POST');
     expect(result).toEqual(quizResponse);
   });
@@ -280,7 +281,7 @@ describe('RAG API functions', () => {
     const result = await approveDraft('token', 'd-1');
 
     const [url, options] = mockFetch.mock.calls[0];
-    expect(url).toContain('/api/ai/drafts/d-1/approve');
+    expect(url).toContain(API_ROUTES.ai.draftApprove('d-1'));
     expect(options.method).toBe('POST');
     expect(result).toEqual(draft);
   });
@@ -292,7 +293,7 @@ describe('RAG API functions', () => {
     const result = await rejectDraft('token', 'd-1');
 
     const [url, options] = mockFetch.mock.calls[0];
-    expect(url).toContain('/api/ai/drafts/d-1/reject');
+    expect(url).toContain(API_ROUTES.ai.draftReject('d-1'));
     expect(options.method).toBe('POST');
     expect(result).toEqual(draft);
   });
@@ -304,7 +305,7 @@ describe('RAG API functions', () => {
     const result = await getUnitsForSubject('token', 'subj-1');
 
     const [url] = mockFetch.mock.calls[0];
-    expect(url).toContain('/api/units?subjectId=subj-1');
+    expect(url).toContain(`${API_ROUTES.units.root}?subjectId=subj-1`);
     expect(result).toEqual(units);
   });
 
@@ -314,7 +315,7 @@ describe('RAG API functions', () => {
     await deleteSource('token', 'src-1');
 
     const [url, options] = mockFetch.mock.calls[0];
-    expect(url).toContain('/api/sources/src-1');
+    expect(url).toContain(API_ROUTES.sources.single('src-1'));
     expect(options.method).toBe('DELETE');
   });
 });
@@ -335,7 +336,7 @@ describe('exportFlashcardsBySubject', () => {
 
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, options] = mockFetch.mock.calls[0];
-    expect(url).toContain('subjectId=subj-1');
+    expect(url).toContain(`${API_ROUTES.flashcards.export}?subjectId=subj-1`);
     expect(url).toContain('format=csv');
     expect(options.headers.Authorization).toBe('Bearer my-token');
     expect(result).toBe('front,back\nHello,Hola\n');

--- a/frontend/src/__tests__/apiRoutes.test.ts
+++ b/frontend/src/__tests__/apiRoutes.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect } from 'vitest';
+import { API_ROUTES } from '../constants/apiRoutes';
+
+function hasNoTrailingSlash(path: string) {
+  return !path.endsWith('/');
+}
+
+function hasNoDoubleSlash(path: string) {
+  return !path.includes('//');
+}
+
+describe('API_ROUTES — static routes', () => {
+  const staticRoutes: [string, string][] = [
+    ['auth.login', API_ROUTES.auth.login],
+    ['auth.register', API_ROUTES.auth.register],
+    ['auth.oauthGoogle', API_ROUTES.auth.oauthGoogle],
+    ['users.me', API_ROUTES.users.me],
+    ['subjects', API_ROUTES.subjects],
+    ['units.root', API_ROUTES.units.root],
+    ['units.availability', API_ROUTES.units.availability],
+    ['exams.attempts', API_ROUTES.exams.attempts],
+    ['exams.start', API_ROUTES.exams.start],
+    ['exams.startRandom', API_ROUTES.exams.startRandom],
+    ['flashcards.root', API_ROUTES.flashcards.root],
+    ['flashcards.unitsSummary', API_ROUTES.flashcards.unitsSummary],
+    ['flashcards.studyQueue', API_ROUTES.flashcards.studyQueue],
+    ['flashcards.studyNext', API_ROUTES.flashcards.studyNext],
+    ['flashcards.studyReview', API_ROUTES.flashcards.studyReview],
+    ['flashcards.history', API_ROUTES.flashcards.history],
+    ['flashcards.export', API_ROUTES.flashcards.export],
+    ['flashcards.import', API_ROUTES.flashcards.import],
+    ['sources.root', API_ROUTES.sources.root],
+    ['ai.quizzesGenerate', API_ROUTES.ai.quizzesGenerate],
+    ['ai.quizzesDrafts', API_ROUTES.ai.quizzesDrafts],
+    ['settings', API_ROUTES.settings],
+    ['admin.users', API_ROUTES.admin.users],
+    ['admin.subjects', API_ROUTES.admin.subjects],
+    ['admin.units', API_ROUTES.admin.units],
+    ['admin.questions', API_ROUTES.admin.questions],
+    ['admin.questionsExport', API_ROUTES.admin.questionsExport],
+    ['admin.questionsImport', API_ROUTES.admin.questionsImport],
+  ];
+
+  it.each(staticRoutes)('%s starts with /api', (_name, path) => {
+    expect(path.startsWith('/api')).toBe(true);
+  });
+
+  it.each(staticRoutes)('%s has no trailing slash', (_name, path) => {
+    expect(hasNoTrailingSlash(path)).toBe(true);
+  });
+
+  it.each(staticRoutes)('%s has no double slashes', (_name, path) => {
+    expect(hasNoDoubleSlash(path)).toBe(true);
+  });
+
+  it('auth.login resolves to /api/auth/login', () => {
+    expect(API_ROUTES.auth.login).toBe('/api/auth/login');
+  });
+
+  it('auth.register resolves to /api/auth/register', () => {
+    expect(API_ROUTES.auth.register).toBe('/api/auth/register');
+  });
+
+  it('auth.oauthGoogle resolves to /api/oauth2/authorization/google', () => {
+    expect(API_ROUTES.auth.oauthGoogle).toBe('/api/oauth2/authorization/google');
+  });
+
+  it('users.me resolves to /api/v1/users/me', () => {
+    expect(API_ROUTES.users.me).toBe('/api/v1/users/me');
+  });
+
+  it('subjects resolves to /api/subjects', () => {
+    expect(API_ROUTES.subjects).toBe('/api/subjects');
+  });
+
+  it('units.root resolves to /api/units', () => {
+    expect(API_ROUTES.units.root).toBe('/api/units');
+  });
+
+  it('units.availability resolves to /api/units/availability', () => {
+    expect(API_ROUTES.units.availability).toBe('/api/units/availability');
+  });
+
+  it('exams.attempts resolves to /api/exams/attempts', () => {
+    expect(API_ROUTES.exams.attempts).toBe('/api/exams/attempts');
+  });
+
+  it('exams.start resolves to /api/exams/attempts/start', () => {
+    expect(API_ROUTES.exams.start).toBe('/api/exams/attempts/start');
+  });
+
+  it('exams.startRandom resolves to /api/exams/attempts/start-random', () => {
+    expect(API_ROUTES.exams.startRandom).toBe('/api/exams/attempts/start-random');
+  });
+
+  it('flashcards.root resolves to /api/flashcards', () => {
+    expect(API_ROUTES.flashcards.root).toBe('/api/flashcards');
+  });
+
+  it('flashcards.unitsSummary resolves to /api/flashcards/units/summary', () => {
+    expect(API_ROUTES.flashcards.unitsSummary).toBe('/api/flashcards/units/summary');
+  });
+
+  it('flashcards.studyQueue resolves to /api/flashcards/study/queue', () => {
+    expect(API_ROUTES.flashcards.studyQueue).toBe('/api/flashcards/study/queue');
+  });
+
+  it('flashcards.studyNext resolves to /api/flashcards/study/next', () => {
+    expect(API_ROUTES.flashcards.studyNext).toBe('/api/flashcards/study/next');
+  });
+
+  it('flashcards.studyReview resolves to /api/flashcards/study/review', () => {
+    expect(API_ROUTES.flashcards.studyReview).toBe('/api/flashcards/study/review');
+  });
+
+  it('flashcards.history resolves to /api/flashcards/history', () => {
+    expect(API_ROUTES.flashcards.history).toBe('/api/flashcards/history');
+  });
+
+  it('flashcards.export resolves to /api/flashcards/export', () => {
+    expect(API_ROUTES.flashcards.export).toBe('/api/flashcards/export');
+  });
+
+  it('flashcards.import resolves to /api/flashcards/import', () => {
+    expect(API_ROUTES.flashcards.import).toBe('/api/flashcards/import');
+  });
+
+  it('sources.root resolves to /api/sources', () => {
+    expect(API_ROUTES.sources.root).toBe('/api/sources');
+  });
+
+  it('ai.quizzesGenerate resolves to /api/ai/quizzes/generate', () => {
+    expect(API_ROUTES.ai.quizzesGenerate).toBe('/api/ai/quizzes/generate');
+  });
+
+  it('ai.quizzesDrafts resolves to /api/ai/quizzes/drafts', () => {
+    expect(API_ROUTES.ai.quizzesDrafts).toBe('/api/ai/quizzes/drafts');
+  });
+
+  it('settings resolves to /api/settings', () => {
+    expect(API_ROUTES.settings).toBe('/api/settings');
+  });
+
+  it('admin.users resolves to /api/admin/users', () => {
+    expect(API_ROUTES.admin.users).toBe('/api/admin/users');
+  });
+
+  it('admin.subjects resolves to /api/admin/subjects', () => {
+    expect(API_ROUTES.admin.subjects).toBe('/api/admin/subjects');
+  });
+
+  it('admin.units resolves to /api/admin/units', () => {
+    expect(API_ROUTES.admin.units).toBe('/api/admin/units');
+  });
+
+  it('admin.questions resolves to /api/admin/questions', () => {
+    expect(API_ROUTES.admin.questions).toBe('/api/admin/questions');
+  });
+
+  it('admin.questionsExport resolves to /api/admin/questions/export', () => {
+    expect(API_ROUTES.admin.questionsExport).toBe('/api/admin/questions/export');
+  });
+
+  it('admin.questionsImport resolves to /api/admin/questions/import', () => {
+    expect(API_ROUTES.admin.questionsImport).toBe('/api/admin/questions/import');
+  });
+});
+
+describe('API_ROUTES — dynamic route builders', () => {
+  it('exams.attempt returns correct path', () => {
+    expect(API_ROUTES.exams.attempt('abc-123')).toBe('/api/exams/attempts/abc-123');
+  });
+
+  it('exams.answers returns correct path', () => {
+    expect(API_ROUTES.exams.answers('attempt-1', 'q-99')).toBe(
+      '/api/exams/attempts/attempt-1/answers/q-99'
+    );
+  });
+
+  it('exams.submit returns correct path', () => {
+    expect(API_ROUTES.exams.submit('attempt-42')).toBe('/api/exams/attempts/attempt-42/submit');
+  });
+
+  it('sources.confirm returns correct path', () => {
+    expect(API_ROUTES.sources.confirm('doc-1')).toBe('/api/sources/doc-1/confirm');
+  });
+
+  it('sources.single returns correct path', () => {
+    expect(API_ROUTES.sources.single('src-7')).toBe('/api/sources/src-7');
+  });
+
+  it('ai.draftApprove returns correct path', () => {
+    expect(API_ROUTES.ai.draftApprove('d-1')).toBe('/api/ai/drafts/d-1/approve');
+  });
+
+  it('ai.draftReject returns correct path', () => {
+    expect(API_ROUTES.ai.draftReject('d-1')).toBe('/api/ai/drafts/d-1/reject');
+  });
+
+  it('admin.user returns correct path', () => {
+    expect(API_ROUTES.admin.user('u-5')).toBe('/api/admin/users/u-5');
+  });
+
+  it('admin.subject returns correct path', () => {
+    expect(API_ROUTES.admin.subject('s-3')).toBe('/api/admin/subjects/s-3');
+  });
+
+  it('admin.unit returns correct path', () => {
+    expect(API_ROUTES.admin.unit('un-8')).toBe('/api/admin/units/un-8');
+  });
+
+  it('admin.question returns correct path', () => {
+    expect(API_ROUTES.admin.question('q-12')).toBe('/api/admin/questions/q-12');
+  });
+
+  describe('no trailing or double slashes in dynamic routes', () => {
+    const dynamicResults = [
+      API_ROUTES.exams.attempt('x'),
+      API_ROUTES.exams.answers('a', 'b'),
+      API_ROUTES.exams.submit('x'),
+      API_ROUTES.sources.confirm('x'),
+      API_ROUTES.sources.single('x'),
+      API_ROUTES.ai.draftApprove('x'),
+      API_ROUTES.ai.draftReject('x'),
+      API_ROUTES.admin.user('x'),
+      API_ROUTES.admin.subject('x'),
+      API_ROUTES.admin.unit('x'),
+      API_ROUTES.admin.question('x'),
+    ];
+
+    it.each(dynamicResults)('"%s" has no trailing slash', (path) => {
+      expect(hasNoTrailingSlash(path)).toBe(true);
+    });
+
+    it.each(dynamicResults)('"%s" has no double slashes', (path) => {
+      expect(hasNoDoubleSlash(path)).toBe(true);
+    });
+  });
+});

--- a/frontend/src/__tests__/flashcards/FlashcardImportModal.test.tsx
+++ b/frontend/src/__tests__/flashcards/FlashcardImportModal.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import FlashcardImportModal from '../../components/flashcards/FlashcardImportModal';
+import * as api from '../../api';
+
+vi.mock('../../api', async (importOriginal) => {
+  const actual = await importOriginal<typeof api>();
+  return {
+    ...actual,
+    getSubjects: vi.fn(),
+    getUnitsForSubject: vi.fn(),
+    importFlashcards: vi.fn(),
+  };
+});
+
+const mockSubjects = [
+  { id: 'subj-1', name: 'Matemáticas', description: 'Álgebra' },
+  { id: 'subj-2', name: 'Física', description: 'Mecánica' },
+];
+
+const mockUnits = [
+  { id: 'unit-1', name: 'Álgebra' },
+  { id: 'unit-2', name: 'Geometría' },
+];
+
+describe('FlashcardImportModal', () => {
+  const onClose = vi.fn();
+  const onImported = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.getSubjects).mockResolvedValue(mockSubjects as any);
+    vi.mocked(api.getUnitsForSubject).mockResolvedValue(mockUnits);
+  });
+
+  it('renders the modal with subject and unit selectors', async () => {
+    render(<FlashcardImportModal token="test-token" onClose={onClose} onImported={onImported} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Importar flashcards')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Materia')).toBeInTheDocument();
+    expect(screen.getByText('Mazo (unidad destino)')).toBeInTheDocument();
+  });
+
+  it('loads subjects on mount', async () => {
+    render(<FlashcardImportModal token="test-token" onClose={onClose} onImported={onImported} />);
+
+    await waitFor(() => {
+      expect(vi.mocked(api.getSubjects)).toHaveBeenCalledWith('test-token');
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Matemáticas')).toBeInTheDocument();
+    });
+  });
+
+  it('loads units when subject is selected', async () => {
+    render(<FlashcardImportModal token="test-token" onClose={onClose} onImported={onImported} />);
+
+    await waitFor(() => {
+      expect(vi.mocked(api.getUnitsForSubject)).toHaveBeenCalledWith('test-token', 'subj-1');
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Álgebra')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onClose when cancel button is clicked', async () => {
+    render(<FlashcardImportModal token="test-token" onClose={onClose} onImported={onImported} />);
+
+    await waitFor(() => screen.getByText('Cancelar'));
+    fireEvent.click(screen.getByText('Cancelar'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when X button is clicked', async () => {
+    render(<FlashcardImportModal token="test-token" onClose={onClose} onImported={onImported} />);
+
+    await waitFor(() => screen.getByText('Importar flashcards'));
+    fireEvent.click(screen.getByText('✕'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when clicking backdrop', async () => {
+    render(<FlashcardImportModal token="test-token" onClose={onClose} onImported={onImported} />);
+
+    await waitFor(() => screen.getByText('Importar flashcards'));
+    const backdrop = document.querySelector('.fixed.inset-0') as HTMLElement;
+    // Simulate click on the backdrop itself (not the inner modal)
+    fireEvent.click(backdrop);
+    // backdrop click only triggers when target === currentTarget; test that the handler exists
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('shows error when import is submitted without a file', async () => {
+    render(<FlashcardImportModal token="test-token" onClose={onClose} onImported={onImported} />);
+
+    await waitFor(() => screen.getByText('Importar'));
+    fireEvent.click(screen.getByText('Importar'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Selecciona un archivo para importar.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows CSV format description', async () => {
+    render(<FlashcardImportModal token="test-token" onClose={onClose} onImported={onImported} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Columnas: front,back/)).toBeInTheDocument();
+    });
+  });
+
+  it('switches to JSON format when JSON button is clicked', async () => {
+    render(<FlashcardImportModal token="test-token" onClose={onClose} onImported={onImported} />);
+
+    await waitFor(() => screen.getByText('JSON'));
+    fireEvent.click(screen.getByText('JSON'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Array JSON/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when subjects fail to load', async () => {
+    vi.mocked(api.getSubjects).mockRejectedValue(new Error('network error'));
+
+    render(<FlashcardImportModal token="test-token" onClose={onClose} onImported={onImported} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No se pudieron cargar las materias.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows import result after successful import', async () => {
+    vi.mocked(api.getSubjects).mockResolvedValue(mockSubjects as any);
+    vi.mocked(api.getUnitsForSubject).mockResolvedValue(mockUnits);
+    vi.mocked(api.importFlashcards).mockResolvedValue({ imported: 5, skipped: 1, errors: [] });
+
+    render(<FlashcardImportModal token="test-token" onClose={onClose} onImported={onImported} />);
+
+    await waitFor(() => screen.getByText('Importar'));
+
+    // Simulate file upload
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['front,back\nHello,Hola'], 'test.csv', { type: 'text/csv' }); file.text = () => Promise.resolve('front,back\nHello,Hola');
+    Object.defineProperty(fileInput, 'files', { value: [file], writable: false });
+    fireEvent.change(fileInput);
+
+    fireEvent.click(screen.getByText('Importar'));
+
+    await waitFor(() => {
+      expect(screen.getByText('5 importadas · 1 omitidas')).toBeInTheDocument();
+    });
+    expect(onImported).toHaveBeenCalledOnce();
+  });
+
+  it('shows error message when import throws', async () => {
+    vi.mocked(api.importFlashcards).mockRejectedValue(new Error('Error 400'));
+
+    render(<FlashcardImportModal token="test-token" onClose={onClose} onImported={onImported} />);
+
+    await waitFor(() => screen.getByText('Importar'));
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['bad data'], 'test.csv', { type: 'text/csv' }); file.text = () => Promise.resolve('bad data');
+    Object.defineProperty(fileInput, 'files', { value: [file], writable: false });
+    fireEvent.change(fileInput);
+
+    fireEvent.click(screen.getByText('Importar'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Error 400')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onClose from result state when Cerrar is clicked', async () => {
+    vi.mocked(api.importFlashcards).mockResolvedValue({ imported: 3, skipped: 0, errors: [] });
+
+    render(<FlashcardImportModal token="test-token" onClose={onClose} onImported={onImported} />);
+
+    await waitFor(() => screen.getByText('Importar'));
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['front,back\nA,B'], 'test.csv', { type: 'text/csv' }); file.text = () => Promise.resolve('front,back\nA,B');
+    Object.defineProperty(fileInput, 'files', { value: [file], writable: false });
+    fireEvent.change(fileInput);
+
+    fireEvent.click(screen.getByText('Importar'));
+
+    await waitFor(() => screen.getByText('3 importadas · 0 omitidas'));
+    fireEvent.click(screen.getByText('Cerrar'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/__tests__/flashcards/FlashcardsExamineUnitPage.test.tsx
+++ b/frontend/src/__tests__/flashcards/FlashcardsExamineUnitPage.test.tsx
@@ -13,6 +13,7 @@ vi.mock('../../api', async (importOriginal) => {
   return {
     ...actual,
     apiAuthJson: vi.fn(),
+    getFlashcardsByUnit: vi.fn(),
   };
 });
 
@@ -28,7 +29,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('shows skeleton while loading', () => {
-    vi.mocked(api.apiAuthJson).mockReturnValue(new Promise(() => {}));
+    vi.mocked(api.getFlashcardsByUnit).mockReturnValue(new Promise(() => {}));
 
     const { container } = render(<FlashcardsExamineUnitPage />);
 
@@ -37,7 +38,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('renders cards when loaded', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+    vi.mocked(api.getFlashcardsByUnit).mockResolvedValue(mockCards);
 
     render(<FlashcardsExamineUnitPage />);
 
@@ -47,7 +48,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('shows empty state with Volver and import CTA when no cards', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsByUnit).mockResolvedValue([]);
 
     render(<FlashcardsExamineUnitPage />);
 
@@ -60,7 +61,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('shows error state on API failure', async () => {
-    vi.mocked(api.apiAuthJson).mockRejectedValue(new Error('api_error'));
+    vi.mocked(api.getFlashcardsByUnit).mockRejectedValue(new Error('api_error'));
 
     render(<FlashcardsExamineUnitPage />);
 
@@ -70,7 +71,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('flips card when clicked to show back, and again to show front', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+    vi.mocked(api.getFlashcardsByUnit).mockResolvedValue(mockCards);
 
     render(<FlashcardsExamineUnitPage />);
 
@@ -96,7 +97,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('navigates to next card when Siguiente is clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+    vi.mocked(api.getFlashcardsByUnit).mockResolvedValue(mockCards);
 
     render(<FlashcardsExamineUnitPage />);
 
@@ -110,7 +111,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('navigates to previous card when Anterior is clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+    vi.mocked(api.getFlashcardsByUnit).mockResolvedValue(mockCards);
 
     render(<FlashcardsExamineUnitPage />);
 
@@ -126,7 +127,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('disables Anterior button on first card', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+    vi.mocked(api.getFlashcardsByUnit).mockResolvedValue(mockCards);
 
     render(<FlashcardsExamineUnitPage />);
 
@@ -137,7 +138,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('disables Siguiente button on last card', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+    vi.mocked(api.getFlashcardsByUnit).mockResolvedValue(mockCards);
 
     render(<FlashcardsExamineUnitPage />);
 
@@ -150,7 +151,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('resets flip state when navigating to next card', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+    vi.mocked(api.getFlashcardsByUnit).mockResolvedValue(mockCards);
 
     render(<FlashcardsExamineUnitPage />);
 

--- a/frontend/src/__tests__/flashcards/FlashcardsExamineUnitPage.test.tsx
+++ b/frontend/src/__tests__/flashcards/FlashcardsExamineUnitPage.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import FlashcardsExamineUnitPage from '../../pages/FlashcardsExamineUnitPage';
+import * as api from '../../api';
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useSearchParams: () => [new URLSearchParams('unitId=unit-1')],
+}));
+
+vi.mock('../../api', async (importOriginal) => {
+  const actual = await importOriginal<typeof api>();
+  return {
+    ...actual,
+    apiAuthJson: vi.fn(),
+  };
+});
+
+const mockCards = [
+  { id: 'card-1', unitId: 'unit-1', front: '¿Qué es la derivada?', back: 'Tasa de cambio instantánea.' },
+  { id: 'card-2', unitId: 'unit-1', front: '¿Qué es la integral?', back: 'Área bajo la curva.' },
+];
+
+describe('FlashcardsExamineUnitPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.setItem('ak_token', 'test-token');
+  });
+
+  it('shows skeleton while loading', () => {
+    vi.mocked(api.apiAuthJson).mockReturnValue(new Promise(() => {}));
+
+    const { container } = render(<FlashcardsExamineUnitPage />);
+
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('renders cards when loaded', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state with Volver and import CTA when no cards', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No hay tarjetas en esta unidad.')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: /volver/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /importar flashcards/i })).toBeInTheDocument();
+  });
+
+  it('shows error state on API failure', async () => {
+    vi.mocked(api.apiAuthJson).mockRejectedValue(new Error('api_error'));
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No se pudieron cargar las tarjetas.')).toBeInTheDocument();
+    });
+  });
+
+  it('flips card when clicked to show back, and again to show front', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument());
+
+    // Initially shows front text
+    expect(screen.getByText('Toca para ver la respuesta')).toBeInTheDocument();
+
+    // Click card to flip
+    fireEvent.click(screen.getByText('¿Qué es la derivada?').closest('.cursor-pointer')!);
+
+    await waitFor(() => {
+      expect(screen.getByText('Tasa de cambio instantánea.')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Toca para ver la pregunta')).toBeInTheDocument();
+
+    // Click again to flip back
+    fireEvent.click(screen.getByText('Tasa de cambio instantánea.').closest('.cursor-pointer')!);
+
+    await waitFor(() => {
+      expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to next card when Siguiente is clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Siguiente →'));
+
+    await waitFor(() => {
+      expect(screen.getByText('¿Qué es la integral?')).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to previous card when Anterior is clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument());
+
+    // Go to second card
+    fireEvent.click(screen.getByText('Siguiente →'));
+    await waitFor(() => expect(screen.getByText('¿Qué es la integral?')).toBeInTheDocument());
+
+    // Go back
+    fireEvent.click(screen.getByText('← Anterior'));
+    await waitFor(() => expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument());
+  });
+
+  it('disables Anterior button on first card', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument());
+
+    const prevBtn = screen.getByText('← Anterior');
+    expect(prevBtn).toBeDisabled();
+  });
+
+  it('disables Siguiente button on last card', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Siguiente →'));
+    await waitFor(() => expect(screen.getByText('¿Qué es la integral?')).toBeInTheDocument());
+
+    expect(screen.getByText('Siguiente →')).toBeDisabled();
+  });
+
+  it('resets flip state when navigating to next card', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+
+    render(<FlashcardsExamineUnitPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Qué es la derivada?')).toBeInTheDocument());
+
+    // Flip current card
+    fireEvent.click(screen.getByText('¿Qué es la derivada?').closest('.cursor-pointer')!);
+    await waitFor(() => expect(screen.getByText('Tasa de cambio instantánea.')).toBeInTheDocument());
+
+    // Navigate to next — flip should reset
+    fireEvent.click(screen.getByText('Siguiente →'));
+    await waitFor(() => {
+      expect(screen.getByText('¿Qué es la integral?')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Toca para ver la respuesta')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/flashcards/FlashcardsPage.test.tsx
+++ b/frontend/src/__tests__/flashcards/FlashcardsPage.test.tsx
@@ -41,6 +41,9 @@ vi.mock('../../api', async (importOriginal) => {
     ...actual,
     apiAuthJson: vi.fn(),
     exportFlashcardsBySubject: vi.fn(),
+    exportFlashcardsByUnit: vi.fn(),
+    getFlashcardsUnitsSummary: vi.fn(),
+    getFlashcardsStudyQueue: vi.fn(),
   };
 });
 
@@ -74,7 +77,8 @@ describe('FlashcardsPage', () => {
   });
 
   it('shows empty state with import CTA when no subjects available', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
 
     render(<FlashcardsPage />);
 
@@ -88,7 +92,8 @@ describe('FlashcardsPage', () => {
   });
 
   it('opens import modal when empty state CTA is clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
 
     render(<FlashcardsPage />);
 
@@ -102,7 +107,8 @@ describe('FlashcardsPage', () => {
   });
 
   it('opens import modal when header Importar button is clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
 
     render(<FlashcardsPage />);
 
@@ -117,7 +123,8 @@ describe('FlashcardsPage', () => {
   });
 
   it('closes import modal when close is clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
 
     render(<FlashcardsPage />);
 
@@ -131,7 +138,8 @@ describe('FlashcardsPage', () => {
   });
 
   it('reloads units when onImported is called from modal', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
 
     render(<FlashcardsPage />);
 
@@ -140,12 +148,13 @@ describe('FlashcardsPage', () => {
     fireEvent.click(screen.getAllByRole('button', { name: /importar/i })[0]);
     fireEvent.click(screen.getByText('Importado'));
 
-    // apiAuthJson should be called again (reload)
-    expect(vi.mocked(api.apiAuthJson).mock.calls.length).toBeGreaterThan(2);
+    // getFlashcardsUnitsSummary should be called again (reload)
+    expect(vi.mocked(api.getFlashcardsUnitsSummary).mock.calls.length).toBeGreaterThan(1);
   });
 
   it('shows subjects when data loads', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue(mockUnits);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
 
     render(<FlashcardsPage />);
 
@@ -155,7 +164,8 @@ describe('FlashcardsPage', () => {
   });
 
   it('shows unit list when subject is selected', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue(mockUnits);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
 
     // We need SubjectCard to be real here — don't mock it
     render(<FlashcardsPage />);
@@ -172,7 +182,8 @@ describe('FlashcardsPage', () => {
   });
 
   it('shows back button and navigates back when clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue(mockUnits);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
 
     render(<FlashcardsPage />);
 
@@ -194,14 +205,16 @@ describe('FlashcardsPage', () => {
       useSearchParams: () => [new URLSearchParams('mode=study')],
     }));
 
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue(mockUnits);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
     render(<FlashcardsPage />);
 
     await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
   });
 
   it('navigates to study page tab when Estudio tab clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
 
     render(<FlashcardsPage />);
 
@@ -212,7 +225,8 @@ describe('FlashcardsPage', () => {
   });
 
   it('navigates to flashcards when Examinar tab clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
 
     render(<FlashcardsPage />);
 
@@ -223,7 +237,8 @@ describe('FlashcardsPage', () => {
   });
 
   it('navigates to history when Historial tab clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue([]);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
 
     render(<FlashcardsPage />);
 
@@ -234,8 +249,9 @@ describe('FlashcardsPage', () => {
   });
 
   it('shows export error banner when unit export fetch fails', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
-    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue(mockUnits);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
+    vi.mocked(api.exportFlashcardsByUnit).mockRejectedValue(Object.assign(new Error('api_error'), { status: 500 }));
 
     render(<FlashcardsPage />);
 
@@ -258,8 +274,9 @@ describe('FlashcardsPage', () => {
   });
 
   it('dismisses export error banner when close button is clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
-    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue(mockUnits);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
+    vi.mocked(api.exportFlashcardsByUnit).mockRejectedValue(Object.assign(new Error('api_error'), { status: 500 }));
 
     render(<FlashcardsPage />);
 
@@ -277,7 +294,8 @@ describe('FlashcardsPage', () => {
   });
 
   it('calls exportFlashcardsBySubject and creates download link on success', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue(mockUnits);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
     vi.mocked(api.exportFlashcardsBySubject).mockResolvedValue('front,back\nHello,Hola\n');
 
     // Spy on link.click without mocking createElement globally
@@ -308,7 +326,8 @@ describe('FlashcardsPage', () => {
   });
 
   it('shows subject export error banner when exportFlashcardsBySubject fails', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue(mockUnits);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
     vi.mocked(api.exportFlashcardsBySubject).mockRejectedValue(new Error('api_error'));
 
     render(<FlashcardsPage />);
@@ -326,7 +345,7 @@ describe('FlashcardsPage', () => {
   });
 
   it('filters subjects by search term', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue([
       ...mockUnits,
       {
         unitId: 'unit-3',
@@ -338,6 +357,7 @@ describe('FlashcardsPage', () => {
         dueCount: 0,
       },
     ]);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
 
     render(<FlashcardsPage />);
 
@@ -355,7 +375,8 @@ describe('FlashcardsPage', () => {
   });
 
   it('filters units by search term when subject is selected', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.getFlashcardsUnitsSummary).mockResolvedValue(mockUnits);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue({ new: 0, due: 0, learning: 0 });
 
     render(<FlashcardsPage />);
 

--- a/frontend/src/__tests__/flashcards/FlashcardsPage.test.tsx
+++ b/frontend/src/__tests__/flashcards/FlashcardsPage.test.tsx
@@ -1,0 +1,373 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import FlashcardsPage from '../../pages/FlashcardsPage';
+import * as api from '../../api';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useSearchParams: () => [new URLSearchParams()],
+}));
+
+vi.mock('../../components/flashcards/FlashcardImportModal', () => ({
+  default: ({ onClose, onImported }: { onClose: () => void; onImported: () => void }) => (
+    <div data-testid="import-modal">
+      <button onClick={onClose}>Cerrar modal</button>
+      <button onClick={onImported}>Importado</button>
+    </div>
+  ),
+}));
+
+vi.mock('../../components/flashcards/FlashcardsTabs', () => ({
+  default: ({ onTab }: { onTab: (tab: string) => void }) => (
+    <div data-testid="flashcards-tabs">
+      <button onClick={() => onTab('estudio')}>Estudio</button>
+      <button onClick={() => onTab('examinar')}>Examinar</button>
+      <button onClick={() => onTab('historial')}>Historial</button>
+    </div>
+  ),
+}));
+
+vi.mock('../../components/flashcards/SearchInput', () => ({
+  default: ({ onChange }: { onChange: (v: string) => void }) => (
+    <input data-testid="search-input" onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+vi.mock('../../api', async (importOriginal) => {
+  const actual = await importOriginal<typeof api>();
+  return {
+    ...actual,
+    apiAuthJson: vi.fn(),
+    exportFlashcardsBySubject: vi.fn(),
+  };
+});
+
+const mockUnits = [
+  {
+    unitId: 'unit-1',
+    unitName: 'Álgebra',
+    subjectId: 'subj-1',
+    subjectName: 'Matemáticas',
+    newCount: 3,
+    reviewCount: 2,
+    dueCount: 1,
+  },
+  {
+    unitId: 'unit-2',
+    unitName: 'Trigonometría',
+    subjectId: 'subj-1',
+    subjectName: 'Matemáticas',
+    newCount: 1,
+    reviewCount: 0,
+    dueCount: 0,
+  },
+];
+
+describe('FlashcardsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.setItem('ak_token', 'test-token');
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:test');
+    globalThis.URL.revokeObjectURL = vi.fn();
+  });
+
+  it('shows empty state with import CTA when no subjects available', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No hay materias disponibles.')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('button', { name: /importar flashcards/i })
+    ).toBeInTheDocument();
+  });
+
+  it('opens import modal when empty state CTA is clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No hay materias disponibles.')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /importar flashcards/i }));
+
+    expect(screen.getByTestId('import-modal')).toBeInTheDocument();
+  });
+
+  it('opens import modal when header Importar button is clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No hay materias disponibles.')).toBeInTheDocument();
+    });
+
+    const importButtons = screen.getAllByRole('button', { name: /importar/i });
+    fireEvent.click(importButtons[0]);
+
+    expect(screen.getByTestId('import-modal')).toBeInTheDocument();
+  });
+
+  it('closes import modal when close is clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('No hay materias disponibles.')).toBeInTheDocument());
+
+    fireEvent.click(screen.getAllByRole('button', { name: /importar/i })[0]);
+    expect(screen.getByTestId('import-modal')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Cerrar modal'));
+    expect(screen.queryByTestId('import-modal')).not.toBeInTheDocument();
+  });
+
+  it('reloads units when onImported is called from modal', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('No hay materias disponibles.')).toBeInTheDocument());
+
+    fireEvent.click(screen.getAllByRole('button', { name: /importar/i })[0]);
+    fireEvent.click(screen.getByText('Importado'));
+
+    // apiAuthJson should be called again (reload)
+    expect(vi.mocked(api.apiAuthJson).mock.calls.length).toBeGreaterThan(2);
+  });
+
+  it('shows subjects when data loads', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Matemáticas')).toBeInTheDocument();
+    });
+  });
+
+  it('shows unit list when subject is selected', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+
+    // We need SubjectCard to be real here — don't mock it
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+
+    // Click on the subject button (the main button inside SubjectCard)
+    fireEvent.click(screen.getByText('Matemáticas'));
+
+    // UnitList should now show the units for the selected subject
+    await waitFor(() => {
+      expect(screen.getByText('Álgebra')).toBeInTheDocument();
+    });
+  });
+
+  it('shows back button and navigates back when clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Matemáticas'));
+
+    await waitFor(() => expect(screen.getByText('Álgebra')).toBeInTheDocument());
+
+    const backButton = screen.getByRole('button', { name: /volver a materias/i });
+    fireEvent.click(backButton);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+    expect(screen.queryByText('Álgebra')).not.toBeInTheDocument();
+  });
+
+  it('navigates to study page when unit clicked in study mode', async () => {
+    vi.mock('react-router-dom', () => ({
+      useNavigate: () => mockNavigate,
+      useSearchParams: () => [new URLSearchParams('mode=study')],
+    }));
+
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+  });
+
+  it('navigates to study page tab when Estudio tab clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByTestId('flashcards-tabs')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Estudio'));
+    expect(mockNavigate).toHaveBeenCalledWith('/flashcards?mode=study');
+  });
+
+  it('navigates to flashcards when Examinar tab clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByTestId('flashcards-tabs')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Examinar'));
+    expect(mockNavigate).toHaveBeenCalledWith('/flashcards');
+  });
+
+  it('navigates to history when Historial tab clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByTestId('flashcards-tabs')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Historial'));
+    expect(mockNavigate).toHaveBeenCalledWith('/flashcards/history');
+  });
+
+  it('shows export error banner when unit export fetch fails', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+
+    // Select subject to show units
+    fireEvent.click(screen.getByText('Matemáticas'));
+
+    await waitFor(() => expect(screen.getByText('Álgebra')).toBeInTheDocument());
+
+    // Click CSV export button in UnitCard
+    const csvButtons = screen.getAllByTitle('Exportar CSV');
+    fireEvent.click(csvButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/no se pudo exportar/i);
+  });
+
+  it('dismisses export error banner when close button is clicked', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Matemáticas'));
+    await waitFor(() => expect(screen.getByText('Álgebra')).toBeInTheDocument());
+
+    const csvButtons = screen.getAllByTitle('Exportar CSV');
+    fireEvent.click(csvButtons[0]);
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /cerrar error/i }));
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('calls exportFlashcardsBySubject and creates download link on success', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.exportFlashcardsBySubject).mockResolvedValue('front,back\nHello,Hola\n');
+
+    // Spy on link.click without mocking createElement globally
+    const realCreateElement = document.createElement.bind(document);
+    const clickSpy = vi.fn();
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string, ...args: any[]) => {
+      const el = realCreateElement(tag, ...args);
+      if (tag === 'a') {
+        vi.spyOn(el as HTMLAnchorElement, 'click').mockImplementation(clickSpy);
+      }
+      return el;
+    });
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+
+    // Click CSV export on the SubjectCard
+    const csvButtons = screen.getAllByTitle('Exportar CSV');
+    fireEvent.click(csvButtons[0]);
+
+    await waitFor(() => {
+      expect(api.exportFlashcardsBySubject).toHaveBeenCalledWith('test-token', 'subj-1', 'csv');
+    });
+
+    expect(clickSpy).toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it('shows subject export error banner when exportFlashcardsBySubject fails', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.exportFlashcardsBySubject).mockRejectedValue(new Error('api_error'));
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+
+    const csvButtons = screen.getAllByTitle('Exportar CSV');
+    fireEvent.click(csvButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/no se pudo exportar la materia/i);
+  });
+
+  it('filters subjects by search term', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue([
+      ...mockUnits,
+      {
+        unitId: 'unit-3',
+        unitName: 'Historia Medieval',
+        subjectId: 'subj-2',
+        subjectName: 'Historia',
+        newCount: 0,
+        reviewCount: 0,
+        dueCount: 0,
+      },
+    ]);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Matemáticas')).toBeInTheDocument();
+      expect(screen.getByText('Historia')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('search-input'), { target: { value: 'histo' } });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Matemáticas')).not.toBeInTheDocument();
+      expect(screen.getByText('Historia')).toBeInTheDocument();
+    });
+  });
+
+  it('filters units by search term when subject is selected', async () => {
+    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+
+    render(<FlashcardsPage />);
+
+    await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Matemáticas'));
+    await waitFor(() => expect(screen.getByText('Álgebra')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('search-input'), { target: { value: 'álge' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Álgebra')).toBeInTheDocument();
+      expect(screen.queryByText('Trigonometría')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/__tests__/flashcards/FlashcardsStudyPage.test.tsx
+++ b/frontend/src/__tests__/flashcards/FlashcardsStudyPage.test.tsx
@@ -19,6 +19,9 @@ vi.mock('../../api', async (importOriginal) => {
   return {
     ...actual,
     apiAuthJson: vi.fn(),
+    getFlashcardsStudyQueue: vi.fn(),
+    getFlashcardsStudyNext: vi.fn(),
+    reviewFlashcard: vi.fn(),
   };
 });
 
@@ -39,7 +42,8 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('shows skeleton while loading', () => {
-    vi.mocked(api.apiAuthJson).mockReturnValue(new Promise(() => {}));
+    vi.mocked(api.getFlashcardsStudyQueue).mockReturnValue(new Promise(() => {}));
+    vi.mocked(api.getFlashcardsStudyNext).mockReturnValue(new Promise(() => {}));
 
     const { container } = render(<FlashcardsStudyPage />);
 
@@ -48,9 +52,8 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('renders study session when loaded', async () => {
-    vi.mocked(api.apiAuthJson)
-      .mockResolvedValueOnce(mockQueue) // fetchQueue
-      .mockResolvedValueOnce(mockItem); // fetchNext
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue(mockQueue);
+    vi.mocked(api.getFlashcardsStudyNext).mockResolvedValue(mockItem);
 
     render(<FlashcardsStudyPage />);
 
@@ -60,10 +63,9 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('shows inline review error without replacing session', async () => {
-    vi.mocked(api.apiAuthJson)
-      .mockResolvedValueOnce(mockQueue) // initial fetchQueue
-      .mockResolvedValueOnce(mockItem) // initial fetchNext
-      .mockRejectedValueOnce(new Error('api_error')); // POST review fails
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue(mockQueue);
+    vi.mocked(api.getFlashcardsStudyNext).mockResolvedValue(mockItem);
+    vi.mocked(api.reviewFlashcard).mockRejectedValue(new Error('api_error'));
 
     render(<FlashcardsStudyPage />);
 
@@ -94,10 +96,9 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('review error can be dismissed', async () => {
-    vi.mocked(api.apiAuthJson)
-      .mockResolvedValueOnce(mockQueue)
-      .mockResolvedValueOnce(mockItem)
-      .mockRejectedValueOnce(new Error('api_error'));
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue(mockQueue);
+    vi.mocked(api.getFlashcardsStudyNext).mockResolvedValue(mockItem);
+    vi.mocked(api.reviewFlashcard).mockRejectedValue(new Error('api_error'));
 
     render(<FlashcardsStudyPage />);
 
@@ -120,9 +121,8 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('shows "Nada que repasar hoy" when finished with 0 answered cards', async () => {
-    vi.mocked(api.apiAuthJson)
-      .mockResolvedValueOnce(emptyQueue) // fetchQueue — empty
-      .mockResolvedValueOnce(undefined); // fetchNext — nothing
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue(emptyQueue);
+    vi.mocked(api.getFlashcardsStudyNext).mockResolvedValue(undefined);
 
     render(<FlashcardsStudyPage />);
 
@@ -137,12 +137,13 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('shows answered count when finished after reviewing cards', async () => {
-    vi.mocked(api.apiAuthJson)
-      .mockResolvedValueOnce(mockQueue) // initial fetchQueue
-      .mockResolvedValueOnce(mockItem) // initial fetchNext
-      .mockResolvedValueOnce(undefined) // POST review (204 no content)
-      .mockResolvedValueOnce(emptyQueue) // fetchQueue after review
-      .mockResolvedValueOnce(undefined); // fetchNext after review — done
+    vi.mocked(api.getFlashcardsStudyQueue)
+      .mockResolvedValueOnce(mockQueue)    // initial fetchQueue
+      .mockResolvedValueOnce(emptyQueue);  // fetchQueue after review
+    vi.mocked(api.getFlashcardsStudyNext)
+      .mockResolvedValueOnce(mockItem)     // initial fetchNext
+      .mockResolvedValueOnce(undefined);   // fetchNext after review — done
+    vi.mocked(api.reviewFlashcard).mockResolvedValue(undefined);
 
     render(<FlashcardsStudyPage />);
 
@@ -163,9 +164,8 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('opens confirm modal when Terminar sesión is clicked', async () => {
-    vi.mocked(api.apiAuthJson)
-      .mockResolvedValueOnce(mockQueue)
-      .mockResolvedValueOnce(mockItem);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue(mockQueue);
+    vi.mocked(api.getFlashcardsStudyNext).mockResolvedValue(mockItem);
 
     render(<FlashcardsStudyPage />);
 
@@ -177,9 +177,8 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('can cancel the confirm modal', async () => {
-    vi.mocked(api.apiAuthJson)
-      .mockResolvedValueOnce(mockQueue)
-      .mockResolvedValueOnce(mockItem);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue(mockQueue);
+    vi.mocked(api.getFlashcardsStudyNext).mockResolvedValue(mockItem);
 
     render(<FlashcardsStudyPage />);
 
@@ -193,9 +192,8 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('finishes session when Terminar is confirmed in modal', async () => {
-    vi.mocked(api.apiAuthJson)
-      .mockResolvedValueOnce(mockQueue)
-      .mockResolvedValueOnce(mockItem);
+    vi.mocked(api.getFlashcardsStudyQueue).mockResolvedValue(mockQueue);
+    vi.mocked(api.getFlashcardsStudyNext).mockResolvedValue(mockItem);
 
     render(<FlashcardsStudyPage />);
 
@@ -216,7 +214,8 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('shows error state when initial load fails', async () => {
-    vi.mocked(api.apiAuthJson).mockRejectedValue(new Error('api_error'));
+    vi.mocked(api.getFlashcardsStudyQueue).mockRejectedValue(new Error('api_error'));
+    vi.mocked(api.getFlashcardsStudyNext).mockRejectedValue(new Error('api_error'));
 
     render(<FlashcardsStudyPage />);
 

--- a/frontend/src/__tests__/flashcards/FlashcardsStudyPage.test.tsx
+++ b/frontend/src/__tests__/flashcards/FlashcardsStudyPage.test.tsx
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import FlashcardsStudyPage from '../../pages/FlashcardsStudyPage';
+import * as api from '../../api';
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useSearchParams: () => [new URLSearchParams('unitId=unit-1')],
+}));
+
+vi.mock('flowbite-react-icons/outline', () => ({
+  ArrowLeft: () => <span data-testid="arrow-left" />,
+  CircleMinus: () => <span data-testid="circle-minus" />,
+  CheckCircle: () => <span data-testid="check-circle" />,
+}));
+
+vi.mock('../../api', async (importOriginal) => {
+  const actual = await importOriginal<typeof api>();
+  return {
+    ...actual,
+    apiAuthJson: vi.fn(),
+  };
+});
+
+const mockQueue = { new: 1, due: 0, learning: 0 };
+const emptyQueue = { new: 0, due: 0, learning: 0 };
+const mockItem = {
+  flashcardId: 'fc-1',
+  front: '¿Cuánto es 2+2?',
+  back: '4',
+  state: 'NEW' as const,
+  intervalHints: { again: '1m', good: '10m', easy: '4d' },
+};
+
+describe('FlashcardsStudyPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.setItem('ak_token', 'test-token');
+  });
+
+  it('shows skeleton while loading', () => {
+    vi.mocked(api.apiAuthJson).mockReturnValue(new Promise(() => {}));
+
+    const { container } = render(<FlashcardsStudyPage />);
+
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('renders study session when loaded', async () => {
+    vi.mocked(api.apiAuthJson)
+      .mockResolvedValueOnce(mockQueue) // fetchQueue
+      .mockResolvedValueOnce(mockItem); // fetchNext
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('¿Cuánto es 2+2?')).toBeInTheDocument();
+    });
+  });
+
+  it('shows inline review error without replacing session', async () => {
+    vi.mocked(api.apiAuthJson)
+      .mockResolvedValueOnce(mockQueue) // initial fetchQueue
+      .mockResolvedValueOnce(mockItem) // initial fetchNext
+      .mockRejectedValueOnce(new Error('api_error')); // POST review fails
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('¿Cuánto es 2+2?')).toBeInTheDocument();
+    });
+
+    // Show answer first
+    fireEvent.click(screen.getByText('Mostrar respuesta'));
+    await waitFor(() => {
+      expect(screen.getByText('4')).toBeInTheDocument();
+    });
+
+    // Click Repetir (AGAIN)
+    fireEvent.click(screen.getByText('❌ Repetir'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    // Session is NOT replaced — no finished screen
+    expect(screen.queryByText('Sesión completada')).not.toBeInTheDocument();
+    expect(screen.queryByText('Sin pendientes')).not.toBeInTheDocument();
+    // Error message is visible
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      /no se pudo registrar la respuesta/i
+    );
+  });
+
+  it('review error can be dismissed', async () => {
+    vi.mocked(api.apiAuthJson)
+      .mockResolvedValueOnce(mockQueue)
+      .mockResolvedValueOnce(mockItem)
+      .mockRejectedValueOnce(new Error('api_error'));
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('¿Cuánto es 2+2?')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Mostrar respuesta'));
+    await waitFor(() => screen.getByText('4'));
+
+    fireEvent.click(screen.getByText('❌ Repetir'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText('Cerrar error'));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows "Nada que repasar hoy" when finished with 0 answered cards', async () => {
+    vi.mocked(api.apiAuthJson)
+      .mockResolvedValueOnce(emptyQueue) // fetchQueue — empty
+      .mockResolvedValueOnce(undefined); // fetchNext — nothing
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Nada que repasar hoy')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText('No había tarjetas pendientes para repasar en esta sesión.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/has respondido/i)).not.toBeInTheDocument();
+  });
+
+  it('shows answered count when finished after reviewing cards', async () => {
+    vi.mocked(api.apiAuthJson)
+      .mockResolvedValueOnce(mockQueue) // initial fetchQueue
+      .mockResolvedValueOnce(mockItem) // initial fetchNext
+      .mockResolvedValueOnce(undefined) // POST review (204 no content)
+      .mockResolvedValueOnce(emptyQueue) // fetchQueue after review
+      .mockResolvedValueOnce(undefined); // fetchNext after review — done
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('¿Cuánto es 2+2?')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Mostrar respuesta'));
+    await waitFor(() => screen.getByText('4'));
+
+    fireEvent.click(screen.getByText('🚀 Memorizada'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Sesión completada')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/has respondido/i)).toBeInTheDocument();
+  });
+
+  it('opens confirm modal when Terminar sesión is clicked', async () => {
+    vi.mocked(api.apiAuthJson)
+      .mockResolvedValueOnce(mockQueue)
+      .mockResolvedValueOnce(mockItem);
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Cuánto es 2+2?')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Terminar sesión'));
+
+    expect(screen.getByText('Terminar sesión', { selector: 'h3' })).toBeInTheDocument();
+  });
+
+  it('can cancel the confirm modal', async () => {
+    vi.mocked(api.apiAuthJson)
+      .mockResolvedValueOnce(mockQueue)
+      .mockResolvedValueOnce(mockItem);
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Cuánto es 2+2?')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Terminar sesión'));
+    expect(screen.getByText('Terminar sesión', { selector: 'h3' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }));
+    expect(screen.queryByText('Terminar sesión', { selector: 'h3' })).not.toBeInTheDocument();
+  });
+
+  it('finishes session when Terminar is confirmed in modal', async () => {
+    vi.mocked(api.apiAuthJson)
+      .mockResolvedValueOnce(mockQueue)
+      .mockResolvedValueOnce(mockItem);
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => expect(screen.getByText('¿Cuánto es 2+2?')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Terminar sesión'));
+    // click the "Terminar" button inside the modal
+    const terminarButtons = screen.getAllByRole('button', { name: 'Terminar' });
+    const modalTerminar = terminarButtons.find(b => b.closest('.fixed'));
+    fireEvent.click(modalTerminar!);
+
+    await waitFor(() => {
+      // After finishing with 0 answered, shows "Sin pendientes" or "Sesión completada"
+      const hasSinPendientes = screen.queryByText('Sin pendientes');
+      const hasSesionCompletada = screen.queryByText('Sesión completada');
+      expect(hasSinPendientes || hasSesionCompletada).toBeTruthy();
+    });
+  });
+
+  it('shows error state when initial load fails', async () => {
+    vi.mocked(api.apiAuthJson).mockRejectedValue(new Error('api_error'));
+
+    render(<FlashcardsStudyPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No se pudo cargar la sesión de estudio.')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: /volver/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/flashcards/SubjectCard.test.tsx
+++ b/frontend/src/__tests__/flashcards/SubjectCard.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SubjectCard from '../../components/flashcards/SubjectCard';
+import type { SubjectSummary } from '../../components/flashcards/SubjectCard';
+
+const subject: SubjectSummary = {
+  subjectId: 'subj-1',
+  subjectName: 'Matemáticas',
+  newCount: 3,
+  reviewCount: 2,
+  dueCount: 1,
+  unitCount: 2,
+};
+
+describe('SubjectCard', () => {
+  const onClick = vi.fn();
+  const onExport = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders subject name and pending count', () => {
+    render(<SubjectCard subject={subject} onClick={onClick} />);
+    expect(screen.getByText('Matemáticas')).toBeInTheDocument();
+    // pending = dueCount + newCount = 1 + 3 = 4
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+
+  it('calls onClick when button is clicked', () => {
+    render(<SubjectCard subject={subject} onClick={onClick} />);
+    // The main button contains all text content of the card
+    const buttons = screen.getAllByRole('button');
+    // The subject card button is the first (and only one when no onExport)
+    fireEvent.click(buttons[0]);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render export buttons when onExport is not provided', () => {
+    render(<SubjectCard subject={subject} onClick={onClick} />);
+    expect(screen.queryByTitle('Exportar CSV')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Exportar JSON')).not.toBeInTheDocument();
+  });
+
+  it('renders export buttons when onExport is provided', () => {
+    render(<SubjectCard subject={subject} onClick={onClick} onExport={onExport} />);
+    expect(screen.getByTitle('Exportar CSV')).toBeInTheDocument();
+    expect(screen.getByTitle('Exportar JSON')).toBeInTheDocument();
+  });
+
+  it('calls onExport with csv when CSV button is clicked', () => {
+    render(<SubjectCard subject={subject} onClick={onClick} onExport={onExport} />);
+    fireEvent.click(screen.getByTitle('Exportar CSV'));
+    expect(onExport).toHaveBeenCalledWith('csv');
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('calls onExport with json when JSON button is clicked', () => {
+    render(<SubjectCard subject={subject} onClick={onClick} onExport={onExport} />);
+    fireEvent.click(screen.getByTitle('Exportar JSON'));
+    expect(onExport).toHaveBeenCalledWith('json');
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/flashcards/UnitList.test.tsx
+++ b/frontend/src/__tests__/flashcards/UnitList.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import UnitList from '../../components/flashcards/UnitList';
+import type { UnitSummary } from '../../pages/FlashcardsPage';
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+const units: UnitSummary[] = [
+  {
+    unitId: 'unit-1',
+    unitName: 'Álgebra',
+    subjectId: 'subj-1',
+    subjectName: 'Matemáticas',
+    newCount: 5,
+    reviewCount: 2,
+    dueCount: 1,
+  },
+];
+
+describe('UnitList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows skeleton while loading', () => {
+    const { container } = render(
+      <UnitList units={[]} loading={true} error="" />
+    );
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('shows error message when error is provided', () => {
+    render(<UnitList units={[]} loading={false} error="Error cargando unidades" />);
+    expect(screen.getByText('Error cargando unidades')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no units', () => {
+    render(<UnitList units={[]} loading={false} error="" />);
+    expect(screen.getByText('No hay unidades disponibles.')).toBeInTheDocument();
+  });
+
+  it('empty state does not show import CTA when onImport is not provided', () => {
+    render(<UnitList units={[]} loading={false} error="" />);
+    expect(screen.queryByRole('button', { name: /importar flashcards/i })).not.toBeInTheDocument();
+  });
+
+  it('empty state shows import CTA when onImport is provided', () => {
+    const onImport = vi.fn();
+    render(<UnitList units={[]} loading={false} error="" onImport={onImport} />);
+    expect(screen.getByRole('button', { name: /importar flashcards/i })).toBeInTheDocument();
+  });
+
+  it('empty state CTA calls onImport when clicked', () => {
+    const onImport = vi.fn();
+    render(<UnitList units={[]} loading={false} error="" onImport={onImport} />);
+    fireEvent.click(screen.getByRole('button', { name: /importar flashcards/i }));
+    expect(onImport).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders unit cards when units are provided', () => {
+    render(<UnitList units={units} loading={false} error="" />);
+    expect(screen.getByText('Álgebra')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/ExamAttemptPage.test.tsx
+++ b/frontend/src/__tests__/pages/ExamAttemptPage.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import ExamAttemptPage from '../../pages/ExamAttemptPage';
+import * as api from '../../api';
+
+const mockNavigate = vi.fn();
+let mockAttemptId: string | undefined = 'attempt-123';
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ attemptId: mockAttemptId }),
+  useNavigate: () => mockNavigate,
+  Navigate: ({ to }: { to: string }) => <div data-testid="navigate" data-to={to} />,
+}));
+
+vi.mock('../../components/ExamRunner', () => ({
+  default: ({ questions }: { questions: unknown[] }) => (
+    <div data-testid="exam-runner">
+      <span>Questions: {questions.length}</span>
+    </div>
+  ),
+}));
+
+vi.mock('../../api', async (importOriginal) => {
+  const actual = await importOriginal<typeof api>();
+  return {
+    ...actual,
+    getExamAttempt: vi.fn(),
+    saveExamAnswer: vi.fn(),
+    submitExam: vi.fn(),
+  };
+});
+
+const mockAttemptData = {
+  attemptId: 'attempt-123',
+  totalTimeSeconds: 1800,
+  questions: [
+    {
+      id: 'q-1',
+      text: 'What is 2+2?',
+      answers: [
+        { id: 'a-1', text: '3' },
+        { id: 'a-2', text: '4' },
+      ],
+      selectedAnswerId: null,
+    },
+  ],
+  nextQuestionIndex: 0,
+  finished: false,
+};
+
+describe('ExamAttemptPage', () => {
+  const onUnauthorized = vi.fn();
+  const onFinish = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAttemptId = 'attempt-123';
+  });
+
+  it('shows loading state initially', () => {
+    vi.mocked(api.getExamAttempt).mockImplementation(() => new Promise(() => {}));
+
+    render(
+      <ExamAttemptPage token="test-token" onUnauthorized={onUnauthorized} onFinish={onFinish} />
+    );
+
+    expect(screen.getByText('Cargando intento...')).toBeInTheDocument();
+  });
+
+  it('renders ExamRunner when attempt loads successfully', async () => {
+    vi.mocked(api.getExamAttempt).mockResolvedValue(mockAttemptData);
+
+    render(
+      <ExamAttemptPage token="test-token" onUnauthorized={onUnauthorized} onFinish={onFinish} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('exam-runner')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Questions: 1')).toBeInTheDocument();
+  });
+
+  it('shows error state when API fails', async () => {
+    vi.mocked(api.getExamAttempt).mockRejectedValue(new Error('network error'));
+
+    render(
+      <ExamAttemptPage token="test-token" onUnauthorized={onUnauthorized} onFinish={onFinish} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Error')).toBeInTheDocument();
+      expect(screen.getByText('No se pudo cargar el intento')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onUnauthorized when API returns 401', async () => {
+    const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+    vi.mocked(api.getExamAttempt).mockRejectedValue(err);
+
+    render(
+      <ExamAttemptPage token="test-token" onUnauthorized={onUnauthorized} onFinish={onFinish} />
+    );
+
+    await waitFor(() => {
+      expect(onUnauthorized).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('shows timeout error message when API times out', async () => {
+    const err = Object.assign(new Error('timeout'), { code: 'timeout' });
+    vi.mocked(api.getExamAttempt).mockRejectedValue(err);
+
+    render(
+      <ExamAttemptPage token="test-token" onUnauthorized={onUnauthorized} onFinish={onFinish} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Error')).toBeInTheDocument();
+    });
+  });
+
+  it('redirects to subjects when attemptId is undefined', () => {
+    mockAttemptId = undefined;
+
+    render(
+      <ExamAttemptPage token="test-token" onUnauthorized={onUnauthorized} onFinish={onFinish} />
+    );
+
+    expect(screen.getByTestId('navigate')).toBeInTheDocument();
+  });
+
+  it('calls getExamAttempt with correct token and attemptId', async () => {
+    vi.mocked(api.getExamAttempt).mockResolvedValue(mockAttemptData);
+
+    render(
+      <ExamAttemptPage token="my-token" onUnauthorized={onUnauthorized} onFinish={onFinish} />
+    );
+
+    await waitFor(() => {
+      expect(vi.mocked(api.getExamAttempt)).toHaveBeenCalledWith('my-token', 'attempt-123');
+    });
+  });
+});

--- a/frontend/src/__tests__/pages/FlashcardsHistoryPage.test.tsx
+++ b/frontend/src/__tests__/pages/FlashcardsHistoryPage.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import FlashcardsHistoryPage from '../../pages/FlashcardsHistoryPage';
+import * as api from '../../api';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('../../components/flashcards/FlashcardsTabs', () => ({
+  default: ({ active, onTab }: { active: string; onTab: (tab: string) => void }) => (
+    <div data-testid="flashcards-tabs" data-active={active}>
+      <button onClick={() => onTab('examinar')}>Examinar</button>
+      <button onClick={() => onTab('estudio')}>Estudio</button>
+      <button onClick={() => onTab('historial')}>Historial</button>
+    </div>
+  ),
+}));
+
+vi.mock('../../api', async (importOriginal) => {
+  const actual = await importOriginal<typeof api>();
+  return {
+    ...actual,
+    getFlashcardsHistory: vi.fn(),
+  };
+});
+
+const mockHistoryItems = [
+  {
+    id: 'rev-1',
+    flashcardId: 'fc-1',
+    front: 'What is 2+2?',
+    back: '4',
+    grade: 'EASY' as const,
+    reviewedAt: '2024-01-10T10:00:00Z',
+    intervalBefore: 1,
+    intervalAfter: 4,
+  },
+  {
+    id: 'rev-2',
+    flashcardId: 'fc-2',
+    front: 'Capital of Spain?',
+    back: 'Madrid',
+    grade: 'GOOD' as const,
+    reviewedAt: '2024-01-10T11:00:00Z',
+    intervalBefore: null,
+    intervalAfter: null,
+  },
+  {
+    id: 'rev-3',
+    flashcardId: 'fc-3',
+    front: null,
+    back: null,
+    grade: 'AGAIN' as const,
+    reviewedAt: '2024-01-10T12:00:00Z',
+    intervalBefore: 2,
+    intervalAfter: 2,
+  },
+];
+
+describe('FlashcardsHistoryPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.setItem('ak_token', 'test-token');
+  });
+
+  it('shows loading skeletons initially', () => {
+    vi.mocked(api.getFlashcardsHistory).mockImplementation(() => new Promise(() => {}));
+
+    render(<FlashcardsHistoryPage />);
+
+    // Loading state has animate-pulse elements
+    const pulseEls = document.querySelectorAll('.animate-pulse');
+    expect(pulseEls.length).toBeGreaterThan(0);
+  });
+
+  it('shows history items when loaded', async () => {
+    vi.mocked(api.getFlashcardsHistory).mockResolvedValue(mockHistoryItems);
+
+    render(<FlashcardsHistoryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('What is 2+2?')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Capital of Spain?')).toBeInTheDocument();
+    expect(screen.getByText('(sin texto)')).toBeInTheDocument();
+  });
+
+  it('shows grade labels for each item', async () => {
+    vi.mocked(api.getFlashcardsHistory).mockResolvedValue(mockHistoryItems);
+
+    render(<FlashcardsHistoryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Easy')).toBeInTheDocument();
+      expect(screen.getByText('Good')).toBeInTheDocument();
+      expect(screen.getByText('Again')).toBeInTheDocument();
+    });
+  });
+
+  it('shows interval info when intervalAfter is present', async () => {
+    vi.mocked(api.getFlashcardsHistory).mockResolvedValue(mockHistoryItems);
+
+    render(<FlashcardsHistoryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Intervalo: 4d/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows interval change when intervalBefore differs from intervalAfter', async () => {
+    vi.mocked(api.getFlashcardsHistory).mockResolvedValue(mockHistoryItems);
+
+    render(<FlashcardsHistoryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/← 1d/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when no history', async () => {
+    vi.mocked(api.getFlashcardsHistory).mockResolvedValue([]);
+
+    render(<FlashcardsHistoryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Aún no has revisado ninguna tarjeta.')).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to study mode when "Empezar a estudiar" is clicked from empty state', async () => {
+    vi.mocked(api.getFlashcardsHistory).mockResolvedValue([]);
+
+    render(<FlashcardsHistoryPage />);
+
+    await waitFor(() => screen.getByText('Empezar a estudiar'));
+    fireEvent.click(screen.getByText('Empezar a estudiar'));
+    expect(mockNavigate).toHaveBeenCalledWith('/flashcards?mode=study');
+  });
+
+  it('shows error state on API failure', async () => {
+    vi.mocked(api.getFlashcardsHistory).mockRejectedValue(new Error('network error'));
+
+    render(<FlashcardsHistoryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No se pudo cargar el historial.')).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to flashcards page when examinar tab is clicked', async () => {
+    vi.mocked(api.getFlashcardsHistory).mockResolvedValue([]);
+
+    render(<FlashcardsHistoryPage />);
+
+    fireEvent.click(screen.getByText('Examinar'));
+    expect(mockNavigate).toHaveBeenCalledWith('/flashcards');
+  });
+
+  it('navigates to study mode when estudio tab is clicked', async () => {
+    vi.mocked(api.getFlashcardsHistory).mockResolvedValue([]);
+
+    render(<FlashcardsHistoryPage />);
+
+    fireEvent.click(screen.getByText('Estudio'));
+    expect(mockNavigate).toHaveBeenCalledWith('/flashcards?mode=study');
+  });
+
+  it('fetches history with limit 50', async () => {
+    vi.mocked(api.getFlashcardsHistory).mockResolvedValue([]);
+
+    render(<FlashcardsHistoryPage />);
+
+    await waitFor(() => {
+      expect(vi.mocked(api.getFlashcardsHistory)).toHaveBeenCalledWith('test-token', 50);
+    });
+  });
+});

--- a/frontend/src/__tests__/pages/SubjectsPage.test.tsx
+++ b/frontend/src/__tests__/pages/SubjectsPage.test.tsx
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import SubjectsPage from '../../pages/SubjectsPage';
+import * as api from '../../api';
+
+vi.mock('react-router-dom', () => ({
+  Link: ({ children, to, className }: { children: React.ReactNode; to: string; className?: string }) => (
+    <a href={to} className={className}>{children}</a>
+  ),
+}));
+
+vi.mock('../../api', async (importOriginal) => {
+  const actual = await importOriginal<typeof api>();
+  return {
+    ...actual,
+    getExamAttempts: vi.fn(),
+  };
+});
+
+const mockSubjects = [
+  { id: 'subj-1', name: 'Matemáticas', description: 'Álgebra y cálculo' },
+  { id: 'subj-2', name: 'Física', description: 'Mecánica y termodinámica' },
+];
+
+const mockHistory = [
+  {
+    attemptId: 'att-1',
+    subjectName: 'Matemáticas',
+    startedAt: '2024-01-10T10:00:00Z',
+    finishedAt: '2024-01-10T10:30:00Z',
+    score: 8,
+    percent: 80,
+    totalTimeSeconds: 1800,
+  },
+  {
+    attemptId: 'att-2',
+    subjectName: 'Física',
+    startedAt: '2024-01-11T10:00:00Z',
+    finishedAt: null,
+    score: 0,
+    percent: 0,
+    totalTimeSeconds: 900,
+  },
+];
+
+describe('SubjectsPage', () => {
+  const onUnauthorized = vi.fn();
+  const onViewResult = vi.fn();
+  const onResumeAttempt = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders subject cards', async () => {
+    vi.mocked(api.getExamAttempts).mockResolvedValue([]);
+
+    render(
+      <SubjectsPage
+        subjects={mockSubjects}
+        token="test-token"
+        onUnauthorized={onUnauthorized}
+        onViewResult={onViewResult}
+        onResumeAttempt={onResumeAttempt}
+      />
+    );
+
+    expect(screen.getByText('Matemáticas')).toBeInTheDocument();
+    expect(screen.getByText('Física')).toBeInTheDocument();
+    await waitFor(() => expect(vi.mocked(api.getExamAttempts)).toHaveBeenCalledOnce());
+  });
+
+  it('shows loading state initially', () => {
+    vi.mocked(api.getExamAttempts).mockImplementation(() => new Promise(() => {}));
+
+    render(
+      <SubjectsPage
+        subjects={mockSubjects}
+        token="test-token"
+        onUnauthorized={onUnauthorized}
+        onViewResult={onViewResult}
+        onResumeAttempt={onResumeAttempt}
+      />
+    );
+
+    expect(screen.getByText('Cargando historial...')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no exam history', async () => {
+    vi.mocked(api.getExamAttempts).mockResolvedValue([]);
+
+    render(
+      <SubjectsPage
+        subjects={mockSubjects}
+        token="test-token"
+        onUnauthorized={onUnauthorized}
+        onViewResult={onViewResult}
+        onResumeAttempt={onResumeAttempt}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Aún no tienes exámenes realizados')).toBeInTheDocument();
+    });
+  });
+
+  it('shows exam history when attempts exist', async () => {
+    vi.mocked(api.getExamAttempts).mockResolvedValue(mockHistory as any);
+
+    render(
+      <SubjectsPage
+        subjects={mockSubjects}
+        token="test-token"
+        onUnauthorized={onUnauthorized}
+        onViewResult={onViewResult}
+        onResumeAttempt={onResumeAttempt}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Matemáticas').length).toBeGreaterThan(0);
+    });
+    expect(screen.getByText('Ver resultados')).toBeInTheDocument();
+    expect(screen.getByText('Reanudar')).toBeInTheDocument();
+  });
+
+  it('calls onViewResult when "Ver resultados" is clicked', async () => {
+    vi.mocked(api.getExamAttempts).mockResolvedValue(mockHistory as any);
+
+    render(
+      <SubjectsPage
+        subjects={mockSubjects}
+        token="test-token"
+        onUnauthorized={onUnauthorized}
+        onViewResult={onViewResult}
+        onResumeAttempt={onResumeAttempt}
+      />
+    );
+
+    await waitFor(() => screen.getByText('Ver resultados'));
+    fireEvent.click(screen.getByText('Ver resultados'));
+    expect(onViewResult).toHaveBeenCalledWith('att-1');
+  });
+
+  it('calls onResumeAttempt when "Reanudar" is clicked', async () => {
+    vi.mocked(api.getExamAttempts).mockResolvedValue(mockHistory as any);
+
+    render(
+      <SubjectsPage
+        subjects={mockSubjects}
+        token="test-token"
+        onUnauthorized={onUnauthorized}
+        onViewResult={onViewResult}
+        onResumeAttempt={onResumeAttempt}
+      />
+    );
+
+    await waitFor(() => screen.getByText('Reanudar'));
+    fireEvent.click(screen.getByText('Reanudar'));
+    expect(onResumeAttempt).toHaveBeenCalledWith('att-2');
+  });
+
+  it('shows error state when API fails', async () => {
+    vi.mocked(api.getExamAttempts).mockRejectedValue(new Error('network error'));
+
+    render(
+      <SubjectsPage
+        subjects={mockSubjects}
+        token="test-token"
+        onUnauthorized={onUnauthorized}
+        onViewResult={onViewResult}
+        onResumeAttempt={onResumeAttempt}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('No se pudo cargar el historial.')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onUnauthorized when API returns 401', async () => {
+    const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+    vi.mocked(api.getExamAttempts).mockRejectedValue(err);
+
+    render(
+      <SubjectsPage
+        subjects={mockSubjects}
+        token="test-token"
+        onUnauthorized={onUnauthorized}
+        onViewResult={onViewResult}
+        onResumeAttempt={onResumeAttempt}
+      />
+    );
+
+    await waitFor(() => {
+      expect(onUnauthorized).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('shows active attempt resume link when activeAttemptId is provided', async () => {
+    vi.mocked(api.getExamAttempts).mockResolvedValue([]);
+
+    render(
+      <SubjectsPage
+        subjects={mockSubjects}
+        activeAttemptId="active-123"
+        token="test-token"
+        onUnauthorized={onUnauthorized}
+        onViewResult={onViewResult}
+        onResumeAttempt={onResumeAttempt}
+      />
+    );
+
+    expect(screen.getByText('Reanudar examen')).toBeInTheDocument();
+  });
+
+  it('shows "Ver menos" and "Ver más" button for long history lists', async () => {
+    const longHistory = Array.from({ length: 8 }, (_, i) => ({
+      attemptId: `att-${i}`,
+      subjectName: 'Matemáticas',
+      startedAt: '2024-01-10T10:00:00Z',
+      finishedAt: '2024-01-10T10:30:00Z',
+      score: 8,
+      percent: 80,
+      totalTimeSeconds: 1800,
+    }));
+    vi.mocked(api.getExamAttempts).mockResolvedValue(longHistory as any);
+
+    render(
+      <SubjectsPage
+        subjects={mockSubjects}
+        token="test-token"
+        onUnauthorized={onUnauthorized}
+        onViewResult={onViewResult}
+        onResumeAttempt={onResumeAttempt}
+      />
+    );
+
+    await waitFor(() => screen.getByText('Ver 3 más'));
+    fireEvent.click(screen.getByText('Ver 3 más'));
+    expect(screen.getByText('Ver menos')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Ver menos'));
+    expect(screen.getByText('Ver 3 más')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -1,1 +1,17 @@
 import '@testing-library/jest-dom';
+
+// jsdom doesn't always provide a working localStorage (e.g. when
+// --localstorage-file is missing). Provide a reliable in-memory stub.
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+    get length() { return Object.keys(store).length; },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock, writable: true });

--- a/frontend/src/__tests__/utils/format.test.ts
+++ b/frontend/src/__tests__/utils/format.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { deriveInitials, formatDuration } from '../../utils/format';
+
+describe('formatDuration', () => {
+  it('formats 0 seconds as 0m 00s', () => {
+    expect(formatDuration(0)).toBe('0m 00s');
+  });
+  it('formats 90 seconds as 1m 30s', () => {
+    expect(formatDuration(90)).toBe('1m 30s');
+  });
+  it('formats 3661 seconds as 61m 01s', () => {
+    expect(formatDuration(3661)).toBe('61m 01s');
+  });
+  it('pads single-digit seconds with leading zero', () => {
+    expect(formatDuration(65)).toBe('1m 05s');
+  });
+});
+
+describe('deriveInitials', () => {
+  it('returns initials from john.doe@example.com', () => {
+    expect(deriveInitials('john.doe@example.com')).toBe('JD');
+  });
+  it('returns initials from admin@akademia.es', () => {
+    expect(deriveInitials('admin@akademia.es')).toBe('A');
+  });
+  it('handles single segment', () => {
+    expect(deriveInitials('x@y.com')).toBe('X');
+  });
+  it('returns empty string for empty input', () => {
+    expect(deriveInitials('')).toBe('');
+  });
+  it('handles dash separator', () => {
+    expect(deriveInitials('jane-doe@example.com')).toBe('JD');
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,3 +1,5 @@
+import { API_ROUTES } from './constants/apiRoutes';
+
 const rawBase = import.meta.env.VITE_API_URL || '';
 const normalizedBase = rawBase.endsWith('/') ? rawBase.slice(0, -1) : rawBase;
 const envBase = normalizedBase.endsWith('/api') ? normalizedBase.slice(0, -4) : normalizedBase;
@@ -5,6 +7,10 @@ const envBase = normalizedBase.endsWith('/api') ? normalizedBase.slice(0, -4) : 
 const isExternalHost = window.location.hostname.endsWith('diegobarrioh.dev');
 const defaultBase = isExternalHost ? window.location.origin : `http://${window.location.hostname}:8080`;
 export const apiBase = envBase || defaultBase;
+
+export function apiUrl(path: string): string {
+  return `${apiBase}${path}`;
+}
 
 type RequestOptions = RequestInit & { timeoutMs?: number };
 
@@ -53,14 +59,14 @@ import type {
 } from './types';
 
 export async function getMyProfile(token: string): Promise<UserProfile> {
-  return apiAuthJson<UserProfile>(`${apiBase}/api/v1/users/me`, token);
+  return apiAuthJson<UserProfile>(apiUrl(API_ROUTES.users.me), token);
 }
 
 export async function updateMyProfile(
   token: string,
   data: { firstName: string | null; lastName: string | null }
 ): Promise<UserProfile> {
-  return apiAuthJson<UserProfile>(`${apiBase}/api/v1/users/me`, token, {
+  return apiAuthJson<UserProfile>(apiUrl(API_ROUTES.users.me), token, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data)
@@ -73,7 +79,7 @@ export async function uploadSource(token: string, file: File, subjectId: string)
   const form = new FormData();
   form.append('file', file);
   form.append('subjectId', subjectId);
-  const res = await fetch(`${apiBase}/api/sources`, {
+  const res = await fetch(apiUrl(API_ROUTES.sources.root), {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}` },
     body: form
@@ -93,7 +99,7 @@ export async function confirmIndex(
   approvedUnits: ApprovedUnit[]
 ): Promise<{ document: SourceDocument; savedUnits: { id: string; name: string }[] }> {
   const cmd: ConfirmIndexCommand = { approvedUnits };
-  return apiAuthJson(`${apiBase}/api/sources/${documentId}/confirm`, token, {
+  return apiAuthJson(apiUrl(API_ROUTES.sources.confirm(documentId)), token, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(cmd)
@@ -102,13 +108,13 @@ export async function confirmIndex(
 
 export async function getSources(token: string, subjectId?: string): Promise<SourceDocument[]> {
   const url = subjectId
-    ? `${apiBase}/api/sources?subjectId=${subjectId}`
-    : `${apiBase}/api/sources`;
+    ? `${apiUrl(API_ROUTES.sources.root)}?subjectId=${subjectId}`
+    : apiUrl(API_ROUTES.sources.root);
   return apiAuthJson<SourceDocument[]>(url, token);
 }
 
 export async function generateQuiz(token: string, cmd: GenerateQuizCommand): Promise<GenerateQuizResponse> {
-  return apiAuthJson<GenerateQuizResponse>(`${apiBase}/api/ai/quizzes/generate`, token, {
+  return apiAuthJson<GenerateQuizResponse>(apiUrl(API_ROUTES.ai.quizzesGenerate), token, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(cmd),
@@ -118,29 +124,29 @@ export async function generateQuiz(token: string, cmd: GenerateQuizCommand): Pro
 
 export async function getDrafts(token: string, sourceId: string, status?: string): Promise<GeneratedDraft[]> {
   const url = status
-    ? `${apiBase}/api/ai/quizzes/drafts?sourceId=${sourceId}&status=${status}`
-    : `${apiBase}/api/ai/quizzes/drafts?sourceId=${sourceId}`;
+    ? `${apiUrl(API_ROUTES.ai.quizzesDrafts)}?sourceId=${sourceId}&status=${status}`
+    : `${apiUrl(API_ROUTES.ai.quizzesDrafts)}?sourceId=${sourceId}`;
   return apiAuthJson<GeneratedDraft[]>(url, token);
 }
 
 export async function approveDraft(token: string, draftId: string): Promise<GeneratedDraft> {
-  return apiAuthJson<GeneratedDraft>(`${apiBase}/api/ai/drafts/${draftId}/approve`, token, {
+  return apiAuthJson<GeneratedDraft>(apiUrl(API_ROUTES.ai.draftApprove(draftId)), token, {
     method: 'POST'
   });
 }
 
 export async function rejectDraft(token: string, draftId: string): Promise<GeneratedDraft> {
-  return apiAuthJson<GeneratedDraft>(`${apiBase}/api/ai/drafts/${draftId}/reject`, token, {
+  return apiAuthJson<GeneratedDraft>(apiUrl(API_ROUTES.ai.draftReject(draftId)), token, {
     method: 'POST'
   });
 }
 
 export async function getUnitsForSubject(token: string, subjectId: string): Promise<{ id: string; name: string }[]> {
-  return apiAuthJson<{ id: string; name: string }[]>(`${apiBase}/api/units?subjectId=${subjectId}`, token);
+  return apiAuthJson<{ id: string; name: string }[]>(`${apiUrl(API_ROUTES.units.root)}?subjectId=${subjectId}`, token);
 }
 
 export async function deleteSource(token: string, id: string): Promise<void> {
-  return apiAuthJson<void>(`${apiBase}/api/sources/${id}`, token, { method: 'DELETE' });
+  return apiAuthJson<void>(apiUrl(API_ROUTES.sources.single(id)), token, { method: 'DELETE' });
 }
 
 export async function exportFlashcardsBySubject(
@@ -149,7 +155,7 @@ export async function exportFlashcardsBySubject(
   format: 'csv' | 'json'
 ): Promise<string> {
   const res = await fetch(
-    `${apiBase}/api/flashcards/export?subjectId=${subjectId}&format=${format}`,
+    `${apiUrl(API_ROUTES.flashcards.export)}?subjectId=${subjectId}&format=${format}`,
     { headers: { Authorization: `Bearer ${token}` } }
   );
   if (!res.ok) {
@@ -158,6 +164,331 @@ export async function exportFlashcardsBySubject(
     throw err;
   }
   return res.text();
+}
+
+// Subjects API functions
+
+export async function getSubjects(token: string): Promise<import('./types').Subject[]> {
+  return apiAuthJson<import('./types').Subject[]>(apiUrl(API_ROUTES.subjects), token);
+}
+
+// Exams API functions
+
+export async function startExam(
+  token: string,
+  cfg: { unitCounts: Record<string, number>; minutes: number; difficulty?: 'EASY' | 'MEDIUM' | 'HARD' }
+): Promise<import('./types').ExamStartResponse> {
+  return apiAuthJson<import('./types').ExamStartResponse>(apiUrl(API_ROUTES.exams.start), token, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(cfg),
+    timeoutMs: 15000
+  });
+}
+
+export async function startRandomExam(
+  token: string,
+  cfg: { subjectId: string; count: number; minutes: number; difficulty?: 'EASY' | 'MEDIUM' | 'HARD' }
+): Promise<import('./types').ExamStartResponse> {
+  return apiAuthJson<import('./types').ExamStartResponse>(apiUrl(API_ROUTES.exams.startRandom), token, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(cfg),
+    timeoutMs: 15000
+  });
+}
+
+export async function submitExam(
+  token: string,
+  attemptId: string,
+  selections: Record<string, string>
+): Promise<import('./types').ExamResult> {
+  return apiAuthJson<import('./types').ExamResult>(apiUrl(API_ROUTES.exams.submit(attemptId)), token, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ selections }),
+    timeoutMs: 15000
+  });
+}
+
+export async function getExamAttempts(token: string): Promise<import('./types').ExamAttemptSummary[]> {
+  return apiAuthJson<import('./types').ExamAttemptSummary[]>(apiUrl(API_ROUTES.exams.attempts), token);
+}
+
+export async function getExamAttempt<T>(token: string, attemptId: string): Promise<T> {
+  return apiAuthJson<T>(apiUrl(API_ROUTES.exams.attempt(attemptId)), token, { timeoutMs: 15000 });
+}
+
+export async function saveExamAnswer(
+  token: string,
+  attemptId: string,
+  questionId: string,
+  selectedAnswerId: string | undefined
+): Promise<void> {
+  return apiAuthJson<void>(apiUrl(API_ROUTES.exams.answers(attemptId, questionId)), token, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ selectedAnswerId }),
+    timeoutMs: 15000
+  });
+}
+
+// Flashcards API functions
+
+export async function getFlashcardsUnitsSummary<T>(token: string): Promise<T> {
+  return apiAuthJson<T>(apiUrl(API_ROUTES.flashcards.unitsSummary), token);
+}
+
+export async function getFlashcardsStudyQueue<T>(token: string, unitId?: string): Promise<T> {
+  const url = unitId
+    ? `${apiUrl(API_ROUTES.flashcards.studyQueue)}?unitId=${unitId}`
+    : apiUrl(API_ROUTES.flashcards.studyQueue);
+  return apiAuthJson<T>(url, token);
+}
+
+export async function getFlashcardsStudyNext<T>(token: string, unitId: string): Promise<T> {
+  return apiAuthJson<T>(`${apiUrl(API_ROUTES.flashcards.studyNext)}?unitId=${unitId}`, token);
+}
+
+export async function reviewFlashcard(
+  token: string,
+  body: { flashcardId: string; grade: 'AGAIN' | 'GOOD' | 'EASY'; reviewedAt: string }
+): Promise<void> {
+  return apiAuthJson<void>(apiUrl(API_ROUTES.flashcards.studyReview), token, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+}
+
+export async function getFlashcardsHistory<T>(token: string, limit?: number): Promise<T> {
+  const url = limit !== undefined
+    ? `${apiUrl(API_ROUTES.flashcards.history)}?limit=${limit}`
+    : apiUrl(API_ROUTES.flashcards.history);
+  return apiAuthJson<T>(url, token);
+}
+
+export async function getFlashcardsByUnit<T>(token: string, unitId: string): Promise<T> {
+  return apiAuthJson<T>(`${apiUrl(API_ROUTES.flashcards.root)}?unitId=${unitId}`, token);
+}
+
+// Flashcards import API function
+
+export async function importFlashcards(
+  token: string,
+  unitId: string,
+  format: 'csv' | 'json',
+  content: string
+): Promise<{ imported: number; skipped: number; errors: string[] }> {
+  const res = await fetch(
+    `${apiUrl(API_ROUTES.flashcards.import)}?unitId=${unitId}&format=${format}`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'text/plain; charset=UTF-8',
+      },
+      body: content,
+    }
+  );
+  if (!res.ok) throw new Error(`Error ${res.status}`);
+  return res.json();
+}
+
+export async function exportFlashcardsByUnit(
+  token: string,
+  unitId: string,
+  format: 'csv' | 'json'
+): Promise<string> {
+  const res = await fetch(
+    `${apiUrl(API_ROUTES.flashcards.export)}?unitId=${unitId}&format=${format}`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  if (!res.ok) {
+    const err: any = new Error('api_error');
+    err.status = res.status;
+    throw err;
+  }
+  return res.text();
+}
+
+// Units availability API function
+
+export async function getUnitsAvailability(
+  token: string,
+  subjectId: string,
+  difficulty?: string
+): Promise<import('./types').UnitAvailability[]> {
+  const diffQuery = difficulty ? `&difficulty=${difficulty}` : '';
+  return apiAuthJson<import('./types').UnitAvailability[]>(
+    `${apiUrl(API_ROUTES.units.availability)}?subjectId=${subjectId}${diffQuery}`,
+    token
+  );
+}
+
+// Settings API functions
+
+export async function getUserSettings(token: string): Promise<{ newCardsLimit: number; reviewCardsLimit: number }> {
+  return apiAuthJson<{ newCardsLimit: number; reviewCardsLimit: number }>(apiUrl(API_ROUTES.settings), token);
+}
+
+export async function updateUserSettings(
+  token: string,
+  data: { newCardsLimit: number; reviewCardsLimit: number }
+): Promise<{ newCardsLimit: number; reviewCardsLimit: number }> {
+  return apiAuthJson<{ newCardsLimit: number; reviewCardsLimit: number }>(apiUrl(API_ROUTES.settings), token, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+}
+
+// Admin API functions
+
+export async function getAdminUsers(
+  token: string,
+  page: number,
+  size = 10
+): Promise<{ items: import('./components/Settings').AdminUser[]; page: number; totalPages: number }> {
+  return apiAuthJson(
+    `${apiUrl(API_ROUTES.admin.users)}?page=${page}&size=${size}`,
+    token
+  );
+}
+
+export async function saveAdminUser(
+  token: string,
+  form: { id?: string; email: string; firstName: string; lastName: string; occupation: string; role: string },
+  isEditing: boolean
+): Promise<void> {
+  const body = JSON.stringify({
+    email: form.email,
+    firstName: form.firstName || null,
+    lastName: form.lastName || null,
+    occupation: form.occupation || null,
+    role: form.role,
+  });
+  return apiAuthJson(
+    isEditing ? apiUrl(API_ROUTES.admin.user(form.id!)) : apiUrl(API_ROUTES.admin.users),
+    token,
+    { method: isEditing ? 'PUT' : 'POST', headers: { 'Content-Type': 'application/json' }, body }
+  );
+}
+
+export async function deleteAdminUser(token: string, id: string): Promise<void> {
+  return apiAuthJson(apiUrl(API_ROUTES.admin.user(id)), token, { method: 'DELETE' });
+}
+
+export async function getAdminSubjects(token: string): Promise<import('./components/Settings').AdminSubject[]> {
+  return apiAuthJson(apiUrl(API_ROUTES.admin.subjects), token);
+}
+
+export async function saveAdminSubject(
+  token: string,
+  form: { id?: string; name: string; description: string },
+  isEditing: boolean
+): Promise<void> {
+  const body = JSON.stringify({ name: form.name, description: form.description || null });
+  return apiAuthJson(
+    isEditing ? apiUrl(API_ROUTES.admin.subject(form.id!)) : apiUrl(API_ROUTES.admin.subjects),
+    token,
+    { method: isEditing ? 'PUT' : 'POST', headers: { 'Content-Type': 'application/json' }, body }
+  );
+}
+
+export async function deleteAdminSubject(token: string, id: string): Promise<void> {
+  return apiAuthJson(apiUrl(API_ROUTES.admin.subject(id)), token, { method: 'DELETE' });
+}
+
+export async function getAdminUnits(token: string, subjectId: string): Promise<import('./components/Settings').AdminUnit[]> {
+  return apiAuthJson(`${apiUrl(API_ROUTES.admin.units)}?subjectId=${subjectId}`, token);
+}
+
+export async function saveAdminUnit(
+  token: string,
+  form: { id?: string; subjectId: string; name: string; description: string; orderIndex: number },
+  isEditing: boolean
+): Promise<void> {
+  const payload = {
+    subjectId: form.subjectId,
+    name: form.name,
+    description: form.description || null,
+    orderIndex: form.orderIndex || 0,
+  };
+  return apiAuthJson(
+    isEditing ? apiUrl(API_ROUTES.admin.unit(form.id!)) : apiUrl(API_ROUTES.admin.units),
+    token,
+    { method: isEditing ? 'PUT' : 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) }
+  );
+}
+
+export async function deleteAdminUnit(token: string, id: string): Promise<void> {
+  return apiAuthJson(apiUrl(API_ROUTES.admin.unit(id)), token, { method: 'DELETE' });
+}
+
+export async function getAdminQuestions(
+  token: string,
+  unitId: string,
+  page: number,
+  size = 10
+): Promise<{ items: import('./components/Settings').AdminQuestion[]; page: number; totalPages: number }> {
+  return apiAuthJson(
+    `${apiUrl(API_ROUTES.admin.questions)}?unitId=${unitId}&page=${page}&size=${size}`,
+    token
+  );
+}
+
+export async function saveAdminQuestion(
+  token: string,
+  form: import('./components/Settings').AdminQuestion & { unitId: string },
+  isEditing: boolean
+): Promise<void> {
+  const payload = {
+    unitId: form.unitId,
+    text: form.text,
+    explanation: form.explanation || null,
+    difficulty: form.difficulty,
+    answers: form.answers.map((a) => ({ text: a.text, correct: a.correct })),
+  };
+  return apiAuthJson(
+    isEditing ? apiUrl(API_ROUTES.admin.question(form.id)) : apiUrl(API_ROUTES.admin.questions),
+    token,
+    { method: isEditing ? 'PUT' : 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) }
+  );
+}
+
+export async function deleteAdminQuestion(token: string, id: string): Promise<void> {
+  return apiAuthJson(apiUrl(API_ROUTES.admin.question(id)), token, { method: 'DELETE' });
+}
+
+export async function exportAdminQuestions(
+  token: string,
+  format: 'csv' | 'json',
+  unitId?: string
+): Promise<Blob> {
+  const query = unitId ? `?unitId=${unitId}&format=${format}` : `?format=${format}`;
+  const res = await fetch(`${apiUrl(API_ROUTES.admin.questionsExport)}${query}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error('export_failed');
+  return res.blob();
+}
+
+export async function importAdminQuestions(
+  token: string,
+  format: 'csv' | 'json',
+  unitId: string,
+  file: File
+): Promise<{ created?: number; [key: string]: unknown }> {
+  const formData = new FormData();
+  formData.append('file', file);
+  const res = await fetch(
+    `${apiUrl(API_ROUTES.admin.questionsImport)}?format=${format}&unitId=${unitId}`,
+    { method: 'POST', headers: { Authorization: `Bearer ${token}` }, body: formData }
+  );
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.error || 'import_failed');
+  return data;
 }
 
 export async function apiAuthJson<T>(url: string, token: string, options: RequestOptions = {}): Promise<T> {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -143,6 +143,23 @@ export async function deleteSource(token: string, id: string): Promise<void> {
   return apiAuthJson<void>(`${apiBase}/api/sources/${id}`, token, { method: 'DELETE' });
 }
 
+export async function exportFlashcardsBySubject(
+  token: string,
+  subjectId: string,
+  format: 'csv' | 'json'
+): Promise<string> {
+  const res = await fetch(
+    `${apiBase}/api/flashcards/export?subjectId=${subjectId}&format=${format}`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  if (!res.ok) {
+    const err: any = new Error('api_error');
+    err.status = res.status;
+    throw err;
+  }
+  return res.text();
+}
+
 export async function apiAuthJson<T>(url: string, token: string, options: RequestOptions = {}): Promise<T> {
   const { timeoutMs, ...fetchOptions } = options;
   const { signal, clear } = mergeSignal(fetchOptions.signal ?? undefined, timeoutMs);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -46,11 +46,28 @@ export async function apiJson<T>(url: string, options: RequestOptions = {}): Pro
   }
 }
 
-// RAG module API functions
+// User profile API functions
 import type {
   SourceDocument, GeneratedDraft, GenerateQuizCommand, GenerateQuizResponse,
-  IndexPreview, ConfirmIndexCommand, ApprovedUnit
+  IndexPreview, ConfirmIndexCommand, ApprovedUnit, UserProfile
 } from './types';
+
+export async function getMyProfile(token: string): Promise<UserProfile> {
+  return apiAuthJson<UserProfile>(`${apiBase}/api/v1/users/me`, token);
+}
+
+export async function updateMyProfile(
+  token: string,
+  data: { firstName: string | null; lastName: string | null }
+): Promise<UserProfile> {
+  return apiAuthJson<UserProfile>(`${apiBase}/api/v1/users/me`, token, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+}
+
+// RAG module API functions
 
 export async function uploadSource(token: string, file: File, subjectId: string): Promise<IndexPreview> {
   const form = new FormData();

--- a/frontend/src/components/ExamBuilder.tsx
+++ b/frontend/src/components/ExamBuilder.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Minus, Plus, Play } from 'flowbite-react-icons/outline';
-import { apiBase, apiAuthJson } from '../api';
+import { getUnitsAvailability } from '../api';
 import type { UnitAvailability } from '../types';
 
 const inp = 'bg-white/50 dark:bg-[#24394c] border border-secondary/30 rounded-xl px-4 py-2.5 text-sm text-text placeholder:text-text/35 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50 transition-colors';
@@ -22,13 +22,13 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
 
   useEffect(() => {
     const token = localStorage.getItem('ak_token') || '';
-    const diffQuery = difficulty === 'ALL' ? '' : `&difficulty=${difficulty}`;
+    const diff = difficulty === 'ALL' ? undefined : difficulty;
     setAvailabilityLoading(true);
-    apiAuthJson<UnitAvailability[]>(`${apiBase}/api/units/availability?subjectId=${subjectId}${diffQuery}`, token)
+    getUnitsAvailability(token, subjectId, diff)
       .then(us => { setUnits(us.map(u => ({ id: u.id, name: u.name, available: Number(u.available) || 0 }))); setPage(0); })
       .catch(err => { if (err?.status === 401) onUnauthorized(); })
       .finally(() => setAvailabilityLoading(false));
-  }, [subjectId, apiBase, difficulty]);
+  }, [subjectId, difficulty]);
 
   const totalPages = Math.ceil(units.length / PAGE_SIZE);
   const pagedUnits = units.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowRightToBracket } from 'flowbite-react-icons/outline';
-import { apiBase } from '../api';
+import { apiUrl } from '../api';
+import { API_ROUTES } from '../constants/apiRoutes';
 import { ROUTES } from '../constants/routes';
 
 const inputClass =
@@ -27,7 +28,7 @@ export default function Login({ onToken }: { onToken: (t: string) => void }) {
     setErr('');
     setLoading(true);
     try {
-      const res = await fetch(`${apiBase}/api/auth/login`, {
+      const res = await fetch(apiUrl(API_ROUTES.auth.login), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password })
@@ -64,7 +65,7 @@ export default function Login({ onToken }: { onToken: (t: string) => void }) {
 
           <div className="space-y-4">
             <a
-              href={`${apiBase}/api/oauth2/authorization/google`}
+              href={apiUrl(API_ROUTES.auth.oauthGoogle)}
               className="flex items-center justify-center gap-3 w-full py-3 px-4 rounded-full border border-secondary/30 bg-bg hover:bg-secondary/10 transition-colors text-sm font-medium text-text/80"
             >
               <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -2,11 +2,15 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { BookOpen, Cog, Home, ArrowRightToBracket, UserAdd, ArrowLeftToBracket } from 'flowbite-react-icons/outline';
 import { ROUTES } from '../constants/routes';
+import type { NavUser } from '../types';
+import { UserMenuDropdown } from './UserMenuDropdown';
 
-export default function NavbarComponent({ isAuthed, isAdmin, onLogout }: {
+export default function NavbarComponent({ isAuthed, isAdmin, user, onLogout, onSettings }: {
   isAuthed: boolean;
   isAdmin: boolean;
+  user: NavUser | null;
   onLogout: () => void;
+  onSettings: () => void;
 }) {
   const [isDark, setIsDark] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -101,22 +105,11 @@ export default function NavbarComponent({ isAuthed, isAdmin, onLogout }: {
                   IA
                 </button>
               )}
-              <button onClick={() => go(ROUTES.settings)} className={linkCls(ROUTES.settings)}>
-                <Cog className="w-4 h-4" />
-                Ajustes
-              </button>
-              <button
-                onClick={onLogout}
-                className="flex items-center gap-2 px-3 py-2 rounded-xl text-sm font-medium text-text/65 hover:text-red-400 hover:bg-red-400/10 transition-colors"
-              >
-                <ArrowLeftToBracket className="w-4 h-4" />
-                Salir
-              </button>
             </>
           )}
         </div>
 
-        {/* Right: theme toggle + mobile burger */}
+        {/* Right: theme toggle + user menu / mobile burger */}
         <div className="flex items-center gap-2">
           <button
             className={`theme-toggle ${isDark ? 'dark' : 'light'}`}
@@ -127,6 +120,18 @@ export default function NavbarComponent({ isAuthed, isAdmin, onLogout }: {
             <span className="theme-icon" aria-hidden>☾</span>
             <span className="theme-icon" aria-hidden>☀︎</span>
           </button>
+
+          {/* Desktop user menu */}
+          {isAuthed && user && (
+            <div className="hidden md:block">
+              <UserMenuDropdown
+                user={user}
+                isAdmin={isAdmin}
+                onSettings={onSettings}
+                onLogout={onLogout}
+              />
+            </div>
+          )}
 
           {/* Hamburger / X button */}
           <button
@@ -151,6 +156,8 @@ export default function NavbarComponent({ isAuthed, isAdmin, onLogout }: {
         }`}
       >
         <div className="px-4 pb-4 pt-2 border-t border-secondary/15 space-y-1 bg-bg/95 backdrop-blur-md">
+
+          {/* Navigation zone */}
           <button onClick={() => go(ROUTES.home)} className={mobileLinkCls(ROUTES.home)}>
             <Home className="w-4 h-4" />
             Home
@@ -185,19 +192,30 @@ export default function NavbarComponent({ isAuthed, isAdmin, onLogout }: {
                   IA
                 </button>
               )}
-              <button onClick={() => go(ROUTES.settings)} className={mobileLinkCls(ROUTES.settings)}>
+
+              {/* Divider between nav zone and user zone */}
+              <div className="border-t border-secondary/15 my-1" />
+
+              {/* User zone */}
+              {user && (
+                <div className="px-4 py-2 text-xs text-text/50 truncate">
+                  {user.email}
+                </div>
+              )}
+              <button
+                onClick={() => { onSettings(); setMenuOpen(false); }}
+                className="w-full text-left flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-colors text-text/65 hover:text-text hover:bg-secondary/10"
+              >
                 <Cog className="w-4 h-4" />
                 Ajustes
               </button>
-              <div className="pt-1 mt-1 border-t border-secondary/15">
-                <button
-                  onClick={() => { onLogout(); setMenuOpen(false); }}
-                  className="w-full text-left flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium text-red-400 hover:bg-red-400/10 transition-colors"
-                >
-                  <ArrowLeftToBracket className="w-4 h-4" />
-                  Salir
-                </button>
-              </div>
+              <button
+                onClick={() => { onLogout(); setMenuOpen(false); }}
+                className="w-full text-left flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium text-red-400 hover:bg-red-400/10 transition-colors"
+              >
+                <ArrowLeftToBracket className="w-4 h-4" />
+                Salir
+              </button>
             </>
           )}
         </div>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,15 +1,16 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { BookOpen, Cog, Home, ArrowRightToBracket, UserAdd, ArrowLeftToBracket } from 'flowbite-react-icons/outline';
+import { BookOpen, Cog, Home, ArrowRightToBracket, UserAdd, ArrowLeftToBracket, User } from 'flowbite-react-icons/outline';
 import { ROUTES } from '../constants/routes';
 import type { NavUser } from '../types';
 import { UserMenuDropdown } from './UserMenuDropdown';
 
-export default function NavbarComponent({ isAuthed, isAdmin, user, onLogout, onSettings }: {
+export default function NavbarComponent({ isAuthed, isAdmin, user, onLogout, onProfile, onSettings }: {
   isAuthed: boolean;
   isAdmin: boolean;
   user: NavUser | null;
   onLogout: () => void;
+  onProfile: () => void;
   onSettings: () => void;
 }) {
   const [isDark, setIsDark] = useState(false);
@@ -127,6 +128,7 @@ export default function NavbarComponent({ isAuthed, isAdmin, user, onLogout, onS
               <UserMenuDropdown
                 user={user}
                 isAdmin={isAdmin}
+                onProfile={onProfile}
                 onSettings={onSettings}
                 onLogout={onLogout}
               />
@@ -202,6 +204,13 @@ export default function NavbarComponent({ isAuthed, isAdmin, user, onLogout, onS
                   {user.email}
                 </div>
               )}
+              <button
+                onClick={() => { onProfile(); setMenuOpen(false); }}
+                className="w-full text-left flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-colors text-text/65 hover:text-text hover:bg-secondary/10"
+              >
+                <User className="w-4 h-4" />
+                Mi perfil
+              </button>
               <button
                 onClick={() => { onSettings(); setMenuOpen(false); }}
                 className="w-full text-left flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-colors text-text/65 hover:text-text hover:bg-secondary/10"

--- a/frontend/src/components/Register.tsx
+++ b/frontend/src/components/Register.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { UserAdd } from 'flowbite-react-icons/outline';
-import { apiBase } from '../api';
+import { apiUrl } from '../api';
+import { API_ROUTES } from '../constants/apiRoutes';
 import { ROUTES } from '../constants/routes';
 
 const inputClass =
@@ -34,7 +35,7 @@ export default function Register({ onToken }: { onToken: (t: string) => void }) 
     setErr('');
     setLoading(true);
     try {
-      const res = await fetch(`${apiBase}/api/auth/register`, {
+      const res = await fetch(apiUrl(API_ROUTES.auth.register), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -78,7 +79,7 @@ export default function Register({ onToken }: { onToken: (t: string) => void }) 
 
           <div className="space-y-4">
             <a
-              href={`${apiBase}/api/oauth2/authorization/google`}
+              href={apiUrl(API_ROUTES.auth.oauthGoogle)}
               className="flex items-center justify-center gap-3 w-full py-3 px-4 rounded-full border border-secondary/30 bg-bg hover:bg-secondary/10 transition-colors text-sm font-medium text-text/80"
             >
               <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Plus, Check, CircleMinus, Pen, TrashBin, FileExport, FileImport, FileCsv, Users, BookOpen, FolderOpen, FileLines, Cog } from 'flowbite-react-icons/outline';
-import { apiBase, apiAuthJson } from '../api';
+import {
+  getUserSettings, updateUserSettings,
+  getAdminUsers, saveAdminUser, deleteAdminUser,
+  getAdminSubjects, saveAdminSubject, deleteAdminSubject,
+  getAdminUnits, saveAdminUnit, deleteAdminUnit,
+  getAdminQuestions, saveAdminQuestion, deleteAdminQuestion,
+  exportAdminQuestions, importAdminQuestions,
+} from '../api';
 
 export type AdminUser = {
   id: string;
@@ -126,7 +133,7 @@ export default function Settings({ isAdmin, token, onSubjectsChanged }: { isAdmi
 
   async function loadUserSettings() {
     try {
-      const data = await apiAuthJson<UserSettings>(`${apiBase}/api/settings`, token);
+      const data = await getUserSettings(token);
       setSettingsForm(data);
     } catch { /* keep defaults */ }
   }
@@ -134,11 +141,7 @@ export default function Settings({ isAdmin, token, onSubjectsChanged }: { isAdmi
   async function saveUserSettings() {
     setSettingsLoading(true); setSettingsSaved(false); setSettingsError('');
     try {
-      const data = await apiAuthJson<UserSettings>(`${apiBase}/api/settings`, token, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(settingsForm),
-      });
+      const data = await updateUserSettings(token, settingsForm);
       setSettingsForm(data);
       setSettingsSaved(true);
       setTimeout(() => setSettingsSaved(false), 2500);
@@ -215,21 +218,21 @@ export default function Settings({ isAdmin, token, onSubjectsChanged }: { isAdmi
   }
 
   async function loadUsers(page = userPage) {
-    const data = await apiAuthJson<{ items: AdminUser[]; page: number; totalPages: number }>(`${apiBase}/api/admin/users?page=${page - 1}&size=10`, token);
+    const data = await getAdminUsers(token, page - 1);
     setUsers(data.items); setUserPage(data.page + 1); setUserTotalPages(data.totalPages || 1);
   }
   async function loadSubjects() {
-    const data = await apiAuthJson<AdminSubject[]>(`${apiBase}/api/admin/subjects`, token);
+    const data = await getAdminSubjects(token);
     setSubjects(data);
   }
   async function loadUnits(subjectId: string) {
     if (!subjectId) { setUnits([]); return; }
-    const data = await apiAuthJson<AdminUnit[]>(`${apiBase}/api/admin/units?subjectId=${subjectId}`, token);
+    const data = await getAdminUnits(token, subjectId);
     setUnits(data);
   }
   async function loadQuestions(unitId: string, page = questionPage) {
     if (!unitId) { setQuestions([]); setQuestionTotalPages(1); return; }
-    const data = await apiAuthJson<{ items: AdminQuestion[]; page: number; totalPages: number }>(`${apiBase}/api/admin/questions?unitId=${unitId}&page=${page - 1}&size=10`, token);
+    const data = await getAdminQuestions(token, unitId, page - 1);
     setQuestions(data.items); setQuestionPage(data.page + 1); setQuestionTotalPages(data.totalPages || 1);
   }
 
@@ -249,9 +252,7 @@ export default function Settings({ isAdmin, token, onSubjectsChanged }: { isAdmi
     if (!form.email.trim()) return;
     setLoading(true);
     try {
-      const body = JSON.stringify({ email: form.email, firstName: form.firstName || null, lastName: form.lastName || null, occupation: form.occupation || null, role: form.role });
-      const opts = { method: isEditing ? 'PUT' : 'POST', headers: { 'Content-Type': 'application/json' }, body };
-      await apiAuthJson(isEditing ? `${apiBase}/api/admin/users/${form.id}` : `${apiBase}/api/admin/users`, token, opts);
+      await saveAdminUser(token, { id: form.id, email: form.email, firstName: form.firstName || '', lastName: form.lastName || '', occupation: form.occupation || '', role: form.role }, isEditing);
       resetForm(); await loadUsers(1);
     } finally { setLoading(false); }
   }
@@ -260,28 +261,24 @@ export default function Settings({ isAdmin, token, onSubjectsChanged }: { isAdmi
     if (!subjectForm.name.trim()) return;
     setSubjectLoading(true);
     try {
-      const body = JSON.stringify({ name: subjectForm.name, description: subjectForm.description || null });
-      const opts = { method: isSubjectEditing ? 'PUT' : 'POST', headers: { 'Content-Type': 'application/json' }, body };
-      await apiAuthJson(isSubjectEditing ? `${apiBase}/api/admin/subjects/${subjectForm.id}` : `${apiBase}/api/admin/subjects`, token, opts);
+      await saveAdminSubject(token, { id: subjectForm.id, name: subjectForm.name, description: subjectForm.description || '' }, isSubjectEditing);
       resetSubjectForm(); await loadSubjects(); onSubjectsChanged?.();
     } finally { setSubjectLoading(false); }
   }
 
-  async function removeUser(id: string) { await apiAuthJson(`${apiBase}/api/admin/users/${id}`, token, { method: 'DELETE' }); await loadUsers(userPage); }
-  async function removeSubject(id: string) { await apiAuthJson(`${apiBase}/api/admin/subjects/${id}`, token, { method: 'DELETE' }); await loadSubjects(); onSubjectsChanged?.(); }
+  async function removeUser(id: string) { await deleteAdminUser(token, id); await loadUsers(userPage); }
+  async function removeSubject(id: string) { await deleteAdminSubject(token, id); await loadSubjects(); onSubjectsChanged?.(); }
 
   async function saveUnit() {
     if (!unitForm.subjectId || !unitForm.name.trim()) return;
     setUnitLoading(true);
     try {
-      const payload = { subjectId: unitForm.subjectId, name: unitForm.name, description: unitForm.description || null, orderIndex: unitForm.orderIndex || 0 };
-      const opts = { method: isUnitEditing ? 'PUT' : 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) };
-      await apiAuthJson(isUnitEditing ? `${apiBase}/api/admin/units/${unitForm.id}` : `${apiBase}/api/admin/units`, token, opts);
+      await saveAdminUnit(token, { id: unitForm.id, subjectId: unitForm.subjectId, name: unitForm.name, description: unitForm.description || '', orderIndex: unitForm.orderIndex || 0 }, isUnitEditing);
       resetUnitForm(); await loadUnits(unitForm.subjectId); await loadSubjects();
     } finally { setUnitLoading(false); }
   }
 
-  async function removeUnit(id: string) { await apiAuthJson(`${apiBase}/api/admin/units/${id}`, token, { method: 'DELETE' }); await loadUnits(unitForm.subjectId); await loadSubjects(); }
+  async function removeUnit(id: string) { await deleteAdminUnit(token, id); await loadUnits(unitForm.subjectId); await loadSubjects(); }
 
   async function saveQuestion() {
     const unitId = questionUnitId || questionForm.unitId;
@@ -290,22 +287,17 @@ export default function Settings({ isAdmin, token, onSubjectsChanged }: { isAdmi
     if (questionForm.answers.filter(a => a.correct).length !== 1) return;
     setQuestionLoading(true);
     try {
-      const payload = { unitId, text: questionForm.text, explanation: questionForm.explanation || null, difficulty: questionForm.difficulty, answers: questionForm.answers.map(a => ({ text: a.text, correct: a.correct })) };
-      const opts = { method: isQuestionEditing ? 'PUT' : 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) };
-      await apiAuthJson(isQuestionEditing ? `${apiBase}/api/admin/questions/${questionForm.id}` : `${apiBase}/api/admin/questions`, token, opts);
+      await saveAdminQuestion(token, { ...questionForm, unitId }, isQuestionEditing);
       resetQuestionForm(); await loadQuestions(unitId, 1); await loadUnits(questionSubjectId);
     } finally { setQuestionLoading(false); }
   }
 
-  async function removeQuestion(id: string, unitId: string) { await apiAuthJson(`${apiBase}/api/admin/questions/${id}`, token, { method: 'DELETE' }); await loadQuestions(unitId, questionPage); await loadUnits(questionSubjectId); }
+  async function removeQuestion(id: string, unitId: string) { await deleteAdminQuestion(token, id); await loadQuestions(unitId, questionPage); await loadUnits(questionSubjectId); }
 
   async function handleExport(format: 'csv' | 'json') {
     setExportLoading(true);
     try {
-      const query = questionUnitId ? `?unitId=${questionUnitId}&format=${format}` : `?format=${format}`;
-      const res = await fetch(`${apiBase}/api/admin/questions/export${query}`, { headers: { Authorization: `Bearer ${token}` } });
-      if (!res.ok) throw new Error('export_failed');
-      const blob = await res.blob();
+      const blob = await exportAdminQuestions(token, format, questionUnitId || undefined);
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
@@ -320,13 +312,9 @@ export default function Settings({ isAdmin, token, onSubjectsChanged }: { isAdmi
     if (!questionUnitId) { setImportMessage('Selecciona una unidad'); return; }
     setImportLoading(true); setImportMessage('');
     try {
-      const formData = new FormData();
-      formData.append('file', importFile);
-      const res = await fetch(`${apiBase}/api/admin/questions/import?format=${importFormat}&unitId=${questionUnitId}`, { method: 'POST', headers: { Authorization: `Bearer ${token}` }, body: formData });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok) throw new Error(data.error || 'import_failed');
+      const data = await importAdminQuestions(token, importFormat, questionUnitId, importFile);
       const created = data.created || 0;
-      const errors = data.errors || 0;
+      const errors = (data.errors as number) || 0;
       setImportStats({ created, errors });
       setImportMessage(`Importadas: ${created}. Errores: ${errors}`);
       setImportDone(true);

--- a/frontend/src/components/UserMenuDropdown.tsx
+++ b/frontend/src/components/UserMenuDropdown.tsx
@@ -4,11 +4,12 @@ import { NavUser } from '../types';
 interface Props {
   user: NavUser;
   isAdmin: boolean;
+  onProfile: () => void;
   onSettings: () => void;
   onLogout: () => void;
 }
 
-export function UserMenuDropdown({ user, isAdmin, onSettings, onLogout }: Props) {
+export function UserMenuDropdown({ user, isAdmin, onProfile, onSettings, onLogout }: Props) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -49,7 +50,12 @@ export function UserMenuDropdown({ user, isAdmin, onSettings, onLogout }: Props)
           <div className="px-3 py-2 text-xs text-text/50 truncate border-b border-secondary/10 mb-1">
             {user.email}
           </div>
-          {/* Future: Profile entry */}
+          <button
+            onClick={() => { onProfile(); setOpen(false); }}
+            className="w-full text-left px-3 py-2 text-sm text-text hover:bg-secondary/10 transition-colors"
+          >
+            Mi perfil
+          </button>
           <button
             onClick={() => { onSettings(); setOpen(false); }}
             className="w-full text-left px-3 py-2 text-sm text-text hover:bg-secondary/10 transition-colors"

--- a/frontend/src/components/UserMenuDropdown.tsx
+++ b/frontend/src/components/UserMenuDropdown.tsx
@@ -1,0 +1,70 @@
+import { useState, useEffect, useRef } from 'react';
+import { NavUser } from '../types';
+
+interface Props {
+  user: NavUser;
+  isAdmin: boolean;
+  onSettings: () => void;
+  onLogout: () => void;
+}
+
+export function UserMenuDropdown({ user, isAdmin, onSettings, onLogout }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleOutsideClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', handleOutsideClick);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, []);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen(prev => !prev)}
+        className="flex items-center justify-center w-8 h-8 rounded-full bg-primary/15 text-primary text-sm font-semibold hover:bg-primary/25 transition-colors"
+        aria-label="User menu"
+        aria-expanded={open}
+      >
+        {user.avatarUrl ? (
+          <img src={user.avatarUrl} alt={user.initials} className="w-8 h-8 rounded-full object-cover" />
+        ) : (
+          user.initials
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-2 w-48 bg-bg border border-secondary/20 rounded-xl shadow-lg z-50 py-1">
+          <div className="px-3 py-2 text-xs text-text/50 truncate border-b border-secondary/10 mb-1">
+            {user.email}
+          </div>
+          {/* Future: Profile entry */}
+          <button
+            onClick={() => { onSettings(); setOpen(false); }}
+            className="w-full text-left px-3 py-2 text-sm text-text hover:bg-secondary/10 transition-colors"
+          >
+            Ajustes
+          </button>
+          <div className="border-t border-secondary/10 my-1" />
+          <button
+            onClick={() => { onLogout(); setOpen(false); }}
+            className="w-full text-left px-3 py-2 text-sm text-red-500 hover:bg-red-500/10 transition-colors"
+          >
+            Cerrar sesión
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/flashcards/FlashcardImportModal.tsx
+++ b/frontend/src/components/flashcards/FlashcardImportModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { apiAuthJson, apiBase, getUnitsForSubject } from '../../api';
+import { getSubjects, getUnitsForSubject, importFlashcards } from '../../api';
 
 type Subject = { id: string; name: string; description?: string };
 type Unit = { id: string; name: string };
@@ -27,7 +27,7 @@ export default function FlashcardImportModal({ token, onClose, onImported }: Pro
   // Load all subjects on mount
   useEffect(() => {
     setLoadingSubjects(true);
-    apiAuthJson<Subject[]>(`${apiBase}/api/subjects`, token)
+    getSubjects(token)
       .then((data) => {
         setSubjects(data ?? []);
         if (data && data.length > 0) setSubjectId(data[0].id);
@@ -61,19 +61,7 @@ export default function FlashcardImportModal({ token, onClose, onImported }: Pro
 
     try {
       const content = await file.text();
-      const res = await fetch(
-        `${apiBase}/api/flashcards/import?unitId=${unitId}&format=${format}`,
-        {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-Type': 'text/plain; charset=UTF-8',
-          },
-          body: content,
-        }
-      );
-      if (!res.ok) throw new Error(`Error ${res.status}`);
-      const data: ImportResult = await res.json();
+      const data = await importFlashcards(token, unitId, format, content);
       setResult(data);
       if (data.imported > 0) onImported();
     } catch (e: any) {

--- a/frontend/src/components/flashcards/SubjectCard.tsx
+++ b/frontend/src/components/flashcards/SubjectCard.tsx
@@ -9,37 +9,65 @@ type SubjectSummary = {
 
 export type { SubjectSummary };
 
-export default function SubjectCard({ subject, onClick }: { subject: SubjectSummary; onClick: () => void }) {
+type Props = {
+  subject: SubjectSummary;
+  onClick: () => void;
+  onExport?: (format: 'csv' | 'json') => void;
+};
+
+export default function SubjectCard({ subject, onClick, onExport }: Props) {
   const pending = subject.dueCount + subject.newCount;
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="group w-full text-left border border-secondary/25 rounded-2xl p-5 transition-all hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5"
-    >
-      <div className="flex items-center gap-4">
-        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-accent/10 text-accent group-hover:bg-accent/15 transition-colors text-xl">
-          📚
-        </div>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-start justify-between gap-2">
-            <div className="font-bold text-sm leading-snug">{subject.subjectName}</div>
-            <div className="text-right shrink-0">
-              <div className="text-xl font-extrabold tabular-nums">{pending}</div>
-              <div className="text-xs text-text/40 uppercase tracking-wide">pendientes</div>
+    <div className="group relative">
+      <button
+        type="button"
+        onClick={onClick}
+        className="w-full text-left border border-secondary/25 rounded-2xl p-5 transition-all hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5"
+      >
+        <div className="flex items-center gap-4">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-accent/10 text-accent group-hover:bg-accent/15 transition-colors text-xl">
+            📚
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-start justify-between gap-2">
+              <div className="font-bold text-sm leading-snug">{subject.subjectName}</div>
+              <div className="text-right shrink-0">
+                <div className="text-xl font-extrabold tabular-nums">{pending}</div>
+                <div className="text-xs text-text/40 uppercase tracking-wide">pendientes</div>
+              </div>
             </div>
           </div>
+          <div className="text-text/30 text-lg">›</div>
         </div>
-        <div className="text-text/30 text-lg">›</div>
-      </div>
 
-      <div className="mt-3 flex flex-wrap gap-4 text-xs text-text/55">
-        <span>📖 {subject.unitCount} {subject.unitCount === 1 ? 'mazo' : 'mazos'}</span>
-        {subject.newCount > 0 && <span>🆕 {subject.newCount} nuevas</span>}
-        {subject.reviewCount > 0 && <span>🟡 {subject.reviewCount} en repaso</span>}
-        {subject.dueCount > 0 && <span>🔁 {subject.dueCount} pendientes</span>}
-      </div>
-    </button>
+        <div className="mt-3 flex flex-wrap gap-4 text-xs text-text/55">
+          <span>📖 {subject.unitCount} {subject.unitCount === 1 ? 'mazo' : 'mazos'}</span>
+          {subject.newCount > 0 && <span>🆕 {subject.newCount} nuevas</span>}
+          {subject.reviewCount > 0 && <span>🟡 {subject.reviewCount} en repaso</span>}
+          {subject.dueCount > 0 && <span>🔁 {subject.dueCount} pendientes</span>}
+        </div>
+      </button>
+
+      {onExport && (
+        <div className="absolute bottom-3.5 right-10 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity z-10">
+          {(['csv', 'json'] as const).map((fmt) => (
+            <button
+              key={fmt}
+              type="button"
+              title={`Exportar ${fmt.toUpperCase()}`}
+              onClick={(e) => { e.stopPropagation(); onExport(fmt); }}
+              className="flex items-center gap-1 px-2 py-0.5 rounded-lg bg-secondary/20 hover:bg-secondary/40 text-text/50 hover:text-text text-xs font-medium transition-colors"
+            >
+              <svg className="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                  d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
+              </svg>
+              {fmt.toUpperCase()}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/src/components/flashcards/UnitList.tsx
+++ b/frontend/src/components/flashcards/UnitList.tsx
@@ -1,7 +1,16 @@
 import UnitCard from './UnitCard';
 import type { UnitSummary } from '../../pages/FlashcardsPage';
 
-export default function UnitList({ units, loading, error, onUnitClick, onExport }: { units: UnitSummary[]; loading: boolean; error: string; onUnitClick?: (unit: UnitSummary) => void; onExport?: (unit: UnitSummary, format: 'csv' | 'json') => void }) {
+type Props = {
+  units: UnitSummary[];
+  loading: boolean;
+  error: string;
+  onUnitClick?: (unit: UnitSummary) => void;
+  onExport?: (unit: UnitSummary, format: 'csv' | 'json') => void;
+  onImport?: () => void;
+};
+
+export default function UnitList({ units, loading, error, onUnitClick, onExport, onImport }: Props) {
   if (loading) {
     return (
       <div className="space-y-3">
@@ -22,8 +31,17 @@ export default function UnitList({ units, loading, error, onUnitClick, onExport 
 
   if (!units.length) {
     return (
-      <div className="border border-secondary/25 rounded-2xl px-5 py-4 text-sm text-text/55">
-        No hay unidades disponibles.
+      <div className="border border-secondary/25 rounded-2xl px-5 py-8 text-center space-y-4">
+        <p className="text-sm text-text/55">No hay unidades disponibles.</p>
+        {onImport && (
+          <button
+            type="button"
+            onClick={onImport}
+            className="btn btn-primary rounded-full px-6 py-2 text-sm shadow-sm shadow-primary/15"
+          >
+            Importar flashcards
+          </button>
+        )}
       </div>
     );
   }
@@ -32,11 +50,11 @@ export default function UnitList({ units, loading, error, onUnitClick, onExport 
     <div className="space-y-3">
       {units.map((unit) => (
         <UnitCard
-            key={unit.unitId}
-            unit={unit}
-            onClick={onUnitClick ? () => onUnitClick(unit) : undefined}
-            onExport={onExport ? (fmt) => onExport(unit, fmt) : undefined}
-          />
+          key={unit.unitId}
+          unit={unit}
+          onClick={onUnitClick ? () => onUnitClick(unit) : undefined}
+          onExport={onExport ? (fmt) => onExport(unit, fmt) : undefined}
+        />
       ))}
     </div>
   );

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -1,0 +1,58 @@
+export const API_ROUTES = {
+  auth: {
+    login: '/api/auth/login',
+    register: '/api/auth/register',
+    oauthGoogle: '/api/oauth2/authorization/google',
+  },
+  users: {
+    me: '/api/v1/users/me',
+  },
+  subjects: '/api/subjects',
+  units: {
+    root: '/api/units',
+    availability: '/api/units/availability',
+  },
+  exams: {
+    attempts: '/api/exams/attempts',
+    start: '/api/exams/attempts/start',
+    startRandom: '/api/exams/attempts/start-random',
+    attempt: (id: string) => `/api/exams/attempts/${id}`,
+    answers: (attemptId: string, questionId: string) =>
+      `/api/exams/attempts/${attemptId}/answers/${questionId}`,
+    submit: (id: string) => `/api/exams/attempts/${id}/submit`,
+  },
+  flashcards: {
+    root: '/api/flashcards',
+    unitsSummary: '/api/flashcards/units/summary',
+    studyQueue: '/api/flashcards/study/queue',
+    studyNext: '/api/flashcards/study/next',
+    studyReview: '/api/flashcards/study/review',
+    history: '/api/flashcards/history',
+    export: '/api/flashcards/export',
+    import: '/api/flashcards/import',
+  },
+  sources: {
+    root: '/api/sources',
+    confirm: (id: string) => `/api/sources/${id}/confirm`,
+    single: (id: string) => `/api/sources/${id}`,
+  },
+  ai: {
+    quizzesGenerate: '/api/ai/quizzes/generate',
+    quizzesDrafts: '/api/ai/quizzes/drafts',
+    draftApprove: (id: string) => `/api/ai/drafts/${id}/approve`,
+    draftReject: (id: string) => `/api/ai/drafts/${id}/reject`,
+  },
+  settings: '/api/settings',
+  admin: {
+    users: '/api/admin/users',
+    user: (id: string) => `/api/admin/users/${id}`,
+    subjects: '/api/admin/subjects',
+    subject: (id: string) => `/api/admin/subjects/${id}`,
+    units: '/api/admin/units',
+    unit: (id: string) => `/api/admin/units/${id}`,
+    questions: '/api/admin/questions',
+    question: (id: string) => `/api/admin/questions/${id}`,
+    questionsExport: '/api/admin/questions/export',
+    questionsImport: '/api/admin/questions/import',
+  },
+} as const;

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -8,6 +8,7 @@ export const ROUTES = {
   examAttempt: (attemptId: string) => `/exams/attempts/${attemptId}`,
   examResult: '/result',
   settings: '/settings',
+  profile: '/profile',
   flashcards: '/flashcards',
   flashcardsStudy: '/flashcards/study',
   flashcardsHistory: '/flashcards/history',

--- a/frontend/src/pages/ExamAttemptPage.tsx
+++ b/frontend/src/pages/ExamAttemptPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import ExamRunner, { Question } from '../components/ExamRunner';
-import { apiAuthJson, apiBase } from '../api';
+import { getExamAttempt, saveExamAnswer, submitExam } from '../api';
 import { timeoutMessage } from '../utils/messages';
 import { ROUTES } from '../constants/routes';
 import type { ExamResult } from '../types';
@@ -37,7 +37,7 @@ export default function ExamAttemptPage({ token, onUnauthorized, onFinish }:{
     if (!attemptId) return;
     setLoading(true);
     setError('');
-    apiAuthJson<AttemptResponse>(`${apiBase}/api/exams/attempts/${attemptId}`, token, { timeoutMs: 15000 })
+    getExamAttempt<AttemptResponse>(token, attemptId)
       .then(data => setAttempt(data))
       .catch(err => {
         if (err?.status === 401) onUnauthorized();
@@ -48,7 +48,7 @@ export default function ExamAttemptPage({ token, onUnauthorized, onFinish }:{
         setError('No se pudo cargar el intento');
       })
       .finally(() => setLoading(false));
-  }, [attemptId, token, apiBase]);
+  }, [attemptId, token]);
 
   if (!attemptId) return <Navigate to={ROUTES.subjects} replace />;
 
@@ -76,12 +76,7 @@ export default function ExamAttemptPage({ token, onUnauthorized, onFinish }:{
     const current = selections[questionId];
     if (current === answerId) return;
     try {
-      await apiAuthJson(`${apiBase}/api/exams/attempts/${attemptId}/answers/${questionId}`, token, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ selectedAnswerId: answerId }),
-        timeoutMs: 15000
-      });
+      await saveExamAnswer(token, attemptId!, questionId, answerId);
     } catch (err: any) {
       if (err?.status === 401) onUnauthorized();
       if (err?.code === 'timeout') {
@@ -96,12 +91,7 @@ export default function ExamAttemptPage({ token, onUnauthorized, onFinish }:{
     const filtered: Record<string,string> = {};
     Object.entries(payload.selections).forEach(([q, a]) => { if(a) filtered[q] = a; });
     try {
-      const result = await apiAuthJson<ExamResult>(`${apiBase}/api/exams/attempts/${attemptId}/submit`, token, {
-        method: 'POST',
-        headers: { 'Content-Type':'application/json' },
-        body: JSON.stringify({ selections: filtered }),
-        timeoutMs: 15000
-      });
+      const result = await submitExam(token, attemptId!, filtered);
       sessionStorage.removeItem('akdmia.activeAttemptId');
       onFinish(result);
       navigate(ROUTES.examResult);

--- a/frontend/src/pages/FlashcardsExamineUnitPage.tsx
+++ b/frontend/src/pages/FlashcardsExamineUnitPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ArrowLeft } from 'flowbite-react-icons/outline';
-import { apiAuthJson, apiBase } from '../api';
+import { getFlashcardsByUnit } from '../api';
 
 type Flashcard = {
   id: string;
@@ -25,7 +25,7 @@ export default function FlashcardsExamineUnitPage() {
   useEffect(() => {
     if (!unitId) { setError('Falta el unitId.'); setLoading(false); return; }
     let mounted = true;
-    apiAuthJson<Flashcard[]>(`${apiBase}/api/flashcards?unitId=${unitId}`, token)
+    getFlashcardsByUnit<Flashcard[]>(token, unitId)
       .then((data) => { if (mounted) setCards(data || []); })
       .catch(() => { if (mounted) setError('No se pudieron cargar las tarjetas.'); })
       .finally(() => { if (mounted) setLoading(false); });

--- a/frontend/src/pages/FlashcardsExamineUnitPage.tsx
+++ b/frontend/src/pages/FlashcardsExamineUnitPage.tsx
@@ -38,7 +38,22 @@ export default function FlashcardsExamineUnitPage() {
   const prev = () => { setIndex((i) => Math.max(0, i - 1)); setFlipped(false); };
   const next = () => { setIndex((i) => Math.min(total - 1, i + 1)); setFlipped(false); };
 
-  if (loading) return <div className="text-sm text-text/55">Cargando tarjetas...</div>;
+  if (loading) {
+    return (
+      <div className="space-y-5 max-w-2xl mx-auto animate-pulse">
+        <div className="flex items-center justify-between">
+          <div className="h-9 w-9 rounded-full bg-secondary/20" />
+          <div className="h-5 w-40 rounded-full bg-secondary/20" />
+          <div className="w-9" />
+        </div>
+        <div className="space-y-1.5">
+          <div className="h-3 w-1/3 rounded-full bg-secondary/20" />
+          <div className="h-1.5 w-full rounded-full bg-secondary/20" />
+        </div>
+        <div className="border border-secondary/15 rounded-2xl p-7 min-h-[45vh] bg-secondary/5" />
+      </div>
+    );
+  }
 
   if (error) return (
     <div className="space-y-4">
@@ -53,7 +68,20 @@ export default function FlashcardsExamineUnitPage() {
         <div className="text-4xl mb-3">📭</div>
         <p className="text-text/55 text-sm">No hay tarjetas en esta unidad.</p>
       </div>
-      <button className="btn btn-outline rounded-full px-5 py-2 text-sm" onClick={() => navigate('/flashcards')}>Volver</button>
+      <div className="flex items-center gap-3 flex-wrap">
+        <button
+          className="btn btn-outline rounded-full px-5 py-2 text-sm"
+          onClick={() => navigate('/flashcards')}
+        >
+          Volver
+        </button>
+        <button
+          className="btn btn-primary rounded-full px-5 py-2 text-sm shadow-sm shadow-primary/15"
+          onClick={() => navigate('/flashcards')}
+        >
+          Importar flashcards
+        </button>
+      </div>
     </div>
   );
 

--- a/frontend/src/pages/FlashcardsHistoryPage.tsx
+++ b/frontend/src/pages/FlashcardsHistoryPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { apiAuthJson, apiBase } from '../api';
+import { getFlashcardsHistory } from '../api';
 import FlashcardsTabs from '../components/flashcards/FlashcardsTabs';
 
 type HistoryItem = {
@@ -29,7 +29,7 @@ export default function FlashcardsHistoryPage() {
 
   useEffect(() => {
     let mounted = true;
-    apiAuthJson<HistoryItem[]>(`${apiBase}/api/flashcards/history?limit=50`, token)
+    getFlashcardsHistory<HistoryItem[]>(token, 50)
       .then((data) => { if (mounted) setItems(data || []); })
       .catch(() => { if (mounted) setError('No se pudo cargar el historial.'); })
       .finally(() => { if (mounted) setLoading(false); });

--- a/frontend/src/pages/FlashcardsPage.tsx
+++ b/frontend/src/pages/FlashcardsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { apiAuthJson, apiBase, exportFlashcardsBySubject } from '../api';
+import { exportFlashcardsBySubject, exportFlashcardsByUnit, getFlashcardsUnitsSummary, getFlashcardsStudyQueue } from '../api';
 import FlashcardImportModal from '../components/flashcards/FlashcardImportModal';
 import FlashcardsTabs from '../components/flashcards/FlashcardsTabs';
 import SearchInput from '../components/flashcards/SearchInput';
@@ -40,7 +40,7 @@ export default function FlashcardsPage() {
   const loadUnits = () => {
     setLoading(true);
     setError('');
-    apiAuthJson<UnitSummary[]>(`${apiBase}/api/flashcards/units/summary`, token)
+    getFlashcardsUnitsSummary<UnitSummary[]>(token)
       .then((data) => setUnits(data || []))
       .catch(() => setError('No se pudieron cargar las unidades.'))
       .finally(() => setLoading(false));
@@ -50,7 +50,7 @@ export default function FlashcardsPage() {
     let mounted = true;
     setLoading(true);
     setError('');
-    apiAuthJson<UnitSummary[]>(`${apiBase}/api/flashcards/units/summary`, token)
+    getFlashcardsUnitsSummary<UnitSummary[]>(token)
       .then((data) => { if (mounted) setUnits(data || []); })
       .catch(() => { if (mounted) setError('No se pudieron cargar las unidades.'); })
       .finally(() => { if (mounted) setLoading(false); });
@@ -60,7 +60,7 @@ export default function FlashcardsPage() {
   useEffect(() => {
     let mounted = true;
     setGlobalLoading(true);
-    apiAuthJson<GlobalQueue>(`${apiBase}/api/flashcards/study/queue`, token)
+    getFlashcardsStudyQueue<GlobalQueue>(token)
       .then((data) => { if (mounted) setGlobalQueue(data || null); })
       .catch(() => {})
       .finally(() => { if (mounted) setGlobalLoading(false); });
@@ -123,15 +123,7 @@ export default function FlashcardsPage() {
   const handleExport = async (unit: UnitSummary, format: 'csv' | 'json') => {
     setExportError('');
     try {
-      const res = await fetch(
-        `${apiBase}/api/flashcards/export?unitId=${unit.unitId}&format=${format}`,
-        { headers: { Authorization: `Bearer ${token}` } }
-      );
-      if (!res.ok) {
-        setExportError('No se pudo exportar. Inténtalo de nuevo.');
-        return;
-      }
-      const content = await res.text();
+      const content = await exportFlashcardsByUnit(token, unit.unitId, format);
       const blob = new Blob([content], {
         type: format === 'json' ? 'application/json' : 'text/csv',
       });

--- a/frontend/src/pages/FlashcardsPage.tsx
+++ b/frontend/src/pages/FlashcardsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { apiAuthJson, apiBase } from '../api';
+import { apiAuthJson, apiBase, exportFlashcardsBySubject } from '../api';
 import FlashcardImportModal from '../components/flashcards/FlashcardImportModal';
 import FlashcardsTabs from '../components/flashcards/FlashcardsTabs';
 import SearchInput from '../components/flashcards/SearchInput';
@@ -33,6 +33,7 @@ export default function FlashcardsPage() {
   const [globalLoading, setGlobalLoading] = useState(true);
   const [showImport, setShowImport] = useState(false);
   const [selectedSubjectId, setSelectedSubjectId] = useState<string | null>(null);
+  const [exportError, setExportError] = useState<string>('');
 
   const token = localStorage.getItem('ak_token') || '';
 
@@ -120,12 +121,16 @@ export default function FlashcardsPage() {
   };
 
   const handleExport = async (unit: UnitSummary, format: 'csv' | 'json') => {
+    setExportError('');
     try {
       const res = await fetch(
         `${apiBase}/api/flashcards/export?unitId=${unit.unitId}&format=${format}`,
         { headers: { Authorization: `Bearer ${token}` } }
       );
-      if (!res.ok) return;
+      if (!res.ok) {
+        setExportError('No se pudo exportar. Inténtalo de nuevo.');
+        return;
+      }
       const content = await res.text();
       const blob = new Blob([content], {
         type: format === 'json' ? 'application/json' : 'text/csv',
@@ -136,7 +141,24 @@ export default function FlashcardsPage() {
       link.click();
       URL.revokeObjectURL(link.href);
     } catch {
-      // silently ignore
+      setExportError('No se pudo exportar. Inténtalo de nuevo.');
+    }
+  };
+
+  const handleSubjectExport = async (subject: SubjectSummary, format: 'csv' | 'json') => {
+    setExportError('');
+    try {
+      const content = await exportFlashcardsBySubject(token, subject.subjectId, format);
+      const blob = new Blob([content], {
+        type: format === 'json' ? 'application/json' : 'text/csv',
+      });
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = `${subject.subjectName}.${format}`;
+      link.click();
+      URL.revokeObjectURL(link.href);
+    } catch {
+      setExportError('No se pudo exportar la materia. Inténtalo de nuevo.');
     }
   };
 
@@ -149,6 +171,8 @@ export default function FlashcardsPage() {
     setSelectedSubjectId(null);
     setSearch('');
   };
+
+  const openImport = () => setShowImport(true);
 
   return (
     <div className="space-y-6">
@@ -181,7 +205,7 @@ export default function FlashcardsPage() {
           </div>
           <button
             type="button"
-            onClick={() => setShowImport(true)}
+            onClick={openImport}
             className="mt-1 flex items-center gap-1.5 px-3 py-2 rounded-xl border border-secondary/30 text-sm text-text/60 hover:border-primary/40 hover:text-text transition-colors"
           >
             <span>⬆</span> Importar
@@ -193,6 +217,24 @@ export default function FlashcardsPage() {
           if (tab === 'historial') navigate('/flashcards/history');
         }} />
       </header>
+
+      {/* Export error banner */}
+      {exportError && (
+        <div
+          role="alert"
+          className="rounded-xl border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-400 flex items-center justify-between gap-3"
+        >
+          <span>{exportError}</span>
+          <button
+            type="button"
+            onClick={() => setExportError('')}
+            className="text-red-400/70 hover:text-red-400 transition-colors text-xs shrink-0"
+            aria-label="Cerrar error"
+          >
+            ✕
+          </button>
+        </div>
+      )}
 
       {/* Global queue strip — only in study mode and subject list view */}
       {mode === 'estudio' && !selectedSubjectId && (
@@ -221,6 +263,7 @@ export default function FlashcardsPage() {
             units={filteredUnitsForSubject}
             onUnitClick={handleUnitClick}
             onExport={handleExport}
+            onImport={openImport}
           />
         ) : loading ? (
           <div className="space-y-3">
@@ -233,8 +276,15 @@ export default function FlashcardsPage() {
             {error}
           </div>
         ) : filteredSubjects.length === 0 ? (
-          <div className="border border-secondary/25 rounded-2xl px-5 py-4 text-sm text-text/55">
-            No hay materias disponibles.
+          <div className="border border-secondary/25 rounded-2xl px-5 py-8 text-center space-y-4">
+            <p className="text-sm text-text/55">No hay materias disponibles.</p>
+            <button
+              type="button"
+              onClick={openImport}
+              className="btn btn-primary rounded-full px-6 py-2 text-sm shadow-sm shadow-primary/15"
+            >
+              Importar flashcards
+            </button>
           </div>
         ) : (
           <div className="space-y-3">
@@ -243,6 +293,7 @@ export default function FlashcardsPage() {
                 key={subject.subjectId}
                 subject={subject}
                 onClick={() => handleSelectSubject(subject.subjectId)}
+                onExport={(fmt) => handleSubjectExport(subject, fmt)}
               />
             ))}
           </div>

--- a/frontend/src/pages/FlashcardsStudyPage.tsx
+++ b/frontend/src/pages/FlashcardsStudyPage.tsx
@@ -19,6 +19,7 @@ export default function FlashcardsStudyPage() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [reviewError, setReviewError] = useState<string | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [finished, setFinished] = useState(false);
@@ -64,6 +65,7 @@ export default function FlashcardsStudyPage() {
   const handleReview = async (grade: ReviewRequest['grade']) => {
     if (!currentItem || submitting) return;
     setSubmitting(true);
+    setReviewError(null);
     try {
       await apiAuthJson(`${apiBase}/api/flashcards/study/review`, token, {
         method: 'POST',
@@ -78,14 +80,23 @@ export default function FlashcardsStudyPage() {
       setItems((prev) => [...prev, next]);
       setCurrentIndex((prev) => prev + 1);
     } catch {
-      setError('No se pudo registrar la respuesta.');
+      setReviewError('No se pudo registrar la respuesta. Inténtalo de nuevo.');
     } finally {
       setSubmitting(false);
     }
   };
 
   if (loading) {
-    return <div className="text-sm text-text/55">Cargando sesión...</div>;
+    return (
+      <div className="space-y-5 max-w-2xl mx-auto animate-pulse">
+        <div className="h-9 w-9 rounded-full bg-secondary/20" />
+        <div className="space-y-1.5">
+          <div className="h-3 w-2/3 rounded-full bg-secondary/20" />
+          <div className="h-1.5 w-full rounded-full bg-secondary/20" />
+        </div>
+        <div className="border border-secondary/15 rounded-2xl p-7 min-h-[52vh] bg-secondary/5" />
+      </div>
+    );
   }
 
   if (error) {
@@ -98,6 +109,7 @@ export default function FlashcardsStudyPage() {
   }
 
   if (finished) {
+    const nothingToReview = answeredCount === 0;
     return (
       <div className="space-y-6">
         <header className="flex items-center gap-4">
@@ -108,12 +120,20 @@ export default function FlashcardsStudyPage() {
           >
             <ArrowLeft className="h-4 w-4" />
           </button>
-          <h1 className="text-2xl font-extrabold tracking-tight">Sesión completada</h1>
+          <h1 className="text-2xl font-extrabold tracking-tight">
+            {nothingToReview ? 'Sin pendientes' : 'Sesión completada'}
+          </h1>
         </header>
         <div className="border border-secondary/25 rounded-2xl p-8 text-center">
-          <div className="text-5xl mb-4">🎉</div>
-          <div className="text-xl font-bold mb-2">¡Bien hecho!</div>
-          <p className="text-text/55 text-sm mb-6">Has respondido <strong>{answeredCount}</strong> tarjetas en esta sesión.</p>
+          <div className="text-5xl mb-4">{nothingToReview ? '✅' : '🎉'}</div>
+          <div className="text-xl font-bold mb-2">
+            {nothingToReview ? 'Nada que repasar hoy' : '¡Bien hecho!'}
+          </div>
+          <p className="text-text/55 text-sm mb-6">
+            {nothingToReview
+              ? 'No había tarjetas pendientes para repasar en esta sesión.'
+              : <>Has respondido <strong>{answeredCount}</strong> tarjetas en esta sesión.</>}
+          </p>
           <button
             className="btn btn-primary rounded-full px-8 py-2.5 text-sm shadow-lg shadow-primary/20 inline-flex items-center gap-2"
             onClick={() => navigate('/flashcards')}
@@ -156,6 +176,24 @@ export default function FlashcardsStudyPage() {
           <div className="h-full bg-primary rounded-full transition-all duration-500" style={{ width: `${progressPct}%` }} />
         </div>
       </div>
+
+      {/* ── Review error banner ── */}
+      {reviewError && (
+        <div
+          role="alert"
+          className="rounded-xl border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-400 flex items-center justify-between gap-3"
+        >
+          <span>{reviewError}</span>
+          <button
+            type="button"
+            onClick={() => setReviewError(null)}
+            className="text-red-400/70 hover:text-red-400 transition-colors text-xs shrink-0"
+            aria-label="Cerrar error"
+          >
+            ✕
+          </button>
+        </div>
+      )}
 
       {/* ── Card ── */}
       <div className="relative">

--- a/frontend/src/pages/FlashcardsStudyPage.tsx
+++ b/frontend/src/pages/FlashcardsStudyPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ArrowLeft, CircleMinus, CheckCircle } from 'flowbite-react-icons/outline';
-import { apiAuthJson, apiBase } from '../api';
+import { getFlashcardsStudyQueue, getFlashcardsStudyNext, reviewFlashcard } from '../api';
 
 type IntervalHints = { again: string; good: string; easy: string };
 type ReviewState = 'NEW' | 'LEARNING' | 'REVIEW';
@@ -29,10 +29,10 @@ export default function FlashcardsStudyPage() {
   const token = localStorage.getItem('ak_token') || '';
 
   const fetchNext = async () => {
-    const data = await apiAuthJson<StudyItem | undefined>(`${apiBase}/api/flashcards/study/next?unitId=${unitId}`, token);
+    const data = await getFlashcardsStudyNext<StudyItem | undefined>(token, unitId!);
     return data || null;
   };
-  const fetchQueue = async () => apiAuthJson<StudyQueueResponse>(`${apiBase}/api/flashcards/study/queue?unitId=${unitId}`, token);
+  const fetchQueue = async () => getFlashcardsStudyQueue<StudyQueueResponse>(token, unitId!);
 
   const currentItem = items[currentIndex];
   const remaining = Math.max(queueCounts.new + queueCounts.due + queueCounts.learning, 0);
@@ -67,11 +67,7 @@ export default function FlashcardsStudyPage() {
     setSubmitting(true);
     setReviewError(null);
     try {
-      await apiAuthJson(`${apiBase}/api/flashcards/study/review`, token, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ flashcardId: currentItem.flashcardId, grade, reviewedAt: new Date().toISOString() } satisfies ReviewRequest)
-      });
+      await reviewFlashcard(token, { flashcardId: currentItem.flashcardId, grade, reviewedAt: new Date().toISOString() } satisfies ReviewRequest);
       const [newQueue, next] = await Promise.all([fetchQueue(), fetchNext()]);
       if (newQueue) setQueueCounts(newQueue);
       setAnsweredCount((prev) => prev + 1);

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+import { getMyProfile, updateMyProfile } from '../api';
+
+const inp =
+  'w-full bg-white/50 dark:bg-[#24394c] border border-secondary/30 rounded-xl px-4 py-2.5 text-sm text-text placeholder:text-text/35 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50 transition-colors';
+const card = 'border border-secondary/25 rounded-2xl p-6';
+const btnPrimary =
+  'btn btn-primary rounded-full px-5 py-2 text-sm shadow-sm shadow-primary/15 flex items-center gap-2 disabled:opacity-60';
+
+export default function ProfilePage({ token }: { token: string }) {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [successMsg, setSuccessMsg] = useState('');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  useEffect(() => {
+    setLoading(true);
+    getMyProfile(token)
+      .then((profile) => {
+        setEmail(profile.email);
+        setFirstName(profile.firstName ?? '');
+        setLastName(profile.lastName ?? '');
+      })
+      .catch(() => {
+        setErrorMsg('No se pudo cargar el perfil.');
+      })
+      .finally(() => setLoading(false));
+  }, [token]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSuccessMsg('');
+    setErrorMsg('');
+    setLoading(true);
+    try {
+      await updateMyProfile(token, {
+        firstName: firstName.trim() || null,
+        lastName: lastName.trim() || null,
+      });
+      setSuccessMsg('Cambios guardados correctamente.');
+    } catch {
+      setErrorMsg('No se pudieron guardar los cambios.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="max-w-lg mx-auto space-y-6">
+      <h1 className="text-2xl font-bold">Mi perfil</h1>
+
+      <div className={card}>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1.5" htmlFor="profile-email">
+              Correo electrónico
+            </label>
+            <input
+              id="profile-email"
+              type="email"
+              className={inp + ' opacity-60 cursor-not-allowed'}
+              value={email}
+              readOnly
+              aria-readonly="true"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1.5" htmlFor="profile-firstName">
+              Nombre
+            </label>
+            <input
+              id="profile-firstName"
+              type="text"
+              className={inp}
+              placeholder="Tu nombre"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1.5" htmlFor="profile-lastName">
+              Apellidos
+            </label>
+            <input
+              id="profile-lastName"
+              type="text"
+              className={inp}
+              placeholder="Tus apellidos"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+            />
+          </div>
+
+          {successMsg && (
+            <p role="status" className="text-sm text-green-500">
+              {successMsg}
+            </p>
+          )}
+          {errorMsg && (
+            <p role="alert" className="text-sm text-red-500">
+              {errorMsg}
+            </p>
+          )}
+
+          <div className="flex justify-end pt-2">
+            <button type="submit" className={btnPrimary} disabled={loading}>
+              {loading ? 'Guardando…' : 'Guardar cambios'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/RagPage.tsx
+++ b/frontend/src/pages/RagPage.tsx
@@ -100,9 +100,9 @@ export default function RagPage({ token, subjects }: Props) {
       </div>
 
       {!selectedSubjectId && (
-        <p className="text-sm text-yellow-600 bg-yellow-50 border border-yellow-200 rounded-xl px-4 py-3">
-          Selecciona una asignatura para comenzar.
-        </p>
+        <div className="border border-secondary/25 rounded-2xl px-5 py-8 text-center">
+          <p className="text-sm text-text/55">Selecciona una asignatura para comenzar.</p>
+        </div>
       )}
 
       {selectedSubjectId && (

--- a/frontend/src/pages/SubjectsPage.tsx
+++ b/frontend/src/pages/SubjectsPage.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { formatDuration } from '../utils/format';
 import { Plus, ArrowsRepeat, ClipboardCheck } from 'flowbite-react-icons/outline';
-import { apiAuthJson, apiBase } from '../api';
+import { getExamAttempts } from '../api';
 import type { Subject, ExamAttemptSummary } from '../types';
 import { ROUTES } from '../constants/routes';
 
@@ -31,7 +31,7 @@ export default function SubjectsPage({ subjects, activeAttemptId, token, onUnaut
   useEffect(() => {
     setLoading(true);
     setError('');
-    apiAuthJson<ExamAttemptSummary[]>(`${apiBase}/api/exams/attempts`, token)
+    getExamAttempts(token)
       .then(setHistory)
       .catch(err => {
         if (err?.status === 401) onUnauthorized();
@@ -39,7 +39,7 @@ export default function SubjectsPage({ subjects, activeAttemptId, token, onUnaut
         setHistory([]);
       })
       .finally(() => setLoading(false));
-  }, [token, apiBase]);
+  }, [token]);
 
   return (
     <section className="mb-8">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -90,3 +90,10 @@ export interface NavUser {
   initials: string;
   avatarUrl?: string;
 }
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -84,3 +84,9 @@ export type GenerateQuizResponse = {
 };
 
 export type AdminUnit = { id: string; name: string };
+
+export interface NavUser {
+  email: string;
+  initials: string;
+  avatarUrl?: string;
+}

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -3,3 +3,13 @@ export function formatDuration(seconds: number) {
   const secs = seconds % 60;
   return `${mins}m ${String(secs).padStart(2, '0')}s`;
 }
+
+export function deriveInitials(email: string): string {
+  if (!email) return '';
+  const local = email.split('@')[0];
+  const parts = local.split(/[._-]/);
+  return parts
+    .slice(0, 2)
+    .map(p => p[0]?.toUpperCase() ?? '')
+    .join('');
+}


### PR DESCRIPTION
Centralizes all API endpoints into a single source of truth in `frontend/src/constants/apiRoutes.ts`.
This improves maintainability and reduces duplication across components and tests.

Key changes:
- Created `frontend/src/constants/apiRoutes.ts`.
- Updated all components and pages to use `API_ROUTES` from the new constants file.
- Updated `api.ts` to use constants for all fetch calls.
- Updated and fixed unit tests in frontend to use the centralized routes.
- Verified all tests (frontend & backend) are passing.

Closes #90