### PR TITLE
🔒 security(auth): stop exposing JWT in OAuth2 callback URL (#94)

### DIFF
--- a/backend/src/main/java/com/akdemya/adapter/inbound/web/AuthController.java
+++ b/backend/src/main/java/com/akdemya/adapter/inbound/web/AuthController.java
@@ -1,5 +1,6 @@
 package com.akdemya.adapter.inbound.web;
 
+import com.akdemya.adapter.infrastructure.security.OAuth2CodeStore;
 import com.akdemya.domain.port.in.AuthUseCase;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -10,9 +11,11 @@ import java.util.Map;
 @RequestMapping("/api/auth")
 public class AuthController {
     private final AuthUseCase authUseCase;
+    private final OAuth2CodeStore codeStore;
 
-    public AuthController(AuthUseCase authUseCase) {
+    public AuthController(AuthUseCase authUseCase, OAuth2CodeStore codeStore) {
         this.authUseCase = authUseCase;
+        this.codeStore = codeStore;
     }
 
     @PostMapping("/register")
@@ -32,4 +35,15 @@ public class AuthController {
         }
         return ResponseEntity.ok(Map.of("accessToken", response.accessToken(), "role", response.role()));
     }
+
+    @PostMapping("/oauth2/exchange")
+    public ResponseEntity<?> exchangeOAuth2Code(@RequestBody ExchangeCodeRequest req) {
+        return codeStore.exchange(req.code())
+            .map(result -> ResponseEntity.ok(
+                (Object) Map.of("accessToken", result.accessToken(), "role", result.role())))
+            .orElseGet(() -> ResponseEntity.badRequest().body(
+                Map.of("error", "invalid_code")));
+    }
+
+    public record ExchangeCodeRequest(String code) {}
 }

--- a/backend/src/main/java/com/akdemya/adapter/infrastructure/security/OAuth2CodeStore.java
+++ b/backend/src/main/java/com/akdemya/adapter/infrastructure/security/OAuth2CodeStore.java
@@ -1,0 +1,45 @@
+package com.akdemya.adapter.infrastructure.security;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class OAuth2CodeStore {
+
+    private final ConcurrentHashMap<String, CodeEntry> codes = new ConcurrentHashMap<>();
+
+    public String store(String jwt, String role) {
+        String code = UUID.randomUUID().toString();
+        codes.put(code, new CodeEntry(jwt, role, Instant.now().plusSeconds(60)));
+        return code;
+    }
+
+    public Optional<ExchangeResult> exchange(String code) {
+        CodeEntry entry = codes.remove(code);
+        if (entry == null) {
+            return Optional.empty();
+        }
+        if (Instant.now().isAfter(entry.expiresAt)) {
+            return Optional.empty();
+        }
+        return Optional.of(new ExchangeResult(entry.jwt, entry.role));
+    }
+
+    static class CodeEntry {
+        final String jwt;
+        final String role;
+        Instant expiresAt;
+
+        CodeEntry(String jwt, String role, Instant expiresAt) {
+            this.jwt = jwt;
+            this.role = role;
+            this.expiresAt = expiresAt;
+        }
+    }
+
+    public record ExchangeResult(String accessToken, String role) {}
+}

--- a/backend/src/main/java/com/akdemya/adapter/infrastructure/security/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/akdemya/adapter/infrastructure/security/OAuth2SuccessHandler.java
@@ -16,11 +16,14 @@ import java.io.IOException;
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final AuthUseCase authUseCase;
+    private final OAuth2CodeStore codeStore;
     private final String frontendUrl;
 
     public OAuth2SuccessHandler(AuthUseCase authUseCase,
+                                OAuth2CodeStore codeStore,
                                 @Value("${app.frontend-url}") String frontendUrl) {
         this.authUseCase = authUseCase;
+        this.codeStore = codeStore;
         this.frontendUrl = frontendUrl;
     }
 
@@ -33,6 +36,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String email = oAuth2User.getAttribute("email");
         String name  = oAuth2User.getAttribute("name");
         AuthUseCase.AuthResponse authResponse = authUseCase.loginWithOAuth2(email, name);
-        response.sendRedirect(frontendUrl + "/oauth2/callback?token=" + authResponse.accessToken());
+        String code = codeStore.store(authResponse.accessToken(), authResponse.role());
+        response.sendRedirect(frontendUrl + "/oauth2/callback?code=" + code);
     }
 }

--- a/backend/src/test/java/com/akdemya/adapter/inbound/web/AuthControllerOAuth2ExchangeTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/inbound/web/AuthControllerOAuth2ExchangeTest.java
@@ -1,0 +1,117 @@
+package com.akdemya.adapter.inbound.web;
+
+import com.akdemya.adapter.infrastructure.security.OAuth2CodeStore;
+import com.akdemya.domain.port.in.AuthUseCase;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AuthControllerOAuth2ExchangeTest {
+
+    private final AuthUseCase authUseCase = mock(AuthUseCase.class);
+    private final OAuth2CodeStore codeStore = mock(OAuth2CodeStore.class);
+    private final AuthController controller = new AuthController(authUseCase, codeStore);
+
+    // --- register ---
+
+    @Test
+    void registerSuccess_returns200WithTokenAndRole() {
+        var cmd = new AuthUseCase.RegisterCommand("a@b.com", "pass", "pass", "A", "B", "dev");
+        when(authUseCase.register(cmd))
+            .thenReturn(AuthUseCase.AuthResponse.success("tok", "STUDENT"));
+
+        ResponseEntity<?> resp = controller.register(cmd);
+
+        assertEquals(200, resp.getStatusCodeValue());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) resp.getBody();
+        assertNotNull(body);
+        assertEquals("tok", body.get("accessToken"));
+        assertEquals("STUDENT", body.get("role"));
+    }
+
+    @Test
+    void registerFailure_returns400WithErrorField() {
+        var cmd = new AuthUseCase.RegisterCommand("a@b.com", "short", "short", "A", "B", "dev");
+        when(authUseCase.register(cmd))
+            .thenReturn(AuthUseCase.AuthResponse.fail("password_too_short"));
+
+        ResponseEntity<?> resp = controller.register(cmd);
+
+        assertEquals(400, resp.getStatusCodeValue());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) resp.getBody();
+        assertNotNull(body);
+        assertEquals("password_too_short", body.get("error"));
+    }
+
+    // --- login ---
+
+    @Test
+    void loginSuccess_returns200WithTokenAndRole() {
+        var cmd = new AuthUseCase.LoginCommand("a@b.com", "pass");
+        when(authUseCase.login(cmd))
+            .thenReturn(AuthUseCase.AuthResponse.success("tok", "ADMIN"));
+
+        ResponseEntity<?> resp = controller.login(cmd);
+
+        assertEquals(200, resp.getStatusCodeValue());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) resp.getBody();
+        assertNotNull(body);
+        assertEquals("tok", body.get("accessToken"));
+        assertEquals("ADMIN", body.get("role"));
+    }
+
+    @Test
+    void loginFailure_returns401WithErrorField() {
+        var cmd = new AuthUseCase.LoginCommand("a@b.com", "wrong");
+        when(authUseCase.login(cmd))
+            .thenReturn(AuthUseCase.AuthResponse.fail("invalid_credentials"));
+
+        ResponseEntity<?> resp = controller.login(cmd);
+
+        assertEquals(401, resp.getStatusCodeValue());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) resp.getBody();
+        assertNotNull(body);
+        assertEquals("invalid_credentials", body.get("error"));
+    }
+
+    @Test
+    void exchangeValidCodeReturns200WithAccessTokenAndRole() {
+        String code = "valid-uuid-code";
+        when(codeStore.exchange(code))
+            .thenReturn(Optional.of(new OAuth2CodeStore.ExchangeResult("jwt.token.here", "STUDENT")));
+
+        var request = new AuthController.ExchangeCodeRequest(code);
+        ResponseEntity<?> response = controller.exchangeOAuth2Code(request);
+
+        assertEquals(200, response.getStatusCodeValue());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertNotNull(body);
+        assertEquals("jwt.token.here", body.get("accessToken"));
+        assertEquals("STUDENT", body.get("role"));
+    }
+
+    @Test
+    void exchangeUnknownCodeReturns400WithErrorField() {
+        String code = "unknown-code";
+        when(codeStore.exchange(code)).thenReturn(Optional.empty());
+
+        var request = new AuthController.ExchangeCodeRequest(code);
+        ResponseEntity<?> response = controller.exchangeOAuth2Code(request);
+
+        assertEquals(400, response.getStatusCodeValue());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertNotNull(body);
+        assertEquals("invalid_code", body.get("error"));
+    }
+}

--- a/backend/src/test/java/com/akdemya/adapter/infrastructure/security/OAuth2CodeStoreTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/infrastructure/security/OAuth2CodeStoreTest.java
@@ -1,0 +1,69 @@
+package com.akdemya.adapter.infrastructure.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OAuth2CodeStoreTest {
+
+    private final OAuth2CodeStore store = new OAuth2CodeStore();
+
+    @Test
+    void storeAndExchangeReturnsCorrectJwtAndRole() {
+        String jwt = "test.jwt.token";
+        String role = "STUDENT";
+
+        String code = store.store(jwt, role);
+
+        assertNotNull(code);
+        assertFalse(code.isBlank());
+
+        Optional<OAuth2CodeStore.ExchangeResult> result = store.exchange(code);
+
+        assertTrue(result.isPresent());
+        assertEquals(jwt, result.get().accessToken());
+        assertEquals(role, result.get().role());
+    }
+
+    @Test
+    void secondExchangeOfSameCodeReturnsEmpty() {
+        String code = store.store("jwt", "ADMIN");
+
+        store.exchange(code); // first use
+        Optional<OAuth2CodeStore.ExchangeResult> second = store.exchange(code);
+
+        assertTrue(second.isEmpty());
+    }
+
+    @Test
+    void expiredCodeReturnsEmpty() throws Exception {
+        String code = store.store("expired.jwt", "STUDENT");
+
+        // Use reflection to manipulate the stored entry's expiresAt to be in the past
+        Field codesField = OAuth2CodeStore.class.getDeclaredField("codes");
+        codesField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, OAuth2CodeStore.CodeEntry> codes =
+            (Map<String, OAuth2CodeStore.CodeEntry>) codesField.get(store);
+
+        OAuth2CodeStore.CodeEntry entry = codes.get(code);
+        Field expiresAtField = OAuth2CodeStore.CodeEntry.class.getDeclaredField("expiresAt");
+        expiresAtField.setAccessible(true);
+        expiresAtField.set(entry, Instant.now().minusSeconds(1));
+
+        Optional<OAuth2CodeStore.ExchangeResult> result = store.exchange(code);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void unknownCodeReturnsEmpty() {
+        Optional<OAuth2CodeStore.ExchangeResult> result = store.exchange("nonexistent-code");
+        assertTrue(result.isEmpty());
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -80,16 +80,26 @@ export default function App() {
     refreshSubjects();
   }, [token, apiBase]);
 
-  // Handle OAuth2 callback: extract token from URL query param
+  // Handle OAuth2 callback: exchange ephemeral code for JWT
   useEffect(() => {
     if (location.pathname === ROUTES.oauth2Callback) {
       const params = new URLSearchParams(location.search);
-      const callbackToken = params.get('token');
-      if (callbackToken) {
-        onToken(callbackToken);
-      } else {
+      const code = params.get('code');
+      if (!code) {
         navigate(ROUTES.login);
+        return;
       }
+      fetch(`${apiBase}/api/auth/oauth2/exchange`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code }),
+      })
+        .then((res) => {
+          if (!res.ok) throw new Error('exchange_failed');
+          return res.json() as Promise<{ accessToken: string; role: string }>;
+        })
+        .then((data) => onToken(data.accessToken))
+        .catch(() => navigate(ROUTES.login));
     }
   }, [location.pathname]);
 


### PR DESCRIPTION
## Summary

Replaces the insecure `?token=<jwt>` redirect in the OAuth2 callback with a short-lived, single-use authorization code (`?code=<uuid>`). The frontend exchanges this code via `POST /api/auth/oauth2/exchange` to obtain the JWT, preventing token exposure in browser history, server logs, and Referer headers.

## Changes

- **`OAuth2CodeStore`** — new in-memory store (ConcurrentHashMap) with 60s TTL and single-use enforcement
- **`OAuth2SuccessHandler`** — redirects with `?code=<uuid>` instead of `?token=<jwt>`
- **`AuthController`** — new `POST /api/auth/oauth2/exchange` endpoint; returns 400 for expired/unknown codes
- **`App.tsx`** — reads `code` param, exchanges it for token, navigates to login on failure

## Test plan

- [ ] Unit: `OAuth2CodeStoreTest` — happy path, single-use, expiry, unknown code (4 tests)
- [ ] Unit: `AuthControllerOAuth2ExchangeTest` — valid code → 200, unknown code → 400 (2 tests)
- [ ] Frontend: existing 132 tests pass

## Coverage

Backend: 67.8% LINE / 55.2% BRANCH (project-wide baseline, pre-existing)
Frontend: 34.67% (project-wide baseline, pre-existing)

## Quality Gate

✅ PASSED — 0 new issues

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)