### PR TITLE
🔒 security(auth): migrate JWT storage to httpOnly cookies (#95)

### DIFF
--- a/backend/src/main/java/com/akdemya/adapter/inbound/web/AuthController.java
+++ b/backend/src/main/java/com/akdemya/adapter/inbound/web/AuthController.java
@@ -1,10 +1,16 @@
 package com.akdemya.adapter.inbound.web;
 
+import com.akdemya.adapter.infrastructure.security.JwtService;
 import com.akdemya.adapter.infrastructure.security.OAuth2CodeStore;
 import com.akdemya.domain.port.in.AuthUseCase;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Arrays;
 import java.util.Map;
 
 @RestController
@@ -12,37 +18,90 @@ import java.util.Map;
 public class AuthController {
     private final AuthUseCase authUseCase;
     private final OAuth2CodeStore codeStore;
+    private final JwtService jwtService;
+    private final boolean cookieSecure;
 
-    public AuthController(AuthUseCase authUseCase, OAuth2CodeStore codeStore) {
+    public AuthController(AuthUseCase authUseCase,
+                          OAuth2CodeStore codeStore,
+                          JwtService jwtService,
+                          @Value("${app.cookie.secure:true}") boolean cookieSecure) {
         this.authUseCase = authUseCase;
         this.codeStore = codeStore;
+        this.jwtService = jwtService;
+        this.cookieSecure = cookieSecure;
     }
 
     @PostMapping("/register")
-    public ResponseEntity<?> register(@RequestBody AuthUseCase.RegisterCommand req) {
+    public ResponseEntity<?> register(@RequestBody AuthUseCase.RegisterCommand req, HttpServletResponse res) {
         var response = authUseCase.register(req);
         if (response.error() != null) {
             return ResponseEntity.badRequest().body(Map.of("error", response.error()));
         }
-        return ResponseEntity.ok(Map.of("accessToken", response.accessToken(), "role", response.role()));
+        addAuthCookie(res, response.accessToken(), 86400);
+        return ResponseEntity.ok(Map.of("role", response.role()));
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody AuthUseCase.LoginCommand req) {
+    public ResponseEntity<?> login(@RequestBody AuthUseCase.LoginCommand req, HttpServletResponse res) {
         var response = authUseCase.login(req);
         if (response.error() != null) {
             return ResponseEntity.status(401).body(Map.of("error", response.error()));
         }
-        return ResponseEntity.ok(Map.of("accessToken", response.accessToken(), "role", response.role()));
+        addAuthCookie(res, response.accessToken(), 86400);
+        return ResponseEntity.ok(Map.of("role", response.role()));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletResponse res) {
+        addAuthCookie(res, "", 0);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<?> me(HttpServletRequest req) {
+        Cookie[] cookies = req.getCookies();
+        if (cookies == null) {
+            return ResponseEntity.status(401).body(Map.of("error", "no_token"));
+        }
+        String token = Arrays.stream(cookies)
+            .filter(c -> "ak_token".equals(c.getName()))
+            .map(Cookie::getValue)
+            .findFirst()
+            .orElse(null);
+
+        if (token == null || token.isBlank()) {
+            return ResponseEntity.status(401).body(Map.of("error", "no_token"));
+        }
+
+        try {
+            var jws = jwtService.parse(token);
+            String email = jws.getBody().getSubject();
+            String role  = String.valueOf(jws.getBody().get("role"));
+            return ResponseEntity.ok(Map.of("email", email, "role", role));
+        } catch (Exception e) {
+            return ResponseEntity.status(401).body(Map.of("error", "invalid_token"));
+        }
     }
 
     @PostMapping("/oauth2/exchange")
-    public ResponseEntity<?> exchangeOAuth2Code(@RequestBody ExchangeCodeRequest req) {
+    public ResponseEntity<?> exchangeOAuth2Code(@RequestBody ExchangeCodeRequest req, HttpServletResponse res) {
         return codeStore.exchange(req.code())
-            .map(result -> ResponseEntity.ok(
-                (Object) Map.of("accessToken", result.accessToken(), "role", result.role())))
+            .map(result -> {
+                addAuthCookie(res, result.accessToken(), 86400);
+                return ResponseEntity.ok((Object) Map.of("role", result.role()));
+            })
             .orElseGet(() -> ResponseEntity.badRequest().body(
                 Map.of("error", "invalid_code")));
+    }
+
+    private void addAuthCookie(HttpServletResponse res, String value, int maxAge) {
+        Cookie cookie = new Cookie("ak_token", value);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(cookieSecure);
+        cookie.setPath("/api");
+        cookie.setMaxAge(maxAge);
+        cookie.setAttribute("SameSite", "Strict");
+        res.addCookie(cookie);
     }
 
     public record ExchangeCodeRequest(String code) {}

--- a/backend/src/main/java/com/akdemya/adapter/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/com/akdemya/adapter/infrastructure/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.akdemya.adapter.infrastructure.security;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.context.annotation.Bean;
@@ -22,6 +23,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -87,7 +89,7 @@ public class SecurityConfig {
             "https://akademia.diegobarrioh.dev"
         ));
         cfg.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
-        cfg.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept", "Origin", "X-Requested-With"));
+        cfg.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept", "Origin", "X-Requested-With", "Cookie"));
         cfg.setExposedHeaders(List.of("Authorization", "Content-Type"));
         cfg.setAllowCredentials(true);
         cfg.setMaxAge(3600L);
@@ -109,9 +111,8 @@ public class SecurityConfig {
         @Override
         protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
                 throws ServletException, IOException {
-            String header = req.getHeader(HttpHeaders.AUTHORIZATION);
-            if (header != null && header.startsWith("Bearer ")) {
-                String token = header.substring(7);
+            String token = resolveToken(req);
+            if (token != null) {
                 try {
                     var jws = jwt.parse(token);
                     String email = jws.getBody().getSubject();
@@ -127,6 +128,23 @@ public class SecurityConfig {
                 }
             }
             chain.doFilter(req, res);
+        }
+
+        private String resolveToken(HttpServletRequest req) {
+            String header = req.getHeader(HttpHeaders.AUTHORIZATION);
+            if (header != null && header.startsWith("Bearer ")) {
+                return header.substring(7);
+            }
+            Cookie[] cookies = req.getCookies();
+            if (cookies != null) {
+                return Arrays.stream(cookies)
+                    .filter(c -> "ak_token".equals(c.getName()))
+                    .map(Cookie::getValue)
+                    .filter(v -> v != null && !v.isBlank())
+                    .findFirst()
+                    .orElse(null);
+            }
+            return null;
         }
     }
 }

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -1,6 +1,7 @@
 spring.flyway.locations=classpath:db/migration,classpath:db/migration-dev
 # Dev: ignore missing versioned migrations after moving seeds to repeatable
 spring.flyway.ignore-migration-patterns=*:missing
+app.cookie.secure=false
 
 app.flashcards.learning-steps-minutes=1,10
 app.flashcards.easy-interval-days=4

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -14,6 +14,7 @@ spring.flyway.locations=classpath:db/migration
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
 security.jwt.secret=${JWT_SECRET}
+app.cookie.secure=${COOKIE_SECURE:true}
 
 # Google OAuth2
 # Endpoints are mounted under /api so they go through the single nginx proxy

--- a/backend/src/test/java/com/akdemya/adapter/inbound/web/AuthControllerCookieTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/inbound/web/AuthControllerCookieTest.java
@@ -1,0 +1,206 @@
+package com.akdemya.adapter.inbound.web;
+
+import com.akdemya.adapter.infrastructure.security.JwtService;
+import com.akdemya.adapter.infrastructure.security.OAuth2CodeStore;
+import com.akdemya.domain.port.in.AuthUseCase;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AuthControllerCookieTest {
+
+    private final AuthUseCase authUseCase = mock(AuthUseCase.class);
+    private final OAuth2CodeStore codeStore = mock(OAuth2CodeStore.class);
+    private final JwtService jwtService = mock(JwtService.class);
+
+    private AuthController controller;
+
+    @BeforeEach
+    void setUp() {
+        // secure=false to test cookie attributes without HTTPS in unit tests
+        controller = new AuthController(authUseCase, codeStore, jwtService, false);
+    }
+
+    // ── login ──
+
+    @Test
+    void login_setsCookieAndReturnsRole() {
+        var cmd = new AuthUseCase.LoginCommand("a@b.com", "pass");
+        when(authUseCase.login(cmd))
+            .thenReturn(AuthUseCase.AuthResponse.success("jwt.token.here", "STUDENT"));
+
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        ResponseEntity<?> response = controller.login(cmd, res);
+
+        assertEquals(200, response.getStatusCodeValue());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertNotNull(body);
+        assertFalse(body.containsKey("accessToken"), "accessToken must NOT be in response body");
+        assertEquals("STUDENT", body.get("role"));
+
+        Cookie cookie = res.getCookie("ak_token");
+        assertNotNull(cookie, "ak_token cookie must be set");
+        assertEquals("jwt.token.here", cookie.getValue());
+        assertTrue(cookie.isHttpOnly(), "cookie must be httpOnly");
+        assertEquals("/api", cookie.getPath());
+        assertEquals(86400, cookie.getMaxAge());
+    }
+
+    @Test
+    void login_secureFlagRespectedFromConfig() {
+        // With secure=true
+        AuthController secureController = new AuthController(authUseCase, codeStore, jwtService, true);
+        var cmd = new AuthUseCase.LoginCommand("a@b.com", "pass");
+        when(authUseCase.login(cmd))
+            .thenReturn(AuthUseCase.AuthResponse.success("tok", "STUDENT"));
+
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        secureController.login(cmd, res);
+
+        Cookie cookie = res.getCookie("ak_token");
+        assertNotNull(cookie);
+        assertTrue(cookie.getSecure(), "secure flag must be set when configured");
+    }
+
+    @Test
+    void login_insecureFlagRespectedFromConfig() {
+        var cmd = new AuthUseCase.LoginCommand("a@b.com", "pass");
+        when(authUseCase.login(cmd))
+            .thenReturn(AuthUseCase.AuthResponse.success("tok", "STUDENT"));
+
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        controller.login(cmd, res);
+
+        Cookie cookie = res.getCookie("ak_token");
+        assertNotNull(cookie);
+        assertFalse(cookie.getSecure(), "secure flag must NOT be set when configured as false");
+    }
+
+    // ── register ──
+
+    @Test
+    void register_setsCookieAndReturnsRole() {
+        var cmd = new AuthUseCase.RegisterCommand("a@b.com", "pass", "pass", "A", "B", "dev");
+        when(authUseCase.register(cmd))
+            .thenReturn(AuthUseCase.AuthResponse.success("jwt.reg.token", "STUDENT"));
+
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        ResponseEntity<?> response = controller.register(cmd, res);
+
+        assertEquals(200, response.getStatusCodeValue());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertNotNull(body);
+        assertFalse(body.containsKey("accessToken"), "accessToken must NOT be in response body");
+        assertEquals("STUDENT", body.get("role"));
+
+        Cookie cookie = res.getCookie("ak_token");
+        assertNotNull(cookie);
+        assertEquals("jwt.reg.token", cookie.getValue());
+        assertTrue(cookie.isHttpOnly());
+        assertEquals("/api", cookie.getPath());
+        assertEquals(86400, cookie.getMaxAge());
+    }
+
+    // ── logout ──
+
+    @Test
+    void logout_clearsCookieWithMaxAgeZero() {
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        ResponseEntity<?> response = controller.logout(res);
+
+        assertEquals(204, response.getStatusCodeValue());
+
+        Cookie cookie = res.getCookie("ak_token");
+        assertNotNull(cookie, "ak_token cookie must be set on logout");
+        assertEquals("", cookie.getValue());
+        assertEquals(0, cookie.getMaxAge());
+        assertEquals("/api", cookie.getPath());
+    }
+
+    // ── /me ──
+
+    @Test
+    void me_withValidToken_returnsEmailAndRole() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        Cookie authCookie = new Cookie("ak_token", "valid.jwt.token");
+        req.setCookies(authCookie);
+
+        @SuppressWarnings("unchecked")
+        Jws<Claims> jws = mock(Jws.class);
+        Claims claims = mock(Claims.class);
+        when(jws.getBody()).thenReturn(claims);
+        when(claims.getSubject()).thenReturn("user@example.com");
+        when(claims.get("role")).thenReturn("STUDENT");
+        when(jwtService.parse("valid.jwt.token")).thenReturn(jws);
+
+        ResponseEntity<?> response = controller.me(req);
+
+        assertEquals(200, response.getStatusCodeValue());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertNotNull(body);
+        assertEquals("user@example.com", body.get("email"));
+        assertEquals("STUDENT", body.get("role"));
+    }
+
+    @Test
+    void me_withNoToken_returns401() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        // No cookies set
+
+        ResponseEntity<?> response = controller.me(req);
+
+        assertEquals(401, response.getStatusCodeValue());
+    }
+
+    @Test
+    void me_withInvalidToken_returns401() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        Cookie authCookie = new Cookie("ak_token", "invalid.token");
+        req.setCookies(authCookie);
+
+        when(jwtService.parse("invalid.token")).thenThrow(new RuntimeException("invalid token"));
+
+        ResponseEntity<?> response = controller.me(req);
+
+        assertEquals(401, response.getStatusCodeValue());
+    }
+
+    // ── oauth2 exchange (now sets cookie too) ──
+
+    @Test
+    void exchangeValidCode_setsCookieAndReturnsRole() {
+        String code = "valid-uuid-code";
+        when(codeStore.exchange(code))
+            .thenReturn(Optional.of(new OAuth2CodeStore.ExchangeResult("jwt.token.here", "STUDENT")));
+
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        var request = new AuthController.ExchangeCodeRequest(code);
+        ResponseEntity<?> response = controller.exchangeOAuth2Code(request, res);
+
+        assertEquals(200, response.getStatusCodeValue());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertNotNull(body);
+        assertFalse(body.containsKey("accessToken"), "accessToken must NOT be in response body");
+        assertEquals("STUDENT", body.get("role"));
+
+        Cookie cookie = res.getCookie("ak_token");
+        assertNotNull(cookie);
+        assertEquals("jwt.token.here", cookie.getValue());
+    }
+}

--- a/backend/src/test/java/com/akdemya/adapter/inbound/web/AuthControllerOAuth2ExchangeTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/inbound/web/AuthControllerOAuth2ExchangeTest.java
@@ -1,9 +1,13 @@
 package com.akdemya.adapter.inbound.web;
 
+import com.akdemya.adapter.infrastructure.security.JwtService;
 import com.akdemya.adapter.infrastructure.security.OAuth2CodeStore;
 import com.akdemya.domain.port.in.AuthUseCase;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.util.Map;
 import java.util.Optional;
@@ -15,24 +19,35 @@ class AuthControllerOAuth2ExchangeTest {
 
     private final AuthUseCase authUseCase = mock(AuthUseCase.class);
     private final OAuth2CodeStore codeStore = mock(OAuth2CodeStore.class);
-    private final AuthController controller = new AuthController(authUseCase, codeStore);
+    private final JwtService jwtService = mock(JwtService.class);
+    private AuthController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new AuthController(authUseCase, codeStore, jwtService, false);
+    }
 
     // --- register ---
 
     @Test
-    void registerSuccess_returns200WithTokenAndRole() {
+    void registerSuccess_setsCookieAndReturnsRole() {
         var cmd = new AuthUseCase.RegisterCommand("a@b.com", "pass", "pass", "A", "B", "dev");
         when(authUseCase.register(cmd))
             .thenReturn(AuthUseCase.AuthResponse.success("tok", "STUDENT"));
 
-        ResponseEntity<?> resp = controller.register(cmd);
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        ResponseEntity<?> resp = controller.register(cmd, res);
 
         assertEquals(200, resp.getStatusCodeValue());
         @SuppressWarnings("unchecked")
         Map<String, Object> body = (Map<String, Object>) resp.getBody();
         assertNotNull(body);
-        assertEquals("tok", body.get("accessToken"));
+        assertFalse(body.containsKey("accessToken"), "accessToken must NOT be in body");
         assertEquals("STUDENT", body.get("role"));
+
+        Cookie cookie = res.getCookie("ak_token");
+        assertNotNull(cookie);
+        assertEquals("tok", cookie.getValue());
     }
 
     @Test
@@ -41,7 +56,8 @@ class AuthControllerOAuth2ExchangeTest {
         when(authUseCase.register(cmd))
             .thenReturn(AuthUseCase.AuthResponse.fail("password_too_short"));
 
-        ResponseEntity<?> resp = controller.register(cmd);
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        ResponseEntity<?> resp = controller.register(cmd, res);
 
         assertEquals(400, resp.getStatusCodeValue());
         @SuppressWarnings("unchecked")
@@ -53,19 +69,24 @@ class AuthControllerOAuth2ExchangeTest {
     // --- login ---
 
     @Test
-    void loginSuccess_returns200WithTokenAndRole() {
+    void loginSuccess_setsCookieAndReturnsRole() {
         var cmd = new AuthUseCase.LoginCommand("a@b.com", "pass");
         when(authUseCase.login(cmd))
             .thenReturn(AuthUseCase.AuthResponse.success("tok", "ADMIN"));
 
-        ResponseEntity<?> resp = controller.login(cmd);
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        ResponseEntity<?> resp = controller.login(cmd, res);
 
         assertEquals(200, resp.getStatusCodeValue());
         @SuppressWarnings("unchecked")
         Map<String, Object> body = (Map<String, Object>) resp.getBody();
         assertNotNull(body);
-        assertEquals("tok", body.get("accessToken"));
+        assertFalse(body.containsKey("accessToken"), "accessToken must NOT be in body");
         assertEquals("ADMIN", body.get("role"));
+
+        Cookie cookie = res.getCookie("ak_token");
+        assertNotNull(cookie);
+        assertEquals("tok", cookie.getValue());
     }
 
     @Test
@@ -74,7 +95,8 @@ class AuthControllerOAuth2ExchangeTest {
         when(authUseCase.login(cmd))
             .thenReturn(AuthUseCase.AuthResponse.fail("invalid_credentials"));
 
-        ResponseEntity<?> resp = controller.login(cmd);
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        ResponseEntity<?> resp = controller.login(cmd, res);
 
         assertEquals(401, resp.getStatusCodeValue());
         @SuppressWarnings("unchecked")
@@ -84,20 +106,25 @@ class AuthControllerOAuth2ExchangeTest {
     }
 
     @Test
-    void exchangeValidCodeReturns200WithAccessTokenAndRole() {
+    void exchangeValidCode_setsCookieAndReturnsRole() {
         String code = "valid-uuid-code";
         when(codeStore.exchange(code))
             .thenReturn(Optional.of(new OAuth2CodeStore.ExchangeResult("jwt.token.here", "STUDENT")));
 
+        MockHttpServletResponse res = new MockHttpServletResponse();
         var request = new AuthController.ExchangeCodeRequest(code);
-        ResponseEntity<?> response = controller.exchangeOAuth2Code(request);
+        ResponseEntity<?> response = controller.exchangeOAuth2Code(request, res);
 
         assertEquals(200, response.getStatusCodeValue());
         @SuppressWarnings("unchecked")
         Map<String, Object> body = (Map<String, Object>) response.getBody();
         assertNotNull(body);
-        assertEquals("jwt.token.here", body.get("accessToken"));
+        assertFalse(body.containsKey("accessToken"), "accessToken must NOT be in body");
         assertEquals("STUDENT", body.get("role"));
+
+        Cookie cookie = res.getCookie("ak_token");
+        assertNotNull(cookie);
+        assertEquals("jwt.token.here", cookie.getValue());
     }
 
     @Test
@@ -105,8 +132,9 @@ class AuthControllerOAuth2ExchangeTest {
         String code = "unknown-code";
         when(codeStore.exchange(code)).thenReturn(Optional.empty());
 
+        MockHttpServletResponse res = new MockHttpServletResponse();
         var request = new AuthController.ExchangeCodeRequest(code);
-        ResponseEntity<?> response = controller.exchangeOAuth2Code(request);
+        ResponseEntity<?> response = controller.exchangeOAuth2Code(request, res);
 
         assertEquals(400, response.getStatusCodeValue());
         @SuppressWarnings("unchecked")

--- a/backend/src/test/java/com/akdemya/adapter/infrastructure/security/JwtAuthFilterCookieTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/infrastructure/security/JwtAuthFilterCookieTest.java
@@ -1,0 +1,103 @@
+package com.akdemya.adapter.infrastructure.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JwtAuthFilterCookieTest {
+
+    private JwtService jwtService;
+    private SecurityConfig.JwtAuthFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        jwtService = mock(JwtService.class);
+        filter = new SecurityConfig.JwtAuthFilter(jwtService);
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void doFilterInternal_withCookieOnly_authenticatesUser() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie("ak_token", "cookie.jwt.token"));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        @SuppressWarnings("unchecked")
+        Jws<Claims> jws = mock(Jws.class);
+        Claims claims = mock(Claims.class);
+        when(jws.getBody()).thenReturn(claims);
+        when(claims.getSubject()).thenReturn("user@example.com");
+        when(claims.get("role")).thenReturn("STUDENT");
+        when(jwtService.parse("cookie.jwt.token")).thenReturn(jws);
+
+        filter.doFilterInternal(req, res, chain);
+
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "authentication must be set");
+        assertEquals("user@example.com", auth.getName());
+        verify(chain).doFilter(req, res);
+    }
+
+    @Test
+    void doFilterInternal_withBearerHeader_authenticatesUser() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("Authorization", "Bearer bearer.jwt.token");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        @SuppressWarnings("unchecked")
+        Jws<Claims> jws = mock(Jws.class);
+        Claims claims = mock(Claims.class);
+        when(jws.getBody()).thenReturn(claims);
+        when(claims.getSubject()).thenReturn("admin@example.com");
+        when(claims.get("role")).thenReturn("ADMIN");
+        when(jwtService.parse("bearer.jwt.token")).thenReturn(jws);
+
+        filter.doFilterInternal(req, res, chain);
+
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth);
+        assertEquals("admin@example.com", auth.getName());
+        verify(chain).doFilter(req, res);
+    }
+
+    @Test
+    void doFilterInternal_withInvalidCookie_doesNotAuthenticate() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie("ak_token", "bad.token"));
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        when(jwtService.parse("bad.token")).thenThrow(new RuntimeException("invalid"));
+
+        filter.doFilterInternal(req, res, chain);
+
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNull(auth, "authentication must NOT be set for invalid token");
+        verify(chain).doFilter(req, res);
+    }
+
+    @Test
+    void doFilterInternal_withNoCookieAndNoHeader_doesNotAuthenticate() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilterInternal(req, res, chain);
+
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNull(auth, "authentication must NOT be set when no token provided");
+        verify(chain).doFilter(req, res);
+        verifyNoInteractions(jwtService);
+    }
+}

--- a/backend/src/test/java/com/akdemya/adapter/infrastructure/security/OAuth2SuccessHandlerTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/infrastructure/security/OAuth2SuccessHandlerTest.java
@@ -1,0 +1,53 @@
+package com.akdemya.adapter.infrastructure.security;
+
+import com.akdemya.domain.port.in.AuthUseCase;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.*;
+
+class OAuth2SuccessHandlerTest {
+
+    private AuthUseCase authUseCase;
+    private OAuth2CodeStore codeStore;
+    private OAuth2SuccessHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        authUseCase = mock(AuthUseCase.class);
+        codeStore = mock(OAuth2CodeStore.class);
+        handler = new OAuth2SuccessHandler(authUseCase, codeStore, "http://localhost:5173");
+    }
+
+    @Test
+    void onAuthenticationSuccess_storesCodeAndRedirects() throws IOException {
+        // Arrange
+        OAuth2User oAuth2User = mock(OAuth2User.class);
+        when(oAuth2User.getAttribute("email")).thenReturn("user@example.com");
+        when(oAuth2User.getAttribute("name")).thenReturn("Test User");
+
+        OAuth2AuthenticationToken token = mock(OAuth2AuthenticationToken.class);
+        when(token.getPrincipal()).thenReturn(oAuth2User);
+
+        AuthUseCase.AuthResponse authResponse = AuthUseCase.AuthResponse.success("jwt.token.here", "STUDENT");
+        when(authUseCase.loginWithOAuth2("user@example.com", "Test User")).thenReturn(authResponse);
+        when(codeStore.store("jwt.token.here", "STUDENT")).thenReturn("ephemeral-code-123");
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        // Act
+        handler.onAuthenticationSuccess(request, response, token);
+
+        // Assert
+        verify(authUseCase).loginWithOAuth2("user@example.com", "Test User");
+        verify(codeStore).store("jwt.token.here", "STUDENT");
+        verify(response).sendRedirect("http://localhost:5173/oauth2/callback?code=ephemeral-code-123");
+    }
+}

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -9,7 +9,12 @@ spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.properties.hibernate.show_sql=false
 spring.jpa.properties.hibernate.format_sql=false
 
-# Inicialización SQL (cargar data.sql)
+# Silence Hibernate DDL and JPA lifecycle logs during tests
+logging.level.org.hibernate.SQL=WARN
+logging.level.org.hibernate.tool.schema=WARN
+logging.level.org.springframework.orm.jpa=WARN
+
+# Inicializaciï¿½n SQL (cargar data.sql)
 spring.sql.init.mode=always
 spring.sql.init.data-locations=classpath:data.sql
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Navigate, Route, Routes, useNavigate, useLocation } from 'react-router-dom';
 import type { Question } from './components/ExamRunner';
 import Navbar from './components/Navbar';
-import { apiBase, apiAuthJson } from './api';
+import { apiBase, apiJson, getMe, logout } from './api';
 import type { Subject, ExamResult, ExamStartResponse, NavUser } from './types';
 import { timeoutMessage } from './utils/messages';
 import { deriveInitials } from './utils/format';
@@ -34,7 +34,8 @@ export default function App() {
   const [questions, setQuestions] = useState<Question[]>([]);
   const [minutes, setMinutes] = useState(20);
   const [attemptId, setAttemptId] = useState<string>('');
-  const [token, setToken] = useState<string>(localStorage.getItem('ak_token') || '');
+  const [authUser, setAuthUser] = useState<{ email: string; role: string } | null>(null);
+  const [authLoading, setAuthLoading] = useState(true);
   const [result, setResult] = useState<ExamResult | null>(null);
   const [activeAttemptId, setActiveAttemptId] = useState<string>(sessionStorage.getItem('akdmia.activeAttemptId') || '');
   const [toastError, setToastError] = useState<string>('');
@@ -44,30 +45,36 @@ export default function App() {
     setTimeout(() => setToastError(''), 5000);
   }
 
-  const isAuthed = useMemo(() => Boolean(token), [token]);
+  // On mount: check if there is a valid session via cookie
+  useEffect(() => {
+    getMe()
+      .then((data) => setAuthUser(data))
+      .catch(() => setAuthUser(null))
+      .finally(() => setAuthLoading(false));
+  }, []);
+
+  const isAuthed = Boolean(authUser) && !authLoading;
+
   const { role, user } = useMemo<{ role: string | null; user: NavUser | null }>(() => {
-    try {
-      if (!token) return { role: null, user: null };
-      const payload = JSON.parse(atob(token.split('.')[1]));
-      const email: string = payload.sub || '';
-      const initials = deriveInitials(email);
-      return { role: payload.role || null, user: { email, initials } };
-    } catch {
-      return { role: null, user: null };
-    }
-  }, [token]);
+    if (!authUser) return { role: null, user: null };
+    const email = authUser.email;
+    const initials = deriveInitials(email);
+    return { role: authUser.role || null, user: { email, initials } };
+  }, [authUser]);
 
   async function authedJson<T>(url: string, options: RequestInit & { timeoutMs?: number } = {}) {
     try {
-      return await apiAuthJson<T>(url, token, options);
-    } catch (err: any) {
-      if (err?.status === 401) onLogout();
+      return await apiJson<T>(url, options);
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'status' in err && (err as { status: number }).status === 401) {
+        onLogout();
+      }
       throw err;
     }
   }
 
   const refreshSubjects = () => {
-    if (!token) {
+    if (!authUser) {
       setSubjects([]);
       return Promise.resolve();
     }
@@ -78,9 +85,9 @@ export default function App() {
 
   useEffect(() => {
     refreshSubjects();
-  }, [token, apiBase]);
+  }, [authUser, apiBase]);
 
-  // Handle OAuth2 callback: exchange ephemeral code for JWT
+  // Handle OAuth2 callback: exchange ephemeral code for JWT cookie
   useEffect(() => {
     if (location.pathname === ROUTES.oauth2Callback) {
       const params = new URLSearchParams(location.search);
@@ -93,27 +100,27 @@ export default function App() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ code }),
+        credentials: 'include',
       })
         .then((res) => {
           if (!res.ok) throw new Error('exchange_failed');
-          return res.json() as Promise<{ accessToken: string; role: string }>;
+          return getMe();
         })
-        .then((data) => onToken(data.accessToken))
+        .then((data) => onAuthSuccess(data))
         .catch(() => navigate(ROUTES.login));
     }
   }, [location.pathname]);
 
-  function onToken(t: string) {
-    setToken(t);
-    localStorage.setItem('ak_token', t);
+  function onAuthSuccess(userData: { email: string; role: string }) {
+    setAuthUser(userData);
     navigate(ROUTES.subjects);
   }
 
-  function onLogout(){
-    localStorage.removeItem('ak_token');
+  function onLogout() {
+    logout().catch(() => {});
     sessionStorage.removeItem('akdmia.activeAttemptId');
     setActiveAttemptId('');
-    setToken('');
+    setAuthUser(null);
     navigate(ROUTES.home);
   }
 
@@ -132,8 +139,8 @@ export default function App() {
       sessionStorage.setItem('akdmia.activeAttemptId', data.attemptId);
       setActiveAttemptId(data.attemptId);
       navigate(ROUTES.examAttempt(data.attemptId));
-    } catch (err: any) {
-      if (err?.code === 'timeout') {
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'code' in err && (err as { code: string }).code === 'timeout') {
         showError(timeoutMessage);
         return;
       }
@@ -155,8 +162,8 @@ export default function App() {
       sessionStorage.setItem('akdmia.activeAttemptId', data.attemptId);
       setActiveAttemptId(data.attemptId);
       navigate(ROUTES.examAttempt(data.attemptId));
-    } catch (err: any) {
-      if (err?.code === 'timeout') {
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'code' in err && (err as { code: string }).code === 'timeout') {
         showError(timeoutMessage);
         return;
       }
@@ -182,8 +189,8 @@ export default function App() {
       setActiveAttemptId('');
       setResult(data);
       navigate(ROUTES.examResult);
-    } catch (err: any) {
-      if (err?.code === 'timeout') {
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'code' in err && (err as { code: string }).code === 'timeout') {
         showError(timeoutMessage);
         return;
       }
@@ -205,8 +212,8 @@ export default function App() {
       }
       setResult(data);
       navigate(ROUTES.examResult);
-    } catch (err: any) {
-      if (err?.code === 'timeout') {
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'code' in err && (err as { code: string }).code === 'timeout') {
         showError(timeoutMessage);
         return;
       }
@@ -218,6 +225,11 @@ export default function App() {
     sessionStorage.setItem('akdmia.activeAttemptId', attempt);
     setActiveAttemptId(attempt);
     navigate(ROUTES.examAttempt(attempt));
+  }
+
+  // While session is being verified, don't redirect protected routes
+  if (authLoading) {
+    return null;
   }
 
   return (
@@ -239,14 +251,13 @@ export default function App() {
       <main className={isFullWidth ? 'pt-[4rem] overflow-x-hidden' : 'max-w-4xl mx-auto p-6 pt-24'}>
         <Routes>
           <Route path={ROUTES.home} element={<HomePage isAuthed={isAuthed} activeAttemptId={activeAttemptId} />} />
-          <Route path={ROUTES.login} element={<LoginPage isAuthed={isAuthed} onToken={onToken} />} />
-          <Route path={ROUTES.register} element={<RegisterPage isAuthed={isAuthed} onToken={onToken} />} />
+          <Route path={ROUTES.login} element={<LoginPage isAuthed={isAuthed} onAuthSuccess={onAuthSuccess} />} />
+          <Route path={ROUTES.register} element={<RegisterPage isAuthed={isAuthed} onAuthSuccess={onAuthSuccess} />} />
           <Route path={ROUTES.subjects} element={
             <ProtectedRoute allow={isAuthed}>
               <SubjectsPage
                 subjects={subjects}
                 activeAttemptId={activeAttemptId}
-                token={token}
                 onUnauthorized={onLogout}
                 onViewResult={viewResult}
                 onResumeAttempt={resumeAttempt}
@@ -265,7 +276,7 @@ export default function App() {
           } />
           <Route path="/exams/attempts/:attemptId" element={
             <ProtectedRoute allow={isAuthed}>
-              <ExamAttemptPage token={token} onUnauthorized={onLogout} onFinish={(res) => {
+              <ExamAttemptPage onUnauthorized={onLogout} onFinish={(res) => {
                 sessionStorage.removeItem('akdmia.activeAttemptId');
                 setActiveAttemptId('');
                 setResult(res);
@@ -279,12 +290,12 @@ export default function App() {
           } />
           <Route path={ROUTES.settings} element={
             <ProtectedRoute allow={isAuthed}>
-              <SettingsPage isAdmin={role === 'ADMIN'} token={token} />
+              <SettingsPage isAdmin={role === 'ADMIN'} />
             </ProtectedRoute>
           } />
           <Route path={ROUTES.manage} element={
             <ProtectedRoute allow={isAuthed}>
-              <ManagePage isAdmin={role === 'ADMIN'} token={token} onSubjectsChanged={refreshSubjects} />
+              <ManagePage isAdmin={role === 'ADMIN'} onSubjectsChanged={refreshSubjects} />
             </ProtectedRoute>
           } />
           <Route path={ROUTES.flashcards} element={
@@ -309,12 +320,12 @@ export default function App() {
           } />
           <Route path={ROUTES.rag} element={
             <ProtectedRoute allow={isAuthed && role === 'ADMIN'}>
-              <RagPage token={token} subjects={subjects} />
+              <RagPage subjects={subjects} />
             </ProtectedRoute>
           } />
           <Route path={ROUTES.profile} element={
             <ProtectedRoute allow={isAuthed}>
-              <ProfilePage token={token} />
+              <ProfilePage />
             </ProtectedRoute>
           } />
           <Route path={ROUTES.oauth2Callback} element={null} />

--- a/frontend/src/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/__tests__/ProfilePage.test.tsx
@@ -24,7 +24,7 @@ describe('ProfilePage', () => {
   it('renders form with email, firstName and lastName fields', async () => {
     vi.mocked(api.getMyProfile).mockResolvedValue(mockProfile);
 
-    render(<ProfilePage token="tok" />);
+    render(<ProfilePage />);
 
     expect(screen.getByLabelText(/correo electrónico/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/nombre/i)).toBeInTheDocument();
@@ -34,10 +34,10 @@ describe('ProfilePage', () => {
   it('on mount calls getMyProfile and populates fields', async () => {
     vi.mocked(api.getMyProfile).mockResolvedValue(mockProfile);
 
-    render(<ProfilePage token="tok" />);
+    render(<ProfilePage />);
 
     await waitFor(() => {
-      expect(api.getMyProfile).toHaveBeenCalledWith('tok');
+      expect(api.getMyProfile).toHaveBeenCalledWith();
     });
 
     expect(screen.getByLabelText(/correo electrónico/i)).toHaveValue('test@example.com');
@@ -49,7 +49,7 @@ describe('ProfilePage', () => {
     vi.mocked(api.getMyProfile).mockResolvedValue(mockProfile);
     vi.mocked(api.updateMyProfile).mockResolvedValue({ ...mockProfile, firstName: 'Ana', lastName: 'García' });
 
-    render(<ProfilePage token="tok" />);
+    render(<ProfilePage />);
 
     await waitFor(() => expect(screen.getByLabelText(/nombre/i)).toHaveValue('Ana'));
 
@@ -57,7 +57,7 @@ describe('ProfilePage', () => {
     fireEvent.submit(screen.getByRole('button', { name: /guardar cambios/i }).closest('form')!);
 
     await waitFor(() => {
-      expect(api.updateMyProfile).toHaveBeenCalledWith('tok', {
+      expect(api.updateMyProfile).toHaveBeenCalledWith({
         firstName: 'María',
         lastName: 'García',
       });
@@ -70,7 +70,7 @@ describe('ProfilePage', () => {
     vi.mocked(api.getMyProfile).mockResolvedValue(mockProfile);
     vi.mocked(api.updateMyProfile).mockRejectedValue(new Error('api_error'));
 
-    render(<ProfilePage token="tok" />);
+    render(<ProfilePage />);
 
     await waitFor(() => expect(screen.getByLabelText(/nombre/i)).toHaveValue('Ana'));
 
@@ -82,7 +82,7 @@ describe('ProfilePage', () => {
   it('on API error from getMyProfile shows error message', async () => {
     vi.mocked(api.getMyProfile).mockRejectedValue(new Error('api_error'));
 
-    render(<ProfilePage token="tok" />);
+    render(<ProfilePage />);
 
     expect(await screen.findByRole('alert')).toHaveTextContent(/no se pudo cargar el perfil/i);
   });
@@ -91,7 +91,7 @@ describe('ProfilePage', () => {
     // Never resolves so loading stays true
     vi.mocked(api.getMyProfile).mockReturnValue(new Promise(() => {}));
 
-    render(<ProfilePage token="tok" />);
+    render(<ProfilePage />);
 
     const btn = screen.getByRole('button', { name: /guardando/i });
     expect(btn).toBeDisabled();
@@ -100,7 +100,7 @@ describe('ProfilePage', () => {
   it('handles null firstName and lastName gracefully', async () => {
     vi.mocked(api.getMyProfile).mockResolvedValue({ ...mockProfile, firstName: null, lastName: null });
 
-    render(<ProfilePage token="tok" />);
+    render(<ProfilePage />);
 
     await waitFor(() => {
       expect(screen.getByLabelText(/nombre/i)).toHaveValue('');

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -243,7 +243,14 @@ describe('RAG API functions', () => {
     const origClearTimeout = window.clearTimeout;
     vi.stubGlobal('clearTimeout', vi.fn());
 
-    const result = await generateQuiz({ sourceId: 'src-1', count: 5 } as Parameters<typeof generateQuiz>[0]);
+    const result = await generateQuiz({
+      sourceId: 'src-1',
+      unitId: 'unit-1',
+      difficulty: 'MEDIUM',
+      questionCount: 5,
+      includeHints: false,
+      storeAsDraft: false,
+    });
 
     vi.stubGlobal('clearTimeout', origClearTimeout);
 

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -23,23 +23,23 @@ describe('getMyProfile', () => {
     mockFetch.mockReset();
   });
 
-  it('calls the correct endpoint with Authorization header and returns parsed profile', async () => {
+  it('calls the correct endpoint with credentials and returns parsed profile', async () => {
     const profile = { id: 'u1', email: 'a@b.com', firstName: 'Ana', lastName: 'García' };
     mockFetch.mockResolvedValue(makeResponse(profile));
 
-    const result = await getMyProfile('my-token');
+    const result = await getMyProfile();
 
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, options] = mockFetch.mock.calls[0];
     expect(url).toContain('/api/v1/users/me');
-    expect(options.headers.Authorization).toBe('Bearer my-token');
+    expect(options.credentials).toBe('include');
     expect(result).toEqual(profile);
   });
 
   it('throws api_error when response is not ok', async () => {
     mockFetch.mockResolvedValue(makeResponse({ message: 'Unauthorized' }, 401, false));
 
-    await expect(getMyProfile('bad-token')).rejects.toMatchObject({ message: 'api_error', status: 401 });
+    await expect(getMyProfile()).rejects.toMatchObject({ message: 'api_error', status: 401 });
   });
 });
 
@@ -52,14 +52,14 @@ describe('updateMyProfile', () => {
     const updated = { id: 'u1', email: 'a@b.com', firstName: 'María', lastName: 'García' };
     mockFetch.mockResolvedValue(makeResponse(updated));
 
-    const result = await updateMyProfile('tok', { firstName: 'María', lastName: 'García' });
+    const result = await updateMyProfile({ firstName: 'María', lastName: 'García' });
 
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, options] = mockFetch.mock.calls[0];
     expect(url).toContain('/api/v1/users/me');
     expect(options.method).toBe('PATCH');
     expect(options.headers['Content-Type']).toBe('application/json');
-    expect(options.headers.Authorization).toBe('Bearer tok');
+    expect(options.credentials).toBe('include');
     expect(JSON.parse(options.body)).toEqual({ firstName: 'María', lastName: 'García' });
     expect(result).toEqual(updated);
   });
@@ -68,7 +68,7 @@ describe('updateMyProfile', () => {
     const updated = { id: 'u1', email: 'a@b.com', firstName: null, lastName: null };
     mockFetch.mockResolvedValue(makeResponse(updated));
 
-    await updateMyProfile('tok', { firstName: null, lastName: null });
+    await updateMyProfile({ firstName: null, lastName: null });
 
     const [, options] = mockFetch.mock.calls[0];
     expect(JSON.parse(options.body)).toEqual({ firstName: null, lastName: null });
@@ -77,7 +77,7 @@ describe('updateMyProfile', () => {
   it('throws api_error on non-ok response', async () => {
     mockFetch.mockResolvedValue(makeResponse({ message: 'Bad Request' }, 400, false));
 
-    await expect(updateMyProfile('tok', { firstName: null, lastName: null })).rejects.toMatchObject({
+    await expect(updateMyProfile({ firstName: null, lastName: null })).rejects.toMatchObject({
       message: 'api_error',
       status: 400,
     });
@@ -92,28 +92,28 @@ describe('apiAuthJson', () => {
   it('returns undefined for 204 response', async () => {
     mockFetch.mockResolvedValue({ ok: true, status: 204, text: () => Promise.resolve(''), json: () => Promise.resolve(undefined) } as unknown as Response);
 
-    const result = await apiAuthJson<void>('http://localhost/test', 'token');
+    const result = await apiAuthJson<void>('http://localhost/test');
     expect(result).toBeUndefined();
   });
 
   it('returns undefined when response body is empty', async () => {
     mockFetch.mockResolvedValue({ ok: true, status: 200, text: () => Promise.resolve(''), json: () => Promise.resolve(undefined) } as unknown as Response);
 
-    const result = await apiAuthJson<void>('http://localhost/test', 'token');
+    const result = await apiAuthJson<void>('http://localhost/test');
     expect(result).toBeUndefined();
   });
 
   it('rethrows non-AbortError errors', async () => {
     mockFetch.mockRejectedValue(new Error('network failure'));
 
-    await expect(apiAuthJson('http://localhost/test', 'token')).rejects.toThrow('network failure');
+    await expect(apiAuthJson('http://localhost/test')).rejects.toThrow('network failure');
   });
 
   it('converts AbortError to timeout error', async () => {
     const abortErr = Object.assign(new Error('aborted'), { name: 'AbortError' });
     mockFetch.mockRejectedValue(abortErr);
 
-    await expect(apiAuthJson('http://localhost/test', 'token')).rejects.toMatchObject({
+    await expect(apiAuthJson('http://localhost/test')).rejects.toMatchObject({
       message: 'timeout',
       code: 'timeout',
     });
@@ -168,7 +168,7 @@ describe('apiAuthJson with timeoutMs', () => {
     const clearSpy = vi.spyOn(window, 'clearTimeout');
     mockFetch.mockResolvedValue(makeResponse({ data: 'ok' }));
 
-    const result = await apiAuthJson<{ data: string }>('http://localhost/test', 'token', { timeoutMs: 5000 });
+    const result = await apiAuthJson<{ data: string }>('http://localhost/test', { timeoutMs: 5000 });
 
     expect(result).toEqual({ data: 'ok' });
     expect(clearSpy).toHaveBeenCalled();
@@ -186,13 +186,13 @@ describe('RAG API functions', () => {
     mockFetch.mockResolvedValue(makeResponse(preview));
 
     const file = new File(['content'], 'test.pdf', { type: 'application/pdf' });
-    const result = await uploadSource('token', file, 'subj-1');
+    const result = await uploadSource(file, 'subj-1');
 
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, options] = mockFetch.mock.calls[0];
     expect(url).toContain('/api/sources');
     expect(options.method).toBe('POST');
-    expect(options.headers.Authorization).toBe('Bearer token');
+    expect(options.credentials).toBe('include');
     expect(result).toEqual(preview);
   });
 
@@ -200,14 +200,14 @@ describe('RAG API functions', () => {
     mockFetch.mockResolvedValue({ ok: false, status: 400, json: () => Promise.resolve({}) } as unknown as Response);
 
     const file = new File([''], 'test.pdf');
-    await expect(uploadSource('token', file, 'subj-1')).rejects.toMatchObject({ message: 'api_error', status: 400 });
+    await expect(uploadSource(file, 'subj-1')).rejects.toMatchObject({ message: 'api_error', status: 400 });
   });
 
   it('confirmIndex posts to confirm endpoint and returns result', async () => {
     const result = { document: { id: 'doc-1' }, savedUnits: [] };
     mockFetch.mockResolvedValue(makeResponse(result));
 
-    const res = await confirmIndex('token', 'doc-1', []);
+    const res = await confirmIndex('doc-1', []);
 
     const [url, options] = mockFetch.mock.calls[0];
     expect(url).toContain('/api/sources/doc-1/confirm');
@@ -219,7 +219,7 @@ describe('RAG API functions', () => {
     const sources = [{ id: 'src-1', name: 'Document' }];
     mockFetch.mockResolvedValue(makeResponse(sources));
 
-    const result = await getSources('token');
+    const result = await getSources();
 
     const [url] = mockFetch.mock.calls[0];
     expect(url).toContain('/api/sources');
@@ -229,7 +229,7 @@ describe('RAG API functions', () => {
   it('getSources with subjectId appends query param', async () => {
     mockFetch.mockResolvedValue(makeResponse([]));
 
-    await getSources('token', 'subj-1');
+    await getSources('subj-1');
 
     const [url] = mockFetch.mock.calls[0];
     expect(url).toContain('subjectId=subj-1');
@@ -243,7 +243,7 @@ describe('RAG API functions', () => {
     const origClearTimeout = window.clearTimeout;
     vi.stubGlobal('clearTimeout', vi.fn());
 
-    const result = await generateQuiz('token', { sourceId: 'src-1', count: 5 } as any);
+    const result = await generateQuiz({ sourceId: 'src-1', count: 5 } as Parameters<typeof generateQuiz>[0]);
 
     vi.stubGlobal('clearTimeout', origClearTimeout);
 
@@ -257,7 +257,7 @@ describe('RAG API functions', () => {
     const drafts = [{ id: 'd-1', status: 'PENDING' }];
     mockFetch.mockResolvedValue(makeResponse(drafts));
 
-    const result = await getDrafts('token', 'src-1');
+    const result = await getDrafts('src-1');
 
     const [url] = mockFetch.mock.calls[0];
     expect(url).toContain('sourceId=src-1');
@@ -267,7 +267,7 @@ describe('RAG API functions', () => {
   it('getDrafts appends status query param when provided', async () => {
     mockFetch.mockResolvedValue(makeResponse([]));
 
-    await getDrafts('token', 'src-1', 'PENDING');
+    await getDrafts('src-1', 'PENDING');
 
     const [url] = mockFetch.mock.calls[0];
     expect(url).toContain('status=PENDING');
@@ -277,7 +277,7 @@ describe('RAG API functions', () => {
     const draft = { id: 'd-1', status: 'APPROVED' };
     mockFetch.mockResolvedValue(makeResponse(draft));
 
-    const result = await approveDraft('token', 'd-1');
+    const result = await approveDraft('d-1');
 
     const [url, options] = mockFetch.mock.calls[0];
     expect(url).toContain('/api/ai/drafts/d-1/approve');
@@ -289,7 +289,7 @@ describe('RAG API functions', () => {
     const draft = { id: 'd-1', status: 'REJECTED' };
     mockFetch.mockResolvedValue(makeResponse(draft));
 
-    const result = await rejectDraft('token', 'd-1');
+    const result = await rejectDraft('d-1');
 
     const [url, options] = mockFetch.mock.calls[0];
     expect(url).toContain('/api/ai/drafts/d-1/reject');
@@ -301,7 +301,7 @@ describe('RAG API functions', () => {
     const units = [{ id: 'u-1', name: 'Unit 1' }];
     mockFetch.mockResolvedValue(makeResponse(units));
 
-    const result = await getUnitsForSubject('token', 'subj-1');
+    const result = await getUnitsForSubject('subj-1');
 
     const [url] = mockFetch.mock.calls[0];
     expect(url).toContain('/api/units?subjectId=subj-1');
@@ -311,7 +311,7 @@ describe('RAG API functions', () => {
   it('deleteSource sends DELETE request', async () => {
     mockFetch.mockResolvedValue({ ok: true, status: 204, text: () => Promise.resolve(''), json: () => Promise.resolve(undefined) } as unknown as Response);
 
-    await deleteSource('token', 'src-1');
+    await deleteSource('src-1');
 
     const [url, options] = mockFetch.mock.calls[0];
     expect(url).toContain('/api/sources/src-1');
@@ -331,13 +331,13 @@ describe('exportFlashcardsBySubject', () => {
       text: () => Promise.resolve('front,back\nHello,Hola\n'),
     } as unknown as Response);
 
-    const result = await exportFlashcardsBySubject('my-token', 'subj-1', 'csv');
+    const result = await exportFlashcardsBySubject('subj-1', 'csv');
 
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, options] = mockFetch.mock.calls[0];
     expect(url).toContain('subjectId=subj-1');
     expect(url).toContain('format=csv');
-    expect(options.headers.Authorization).toBe('Bearer my-token');
+    expect(options.credentials).toBe('include');
     expect(result).toBe('front,back\nHello,Hola\n');
   });
 
@@ -349,7 +349,7 @@ describe('exportFlashcardsBySubject', () => {
       text: () => Promise.resolve(jsonContent),
     } as unknown as Response);
 
-    const result = await exportFlashcardsBySubject('token', 'subj-2', 'json');
+    const result = await exportFlashcardsBySubject('subj-2', 'json');
 
     const [url] = mockFetch.mock.calls[0];
     expect(url).toContain('format=json');
@@ -362,7 +362,7 @@ describe('exportFlashcardsBySubject', () => {
       status: 403,
     } as unknown as Response);
 
-    await expect(exportFlashcardsBySubject('token', 'subj-3', 'csv')).rejects.toMatchObject({
+    await expect(exportFlashcardsBySubject('subj-3', 'csv')).rejects.toMatchObject({
       message: 'api_error',
       status: 403,
     });
@@ -371,6 +371,6 @@ describe('exportFlashcardsBySubject', () => {
   it('throws network error when fetch rejects', async () => {
     mockFetch.mockRejectedValue(new Error('network failure'));
 
-    await expect(exportFlashcardsBySubject('token', 'subj-4', 'csv')).rejects.toThrow('network failure');
+    await expect(exportFlashcardsBySubject('subj-4', 'csv')).rejects.toThrow('network failure');
   });
 });

--- a/frontend/src/__tests__/flashcards/FlashcardsExamineUnitPage.test.tsx
+++ b/frontend/src/__tests__/flashcards/FlashcardsExamineUnitPage.test.tsx
@@ -18,7 +18,7 @@ vi.mock('../../api', async (importOriginal) => {
   const actual = await importOriginal<typeof api>();
   return {
     ...actual,
-    apiAuthJson: vi.fn(),
+    apiJson: vi.fn(),
   };
 });
 
@@ -30,11 +30,10 @@ const mockCards = [
 describe('FlashcardsExamineUnitPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    localStorage.setItem('ak_token', 'test-token');
   });
 
   it('shows skeleton while loading', () => {
-    vi.mocked(api.apiAuthJson).mockReturnValue(new Promise(() => {}));
+    vi.mocked(api.apiJson).mockReturnValue(new Promise(() => {}));
 
     const { container } = render(<FlashcardsExamineUnitPage />);
 
@@ -43,7 +42,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('renders cards when loaded', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+    vi.mocked(api.apiJson).mockResolvedValue(mockCards);
 
     render(<FlashcardsExamineUnitPage />);
 
@@ -53,7 +52,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('shows empty state with Volver and import CTA when no cards', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.apiJson).mockResolvedValue([]);
 
     render(<FlashcardsExamineUnitPage />);
 
@@ -66,7 +65,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('shows error state on API failure', async () => {
-    vi.mocked(api.apiAuthJson).mockRejectedValue(new Error('api_error'));
+    vi.mocked(api.apiJson).mockRejectedValue(new Error('api_error'));
 
     render(<FlashcardsExamineUnitPage />);
 
@@ -76,7 +75,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('flips card when clicked to show back, and again to show front', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+    vi.mocked(api.apiJson).mockResolvedValue(mockCards);
 
     render(<FlashcardsExamineUnitPage />);
 
@@ -102,7 +101,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('navigates to next card when Siguiente is clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+    vi.mocked(api.apiJson).mockResolvedValue(mockCards);
 
     render(<FlashcardsExamineUnitPage />);
 
@@ -116,7 +115,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('navigates to previous card when Anterior is clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+    vi.mocked(api.apiJson).mockResolvedValue(mockCards);
 
     render(<FlashcardsExamineUnitPage />);
 
@@ -132,7 +131,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('disables Anterior button on first card', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+    vi.mocked(api.apiJson).mockResolvedValue(mockCards);
 
     render(<FlashcardsExamineUnitPage />);
 
@@ -143,7 +142,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('disables Siguiente button on last card', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+    vi.mocked(api.apiJson).mockResolvedValue(mockCards);
 
     render(<FlashcardsExamineUnitPage />);
 
@@ -156,7 +155,7 @@ describe('FlashcardsExamineUnitPage', () => {
   });
 
   it('resets flip state when navigating to next card', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockCards);
+    vi.mocked(api.apiJson).mockResolvedValue(mockCards);
 
     render(<FlashcardsExamineUnitPage />);
 

--- a/frontend/src/__tests__/flashcards/FlashcardsPage.test.tsx
+++ b/frontend/src/__tests__/flashcards/FlashcardsPage.test.tsx
@@ -39,7 +39,7 @@ vi.mock('../../api', async (importOriginal) => {
   const actual = await importOriginal<typeof api>();
   return {
     ...actual,
-    apiAuthJson: vi.fn(),
+    apiJson: vi.fn(),
     exportFlashcardsBySubject: vi.fn(),
   };
 });
@@ -68,13 +68,12 @@ const mockUnits = [
 describe('FlashcardsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    localStorage.setItem('ak_token', 'test-token');
     globalThis.URL.createObjectURL = vi.fn(() => 'blob:test');
     globalThis.URL.revokeObjectURL = vi.fn();
   });
 
   it('shows empty state with import CTA when no subjects available', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.apiJson).mockResolvedValue([]);
 
     render(<FlashcardsPage />);
 
@@ -88,7 +87,7 @@ describe('FlashcardsPage', () => {
   });
 
   it('opens import modal when empty state CTA is clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.apiJson).mockResolvedValue([]);
 
     render(<FlashcardsPage />);
 
@@ -102,7 +101,7 @@ describe('FlashcardsPage', () => {
   });
 
   it('opens import modal when header Importar button is clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.apiJson).mockResolvedValue([]);
 
     render(<FlashcardsPage />);
 
@@ -117,7 +116,7 @@ describe('FlashcardsPage', () => {
   });
 
   it('closes import modal when close is clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.apiJson).mockResolvedValue([]);
 
     render(<FlashcardsPage />);
 
@@ -131,7 +130,7 @@ describe('FlashcardsPage', () => {
   });
 
   it('reloads units when onImported is called from modal', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.apiJson).mockResolvedValue([]);
 
     render(<FlashcardsPage />);
 
@@ -140,12 +139,12 @@ describe('FlashcardsPage', () => {
     fireEvent.click(screen.getAllByRole('button', { name: /importar/i })[0]);
     fireEvent.click(screen.getByText('Importado'));
 
-    // apiAuthJson should be called again (reload)
-    expect(vi.mocked(api.apiAuthJson).mock.calls.length).toBeGreaterThan(2);
+    // apiJson should be called again (reload)
+    expect(vi.mocked(api.apiJson).mock.calls.length).toBeGreaterThan(2);
   });
 
   it('shows subjects when data loads', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.apiJson).mockResolvedValue(mockUnits);
 
     render(<FlashcardsPage />);
 
@@ -155,7 +154,7 @@ describe('FlashcardsPage', () => {
   });
 
   it('shows unit list when subject is selected', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.apiJson).mockResolvedValue(mockUnits);
 
     // We need SubjectCard to be real here — don't mock it
     render(<FlashcardsPage />);
@@ -172,7 +171,7 @@ describe('FlashcardsPage', () => {
   });
 
   it('shows back button and navigates back when clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.apiJson).mockResolvedValue(mockUnits);
 
     render(<FlashcardsPage />);
 
@@ -194,14 +193,14 @@ describe('FlashcardsPage', () => {
       useSearchParams: () => [new URLSearchParams('mode=study')],
     }));
 
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.apiJson).mockResolvedValue(mockUnits);
     render(<FlashcardsPage />);
 
     await waitFor(() => expect(screen.getByText('Matemáticas')).toBeInTheDocument());
   });
 
   it('navigates to study page tab when Estudio tab clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.apiJson).mockResolvedValue([]);
 
     render(<FlashcardsPage />);
 
@@ -212,7 +211,7 @@ describe('FlashcardsPage', () => {
   });
 
   it('navigates to flashcards when Examinar tab clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.apiJson).mockResolvedValue([]);
 
     render(<FlashcardsPage />);
 
@@ -223,7 +222,7 @@ describe('FlashcardsPage', () => {
   });
 
   it('navigates to history when Historial tab clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([]);
+    vi.mocked(api.apiJson).mockResolvedValue([]);
 
     render(<FlashcardsPage />);
 
@@ -234,7 +233,7 @@ describe('FlashcardsPage', () => {
   });
 
   it('shows export error banner when unit export fetch fails', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.apiJson).mockResolvedValue(mockUnits);
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
 
     render(<FlashcardsPage />);
@@ -258,7 +257,7 @@ describe('FlashcardsPage', () => {
   });
 
   it('dismisses export error banner when close button is clicked', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.apiJson).mockResolvedValue(mockUnits);
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
 
     render(<FlashcardsPage />);
@@ -277,7 +276,7 @@ describe('FlashcardsPage', () => {
   });
 
   it('calls exportFlashcardsBySubject and creates download link on success', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.apiJson).mockResolvedValue(mockUnits);
     vi.mocked(api.exportFlashcardsBySubject).mockResolvedValue('front,back\nHello,Hola\n');
 
     // Spy on link.click without mocking createElement globally
@@ -300,7 +299,7 @@ describe('FlashcardsPage', () => {
     fireEvent.click(csvButtons[0]);
 
     await waitFor(() => {
-      expect(api.exportFlashcardsBySubject).toHaveBeenCalledWith('test-token', 'subj-1', 'csv');
+      expect(api.exportFlashcardsBySubject).toHaveBeenCalledWith('subj-1', 'csv');
     });
 
     expect(clickSpy).toHaveBeenCalled();
@@ -308,7 +307,7 @@ describe('FlashcardsPage', () => {
   });
 
   it('shows subject export error banner when exportFlashcardsBySubject fails', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.apiJson).mockResolvedValue(mockUnits);
     vi.mocked(api.exportFlashcardsBySubject).mockRejectedValue(new Error('api_error'));
 
     render(<FlashcardsPage />);
@@ -326,7 +325,7 @@ describe('FlashcardsPage', () => {
   });
 
   it('filters subjects by search term', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue([
+    vi.mocked(api.apiJson).mockResolvedValue([
       ...mockUnits,
       {
         unitId: 'unit-3',
@@ -355,7 +354,7 @@ describe('FlashcardsPage', () => {
   });
 
   it('filters units by search term when subject is selected', async () => {
-    vi.mocked(api.apiAuthJson).mockResolvedValue(mockUnits);
+    vi.mocked(api.apiJson).mockResolvedValue(mockUnits);
 
     render(<FlashcardsPage />);
 

--- a/frontend/src/__tests__/flashcards/FlashcardsStudyPage.test.tsx
+++ b/frontend/src/__tests__/flashcards/FlashcardsStudyPage.test.tsx
@@ -23,7 +23,7 @@ vi.mock('../../api', async (importOriginal) => {
   const actual = await importOriginal<typeof api>();
   return {
     ...actual,
-    apiAuthJson: vi.fn(),
+    apiJson: vi.fn(),
   };
 });
 
@@ -40,11 +40,10 @@ const mockItem = {
 describe('FlashcardsStudyPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    localStorage.setItem('ak_token', 'test-token');
   });
 
   it('shows skeleton while loading', () => {
-    vi.mocked(api.apiAuthJson).mockReturnValue(new Promise(() => {}));
+    vi.mocked(api.apiJson).mockReturnValue(new Promise(() => {}));
 
     const { container } = render(<FlashcardsStudyPage />);
 
@@ -53,7 +52,7 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('renders study session when loaded', async () => {
-    vi.mocked(api.apiAuthJson)
+    vi.mocked(api.apiJson)
       .mockResolvedValueOnce(mockQueue) // fetchQueue
       .mockResolvedValueOnce(mockItem); // fetchNext
 
@@ -65,7 +64,7 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('shows inline review error without replacing session', async () => {
-    vi.mocked(api.apiAuthJson)
+    vi.mocked(api.apiJson)
       .mockResolvedValueOnce(mockQueue) // initial fetchQueue
       .mockResolvedValueOnce(mockItem) // initial fetchNext
       .mockRejectedValueOnce(new Error('api_error')); // POST review fails
@@ -99,7 +98,7 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('review error can be dismissed', async () => {
-    vi.mocked(api.apiAuthJson)
+    vi.mocked(api.apiJson)
       .mockResolvedValueOnce(mockQueue)
       .mockResolvedValueOnce(mockItem)
       .mockRejectedValueOnce(new Error('api_error'));
@@ -125,7 +124,7 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('shows "Nada que repasar hoy" when finished with 0 answered cards', async () => {
-    vi.mocked(api.apiAuthJson)
+    vi.mocked(api.apiJson)
       .mockResolvedValueOnce(emptyQueue) // fetchQueue — empty
       .mockResolvedValueOnce(undefined); // fetchNext — nothing
 
@@ -142,7 +141,7 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('shows answered count when finished after reviewing cards', async () => {
-    vi.mocked(api.apiAuthJson)
+    vi.mocked(api.apiJson)
       .mockResolvedValueOnce(mockQueue) // initial fetchQueue
       .mockResolvedValueOnce(mockItem) // initial fetchNext
       .mockResolvedValueOnce(undefined) // POST review (204 no content)
@@ -168,7 +167,7 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('opens confirm modal when Terminar sesión is clicked', async () => {
-    vi.mocked(api.apiAuthJson)
+    vi.mocked(api.apiJson)
       .mockResolvedValueOnce(mockQueue)
       .mockResolvedValueOnce(mockItem);
 
@@ -182,7 +181,7 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('can cancel the confirm modal', async () => {
-    vi.mocked(api.apiAuthJson)
+    vi.mocked(api.apiJson)
       .mockResolvedValueOnce(mockQueue)
       .mockResolvedValueOnce(mockItem);
 
@@ -198,7 +197,7 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('finishes session when Terminar is confirmed in modal', async () => {
-    vi.mocked(api.apiAuthJson)
+    vi.mocked(api.apiJson)
       .mockResolvedValueOnce(mockQueue)
       .mockResolvedValueOnce(mockItem);
 
@@ -221,7 +220,7 @@ describe('FlashcardsStudyPage', () => {
   });
 
   it('shows error state when initial load fails', async () => {
-    vi.mocked(api.apiAuthJson).mockRejectedValue(new Error('api_error'));
+    vi.mocked(api.apiJson).mockRejectedValue(new Error('api_error'));
 
     render(<FlashcardsStudyPage />);
 

--- a/frontend/src/__tests__/rag/QuizGenerateForm.test.tsx
+++ b/frontend/src/__tests__/rag/QuizGenerateForm.test.tsx
@@ -24,26 +24,26 @@ describe('QuizGenerateForm', () => {
   });
 
   it('renders form fields', async () => {
-    render(<QuizGenerateForm token="tok" sources={[processedSource]} subjectId="subj-1" onGenerate={onGenerate} loading={false} />);
+    render(<QuizGenerateForm sources={[processedSource]} subjectId="subj-1" onGenerate={onGenerate} loading={false} />);
     expect(screen.getByText(/documento fuente/i)).toBeInTheDocument();
     expect(screen.getByText(/unidad temática/i)).toBeInTheDocument();
     expect(screen.getByText(/dificultad/i)).toBeInTheDocument();
   });
 
   it('shows warning when no processed sources', () => {
-    render(<QuizGenerateForm token="tok" sources={[]} subjectId="subj-1" onGenerate={onGenerate} loading={false} />);
+    render(<QuizGenerateForm sources={[]} subjectId="subj-1" onGenerate={onGenerate} loading={false} />);
     expect(screen.getByText(/no hay documentos procesados/i)).toBeInTheDocument();
   });
 
   it('validates missing source and unit', async () => {
-    render(<QuizGenerateForm token="tok" sources={[processedSource]} subjectId="subj-1" onGenerate={onGenerate} loading={false} />);
+    render(<QuizGenerateForm sources={[processedSource]} subjectId="subj-1" onGenerate={onGenerate} loading={false} />);
     fireEvent.click(screen.getByRole('button', { name: /generar preguntas/i }));
     expect(await screen.findByRole('alert')).toHaveTextContent(/selecciona un documento/i);
     expect(onGenerate).not.toHaveBeenCalled();
   });
 
   it('calls onGenerate with correct command', async () => {
-    render(<QuizGenerateForm token="tok" sources={[processedSource]} subjectId="subj-1" onGenerate={onGenerate} loading={false} />);
+    render(<QuizGenerateForm sources={[processedSource]} subjectId="subj-1" onGenerate={onGenerate} loading={false} />);
     // Wait for units to load
     await waitFor(() => expect(api.getUnitsForSubject).toHaveBeenCalled());
     fireEvent.change(screen.getByRole('combobox', { name: /documento fuente \*/i }), { target: { value: 'src-1' } });
@@ -58,7 +58,7 @@ describe('QuizGenerateForm', () => {
   });
 
   it('disables submit button while loading', () => {
-    render(<QuizGenerateForm token="tok" sources={[processedSource]} subjectId="subj-1" onGenerate={onGenerate} loading={true} />);
+    render(<QuizGenerateForm sources={[processedSource]} subjectId="subj-1" onGenerate={onGenerate} loading={true} />);
     expect(screen.getByRole('button', { name: /generando/i })).toBeDisabled();
   });
 });

--- a/frontend/src/__tests__/rag/SourceUpload.test.tsx
+++ b/frontend/src/__tests__/rag/SourceUpload.test.tsx
@@ -28,13 +28,13 @@ describe('SourceUpload', () => {
   });
 
   it('renders the upload zone', () => {
-    render(<SourceUpload token="tok" subjectId="subj-1" onUploaded={onUploaded} />);
+    render(<SourceUpload subjectId="subj-1" onUploaded={onUploaded} />);
     expect(screen.getByRole('button', { name: /zona de subida/i })).toBeInTheDocument();
     expect(screen.getByText(/arrastra un pdf/i)).toBeInTheDocument();
   });
 
   it('rejects non-PDF files', async () => {
-    render(<SourceUpload token="tok" subjectId="subj-1" onUploaded={onUploaded} />);
+    render(<SourceUpload subjectId="subj-1" onUploaded={onUploaded} />);
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     const file = new File(['content'], 'doc.docx', { type: 'application/msword' });
     Object.defineProperty(input, 'files', { value: [file] });
@@ -44,7 +44,7 @@ describe('SourceUpload', () => {
   });
 
   it('rejects files over 50 MB', async () => {
-    render(<SourceUpload token="tok" subjectId="subj-1" onUploaded={onUploaded} />);
+    render(<SourceUpload subjectId="subj-1" onUploaded={onUploaded} />);
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     const bigContent = new Uint8Array(51 * 1024 * 1024);
     const file = new File([bigContent], 'big.pdf', { type: 'application/pdf' });
@@ -56,21 +56,20 @@ describe('SourceUpload', () => {
 
   it('calls uploadSource and shows preview for valid PDF', async () => {
     vi.mocked(api.uploadSource).mockResolvedValue(mockPreview);
-    render(<SourceUpload token="tok" subjectId="subj-1" onUploaded={onUploaded} />);
+    render(<SourceUpload subjectId="subj-1" onUploaded={onUploaded} />);
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     const file = new File(['%PDF-1.4'], 'test.pdf', { type: 'application/pdf' });
     Object.defineProperty(input, 'files', { value: [file] });
     fireEvent.change(input);
-    await waitFor(() => expect(api.uploadSource).toHaveBeenCalledWith('tok', file, 'subj-1'));
+    await waitFor(() => expect(api.uploadSource).toHaveBeenCalledWith(file, 'subj-1'));
     // After upload shows the index preview
     expect(await screen.findByText(/temas detectados/i)).toBeInTheDocument();
   });
 
   it('shows error when upload fails', async () => {
-    const err: any = new Error('api_error');
-    err.body = { message: 'Server error' };
+    const err = Object.assign(new Error('api_error'), { body: { message: 'Server error' } });
     vi.mocked(api.uploadSource).mockRejectedValue(err);
-    render(<SourceUpload token="tok" subjectId="subj-1" onUploaded={onUploaded} />);
+    render(<SourceUpload subjectId="subj-1" onUploaded={onUploaded} />);
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     const file = new File(['%PDF'], 'fail.pdf', { type: 'application/pdf' });
     Object.defineProperty(input, 'files', { value: [file] });
@@ -84,7 +83,7 @@ describe('SourceUpload', () => {
       detectedUnits: []
     };
     vi.mocked(api.uploadSource).mockResolvedValue(failedPreview);
-    render(<SourceUpload token="tok" subjectId="subj-1" onUploaded={onUploaded} />);
+    render(<SourceUpload subjectId="subj-1" onUploaded={onUploaded} />);
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     const file = new File(['%PDF'], 'fail.pdf', { type: 'application/pdf' });
     Object.defineProperty(input, 'files', { value: [file] });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -14,7 +14,7 @@ function mergeSignal(existing?: AbortSignal, timeoutMs?: number) {
   const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
   let signal = controller.signal;
   if (existing && typeof (AbortSignal as { any?: unknown }).any === 'function') {
-    signal = (AbortSignal as { any: (...s: AbortSignal[]) => AbortSignal }).any([existing, controller.signal]);
+    signal = (AbortSignal as unknown as { any: (signals: AbortSignal[]) => AbortSignal }).any([existing, controller.signal]);
   }
   return { signal, clear: () => window.clearTimeout(timeoutId) };
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -13,8 +13,8 @@ function mergeSignal(existing?: AbortSignal, timeoutMs?: number) {
   const controller = new AbortController();
   const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
   let signal = controller.signal;
-  if (existing && typeof (AbortSignal as any).any === 'function') {
-    signal = (AbortSignal as any).any([existing, controller.signal]);
+  if (existing && typeof (AbortSignal as { any?: unknown }).any === 'function') {
+    signal = (AbortSignal as { any: (...s: AbortSignal[]) => AbortSignal }).any([existing, controller.signal]);
   }
   return { signal, clear: () => window.clearTimeout(timeoutId) };
 }
@@ -23,21 +23,22 @@ export async function apiJson<T>(url: string, options: RequestOptions = {}): Pro
   const { timeoutMs, ...fetchOptions } = options;
   const { signal, clear } = mergeSignal(fetchOptions.signal ?? undefined, timeoutMs);
   try {
-    const res = await fetch(url, { ...fetchOptions, signal });
+    const res = await fetch(url, { ...fetchOptions, signal, credentials: 'include' });
     if (!res.ok) {
-      const err: any = new Error('api_error');
-      err.status = res.status;
-      err.body = await res.json().catch(() => ({}));
+      const err: { message: string; status: number; body: unknown; name?: string } = {
+        message: 'api_error',
+        status: res.status,
+        body: await res.json().catch(() => ({})),
+      };
       throw err;
     }
     if (res.status === 204) return undefined as T;
     const text = await res.text();
     if (!text) return undefined as T;
     return JSON.parse(text) as T;
-  } catch (err: any) {
-    if (err?.name === 'AbortError') {
-      const timeoutErr: any = new Error('timeout');
-      timeoutErr.code = 'timeout';
+  } catch (err: unknown) {
+    if (err && typeof err === 'object' && 'name' in err && (err as { name: string }).name === 'AbortError') {
+      const timeoutErr = Object.assign(new Error('timeout'), { code: 'timeout' });
       throw timeoutErr;
     }
     throw err;
@@ -46,21 +47,28 @@ export async function apiJson<T>(url: string, options: RequestOptions = {}): Pro
   }
 }
 
-// User profile API functions
+// User auth API functions
 import type {
   SourceDocument, GeneratedDraft, GenerateQuizCommand, GenerateQuizResponse,
   IndexPreview, ConfirmIndexCommand, ApprovedUnit, UserProfile
 } from './types';
 
-export async function getMyProfile(token: string): Promise<UserProfile> {
-  return apiAuthJson<UserProfile>(`${apiBase}/api/v1/users/me`, token);
+export async function getMe(): Promise<{ email: string; role: string }> {
+  return apiJson<{ email: string; role: string }>(`${apiBase}/api/auth/me`);
+}
+
+export async function logout(): Promise<void> {
+  return apiJson<void>(`${apiBase}/api/auth/logout`, { method: 'POST' });
+}
+
+export async function getMyProfile(): Promise<UserProfile> {
+  return apiJson<UserProfile>(`${apiBase}/api/v1/users/me`);
 }
 
 export async function updateMyProfile(
-  token: string,
   data: { firstName: string | null; lastName: string | null }
 ): Promise<UserProfile> {
-  return apiAuthJson<UserProfile>(`${apiBase}/api/v1/users/me`, token, {
+  return apiJson<UserProfile>(`${apiBase}/api/v1/users/me`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data)
@@ -69,46 +77,46 @@ export async function updateMyProfile(
 
 // RAG module API functions
 
-export async function uploadSource(token: string, file: File, subjectId: string): Promise<IndexPreview> {
+export async function uploadSource(file: File, subjectId: string): Promise<IndexPreview> {
   const form = new FormData();
   form.append('file', file);
   form.append('subjectId', subjectId);
   const res = await fetch(`${apiBase}/api/sources`, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${token}` },
-    body: form
+    body: form,
+    credentials: 'include'
   });
   if (!res.ok) {
-    const err: any = new Error('api_error');
-    err.status = res.status;
-    err.body = await res.json().catch(() => ({}));
+    const err = Object.assign(new Error('api_error'), {
+      status: res.status,
+      body: await res.json().catch(() => ({})),
+    });
     throw err;
   }
-  return res.json();
+  return res.json() as Promise<IndexPreview>;
 }
 
 export async function confirmIndex(
-  token: string,
   documentId: string,
   approvedUnits: ApprovedUnit[]
 ): Promise<{ document: SourceDocument; savedUnits: { id: string; name: string }[] }> {
   const cmd: ConfirmIndexCommand = { approvedUnits };
-  return apiAuthJson(`${apiBase}/api/sources/${documentId}/confirm`, token, {
+  return apiJson(`${apiBase}/api/sources/${documentId}/confirm`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(cmd)
   });
 }
 
-export async function getSources(token: string, subjectId?: string): Promise<SourceDocument[]> {
+export async function getSources(subjectId?: string): Promise<SourceDocument[]> {
   const url = subjectId
     ? `${apiBase}/api/sources?subjectId=${subjectId}`
     : `${apiBase}/api/sources`;
-  return apiAuthJson<SourceDocument[]>(url, token);
+  return apiJson<SourceDocument[]>(url);
 }
 
-export async function generateQuiz(token: string, cmd: GenerateQuizCommand): Promise<GenerateQuizResponse> {
-  return apiAuthJson<GenerateQuizResponse>(`${apiBase}/api/ai/quizzes/generate`, token, {
+export async function generateQuiz(cmd: GenerateQuizCommand): Promise<GenerateQuizResponse> {
+  return apiJson<GenerateQuizResponse>(`${apiBase}/api/ai/quizzes/generate`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(cmd),
@@ -116,77 +124,48 @@ export async function generateQuiz(token: string, cmd: GenerateQuizCommand): Pro
   });
 }
 
-export async function getDrafts(token: string, sourceId: string, status?: string): Promise<GeneratedDraft[]> {
+export async function getDrafts(sourceId: string, status?: string): Promise<GeneratedDraft[]> {
   const url = status
     ? `${apiBase}/api/ai/quizzes/drafts?sourceId=${sourceId}&status=${status}`
     : `${apiBase}/api/ai/quizzes/drafts?sourceId=${sourceId}`;
-  return apiAuthJson<GeneratedDraft[]>(url, token);
+  return apiJson<GeneratedDraft[]>(url);
 }
 
-export async function approveDraft(token: string, draftId: string): Promise<GeneratedDraft> {
-  return apiAuthJson<GeneratedDraft>(`${apiBase}/api/ai/drafts/${draftId}/approve`, token, {
+export async function approveDraft(draftId: string): Promise<GeneratedDraft> {
+  return apiJson<GeneratedDraft>(`${apiBase}/api/ai/drafts/${draftId}/approve`, {
     method: 'POST'
   });
 }
 
-export async function rejectDraft(token: string, draftId: string): Promise<GeneratedDraft> {
-  return apiAuthJson<GeneratedDraft>(`${apiBase}/api/ai/drafts/${draftId}/reject`, token, {
+export async function rejectDraft(draftId: string): Promise<GeneratedDraft> {
+  return apiJson<GeneratedDraft>(`${apiBase}/api/ai/drafts/${draftId}/reject`, {
     method: 'POST'
   });
 }
 
-export async function getUnitsForSubject(token: string, subjectId: string): Promise<{ id: string; name: string }[]> {
-  return apiAuthJson<{ id: string; name: string }[]>(`${apiBase}/api/units?subjectId=${subjectId}`, token);
+export async function getUnitsForSubject(subjectId: string): Promise<{ id: string; name: string }[]> {
+  return apiJson<{ id: string; name: string }[]>(`${apiBase}/api/units?subjectId=${subjectId}`);
 }
 
-export async function deleteSource(token: string, id: string): Promise<void> {
-  return apiAuthJson<void>(`${apiBase}/api/sources/${id}`, token, { method: 'DELETE' });
+export async function deleteSource(id: string): Promise<void> {
+  return apiJson<void>(`${apiBase}/api/sources/${id}`, { method: 'DELETE' });
 }
 
 export async function exportFlashcardsBySubject(
-  token: string,
   subjectId: string,
   format: 'csv' | 'json'
 ): Promise<string> {
   const res = await fetch(
     `${apiBase}/api/flashcards/export?subjectId=${subjectId}&format=${format}`,
-    { headers: { Authorization: `Bearer ${token}` } }
+    { credentials: 'include' }
   );
   if (!res.ok) {
-    const err: any = new Error('api_error');
-    err.status = res.status;
+    const err = Object.assign(new Error('api_error'), { status: res.status });
     throw err;
   }
   return res.text();
 }
 
-export async function apiAuthJson<T>(url: string, token: string, options: RequestOptions = {}): Promise<T> {
-  const { timeoutMs, ...fetchOptions } = options;
-  const { signal, clear } = mergeSignal(fetchOptions.signal ?? undefined, timeoutMs);
-  try {
-    const res = await fetch(url, {
-      ...fetchOptions,
-      signal,
-      headers: { ...(fetchOptions.headers || {}), Authorization: `Bearer ${token}` }
-    });
-    if (!res.ok) {
-      const err: any = new Error('api_error');
-      err.status = res.status;
-      err.body = await res.json().catch(() => ({}));
-      throw err;
-    }
-    if (res.status === 204) return undefined as T;
-    const text = await res.text();
-    if (!text) return undefined as T;
-    return JSON.parse(text) as T;
-  } catch (err: any) {
-    if (err?.name === 'AbortError') {
-      const timeoutErr: any = new Error('timeout');
-      timeoutErr.code = 'timeout';
-      throw timeoutErr;
-    }
-    throw err;
-  } finally {
-    clear();
-  }
+export async function apiAuthJson<T>(url: string, options: RequestOptions = {}): Promise<T> {
+  return apiJson<T>(url, options);
 }

--- a/frontend/src/components/ExamBuilder.tsx
+++ b/frontend/src/components/ExamBuilder.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Minus, Plus, Play } from 'flowbite-react-icons/outline';
-import { apiBase, apiAuthJson } from '../api';
+import { apiBase, apiJson } from '../api';
 import type { UnitAvailability } from '../types';
 
 const inp = 'bg-white/50 dark:bg-[#24394c] border border-secondary/30 rounded-xl px-4 py-2.5 text-sm text-text placeholder:text-text/35 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50 transition-colors';
@@ -21,12 +21,11 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
   const PAGE_SIZE = 10;
 
   useEffect(() => {
-    const token = localStorage.getItem('ak_token') || '';
     const diffQuery = difficulty === 'ALL' ? '' : `&difficulty=${difficulty}`;
     setAvailabilityLoading(true);
-    apiAuthJson<UnitAvailability[]>(`${apiBase}/api/units/availability?subjectId=${subjectId}${diffQuery}`, token)
+    apiJson<UnitAvailability[]>(`${apiBase}/api/units/availability?subjectId=${subjectId}${diffQuery}`)
       .then(us => { setUnits(us.map(u => ({ id: u.id, name: u.name, available: Number(u.available) || 0 }))); setPage(0); })
-      .catch(err => { if (err?.status === 401) onUnauthorized(); })
+      .catch((err: unknown) => { if (err && typeof err === 'object' && 'status' in err && (err as { status: number }).status === 401) onUnauthorized(); })
       .finally(() => setAvailabilityLoading(false));
   }, [subjectId, apiBase, difficulty]);
 

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -7,7 +7,7 @@ import { ROUTES } from '../constants/routes';
 const inputClass =
   'w-full bg-white/50 dark:bg-[#24394c] border border-secondary/30 rounded-xl px-4 py-3 text-sm text-text placeholder:text-text/35 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50 transition-colors';
 
-export default function Login({ onToken }: { onToken: (t: string) => void }) {
+export default function Login({ onAuthSuccess }: { onAuthSuccess: (user: { email: string; role: string }) => void }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [err, setErr] = useState<string>('');
@@ -30,11 +30,12 @@ export default function Login({ onToken }: { onToken: (t: string) => void }) {
       const res = await fetch(`${apiBase}/api/auth/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password })
+        body: JSON.stringify({ email, password }),
+        credentials: 'include'
       });
       const data = await res.json().catch(() => ({}));
-      if (res.ok && data.accessToken) {
-        onToken(data.accessToken);
+      if (res.ok) {
+        onAuthSuccess({ email: data.email ?? email, role: data.role ?? '' });
       } else {
         setErr(data.error || 'Credenciales inválidas');
       }

--- a/frontend/src/components/Management.tsx
+++ b/frontend/src/components/Management.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Plus, Check, CircleMinus, Pen, TrashBin, FileExport, FileImport, FileCsv, BookOpen, FolderOpen, FileLines, Inbox } from 'flowbite-react-icons/outline';
-import { apiBase, apiAuthJson } from '../api';
+import { apiBase, apiJson } from '../api';
 import ScopeFilter, { type ContentScope } from './ScopeFilter';
 
 export type AdminSubject = {
@@ -109,7 +109,7 @@ function Pagination({ page, totalPages, onChange }: { page: number; totalPages: 
   );
 }
 
-export default function Management({ isAdmin, token, onSubjectsChanged }: { isAdmin: boolean; token: string; onSubjectsChanged?: () => void }) {
+export default function Management({ isAdmin, onSubjectsChanged }: { isAdmin: boolean; onSubjectsChanged?: () => void }) {
   const [tab, setTab] = useState<Tab>('subjects');
 
   const [subjects, setSubjects] = useState<AdminSubject[]>([]);
@@ -175,19 +175,19 @@ export default function Management({ isAdmin, token, onSubjectsChanged }: { isAd
 
   async function loadSubjects(scope: Scope = subjectScope) {
     const scopeParam = scope === 'ALL' ? '' : `&scope=${scope}`;
-    const data = await apiAuthJson<AdminSubject[]>(`${apiBase}/api/manage/subjects?_=1${scopeParam}`, token);
+    const data = await apiJson<AdminSubject[]>(`${apiBase}/api/manage/subjects?_=1${scopeParam}`);
     setSubjects(data);
   }
   async function loadUnits(subjectId: string, scope: Scope = unitScope) {
     if (!subjectId) { setUnits([]); return; }
     const scopeParam = scope === 'ALL' ? '' : `&scope=${scope}`;
-    const data = await apiAuthJson<AdminUnit[]>(`${apiBase}/api/manage/units?subjectId=${subjectId}${scopeParam}`, token);
+    const data = await apiJson<AdminUnit[]>(`${apiBase}/api/manage/units?subjectId=${subjectId}${scopeParam}`);
     setUnits(data);
   }
   async function loadQuestions(unitId: string, page = questionPage, scope: Scope = questionScope) {
     if (!unitId) { setQuestions([]); setQuestionTotalPages(1); return; }
     const scopeParam = scope === 'ALL' ? '' : `&scope=${scope}`;
-    const data = await apiAuthJson<{ items: AdminQuestion[]; page: number; totalPages: number }>(`${apiBase}/api/manage/questions?unitId=${unitId}&page=${page}&size=10${scopeParam}`, token);
+    const data = await apiJson<{ items: AdminQuestion[]; page: number; totalPages: number }>(`${apiBase}/api/manage/questions?unitId=${unitId}&page=${page}&size=10${scopeParam}`);
     setQuestions(data.items); setQuestionPage(data.page + 1); setQuestionTotalPages(data.totalPages || 1);
   }
 
@@ -210,12 +210,12 @@ export default function Management({ isAdmin, token, onSubjectsChanged }: { isAd
       const visibility = isAdmin && subjectScope === 'GLOBAL' ? 'GLOBAL' : 'PRIVATE';
       const body = JSON.stringify({ name: subjectForm.name, description: subjectForm.description || null, visibility });
       const opts = { method: isSubjectEditing ? 'PUT' : 'POST', headers: { 'Content-Type': 'application/json' }, body };
-      await apiAuthJson(isSubjectEditing ? `${apiBase}/api/manage/subjects/${subjectForm.id}` : `${apiBase}/api/manage/subjects`, token, opts);
+      await apiJson(isSubjectEditing ? `${apiBase}/api/manage/subjects/${subjectForm.id}` : `${apiBase}/api/manage/subjects`, opts);
       resetSubjectForm(); await loadSubjects(subjectScope); onSubjectsChanged?.();
     } finally { setSubjectLoading(false); }
   }
 
-  async function removeSubject(id: string) { await apiAuthJson(`${apiBase}/api/manage/subjects/${id}`, token, { method: 'DELETE' }); await loadSubjects(subjectScope); onSubjectsChanged?.(); }
+  async function removeSubject(id: string) { await apiJson(`${apiBase}/api/manage/subjects/${id}`, { method: 'DELETE' }); await loadSubjects(subjectScope); onSubjectsChanged?.(); }
 
   async function saveUnit() {
     if (!unitForm.subjectId || !unitForm.name.trim()) return;
@@ -224,12 +224,12 @@ export default function Management({ isAdmin, token, onSubjectsChanged }: { isAd
       const visibility = isAdmin && unitScope === 'GLOBAL' ? 'GLOBAL' : 'PRIVATE';
       const payload = { subjectId: unitForm.subjectId, name: unitForm.name, description: unitForm.description || null, orderIndex: unitForm.orderIndex || 0, visibility };
       const opts = { method: isUnitEditing ? 'PUT' : 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) };
-      await apiAuthJson(isUnitEditing ? `${apiBase}/api/manage/units/${unitForm.id}` : `${apiBase}/api/manage/units`, token, opts);
+      await apiJson(isUnitEditing ? `${apiBase}/api/manage/units/${unitForm.id}` : `${apiBase}/api/manage/units`, opts);
       resetUnitForm(); await loadUnits(unitForm.subjectId, unitScope); await loadSubjects(subjectScope);
     } finally { setUnitLoading(false); }
   }
 
-  async function removeUnit(id: string) { await apiAuthJson(`${apiBase}/api/manage/units/${id}`, token, { method: 'DELETE' }); await loadUnits(unitForm.subjectId, unitScope); await loadSubjects(subjectScope); }
+  async function removeUnit(id: string) { await apiJson(`${apiBase}/api/manage/units/${id}`, { method: 'DELETE' }); await loadUnits(unitForm.subjectId, unitScope); await loadSubjects(subjectScope); }
 
   async function saveQuestion() {
     const unitId = questionUnitId || questionForm.unitId;
@@ -241,18 +241,18 @@ export default function Management({ isAdmin, token, onSubjectsChanged }: { isAd
       const visibility = isAdmin && questionScope === 'GLOBAL' ? 'GLOBAL' : 'PRIVATE';
       const payload = { unitId, text: questionForm.text, explanation: questionForm.explanation || null, difficulty: questionForm.difficulty, answers: questionForm.answers.map(a => ({ text: a.text, correct: a.correct })), visibility };
       const opts = { method: isQuestionEditing ? 'PUT' : 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) };
-      await apiAuthJson(isQuestionEditing ? `${apiBase}/api/manage/questions/${questionForm.id}` : `${apiBase}/api/manage/questions`, token, opts);
+      await apiJson(isQuestionEditing ? `${apiBase}/api/manage/questions/${questionForm.id}` : `${apiBase}/api/manage/questions`, opts);
       resetQuestionForm(); await loadQuestions(unitId, 1, questionScope); await loadUnits(questionSubjectId, 'ALL');
     } finally { setQuestionLoading(false); }
   }
 
-  async function removeQuestion(id: string, unitId: string) { await apiAuthJson(`${apiBase}/api/manage/questions/${id}`, token, { method: 'DELETE' }); await loadQuestions(unitId, questionPage, questionScope); await loadUnits(questionSubjectId, 'ALL'); }
+  async function removeQuestion(id: string, unitId: string) { await apiJson(`${apiBase}/api/manage/questions/${id}`, { method: 'DELETE' }); await loadQuestions(unitId, questionPage, questionScope); await loadUnits(questionSubjectId, 'ALL'); }
 
   async function handleExport(format: 'csv' | 'json') {
     setExportLoading(true);
     try {
       const query = questionUnitId ? `?unitId=${questionUnitId}&format=${format}` : `?format=${format}`;
-      const res = await fetch(`${apiBase}/api/manage/questions/export${query}`, { headers: { Authorization: `Bearer ${token}` } });
+      const res = await fetch(`${apiBase}/api/manage/questions/export${query}`, { credentials: 'include' });
       if (!res.ok) throw new Error('export_failed');
       const blob = await res.blob();
       const url = window.URL.createObjectURL(blob);
@@ -271,7 +271,7 @@ export default function Management({ isAdmin, token, onSubjectsChanged }: { isAd
     try {
       const formData = new FormData();
       formData.append('file', importFile);
-      const res = await fetch(`${apiBase}/api/manage/questions/import?format=${importFormat}&unitId=${questionUnitId}`, { method: 'POST', headers: { Authorization: `Bearer ${token}` }, body: formData });
+      const res = await fetch(`${apiBase}/api/manage/questions/import?format=${importFormat}&unitId=${questionUnitId}`, { method: 'POST', credentials: 'include', body: formData });
       const data = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(data.error || 'import_failed');
       const created = data.created || 0;

--- a/frontend/src/components/Register.tsx
+++ b/frontend/src/components/Register.tsx
@@ -7,7 +7,7 @@ import { ROUTES } from '../constants/routes';
 const inputClass =
   'w-full bg-white/50 dark:bg-[#24394c] border border-secondary/30 rounded-xl px-4 py-3 text-sm text-text placeholder:text-text/35 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50 transition-colors';
 
-export default function Register({ onToken }: { onToken: (t: string) => void }) {
+export default function Register({ onAuthSuccess }: { onAuthSuccess: (user: { email: string; role: string }) => void }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -44,11 +44,12 @@ export default function Register({ onToken }: { onToken: (t: string) => void }) 
           firstName: firstName.trim() || null,
           lastName: lastName.trim() || null,
           occupation: occupation || null
-        })
+        }),
+        credentials: 'include'
       });
       const data = await res.json().catch(() => ({}));
-      if (res.ok && data.accessToken) {
-        onToken(data.accessToken);
+      if (res.ok) {
+        onAuthSuccess({ email: data.email ?? email, role: data.role ?? '' });
       } else {
         setErr(data.error || 'No se pudo registrar');
       }

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Plus, Check, CircleMinus, Pen, TrashBin, Users, Cog } from 'flowbite-react-icons/outline';
-import { apiBase, apiAuthJson } from '../api';
+import { apiBase, apiJson } from '../api';
 
 export type AdminUser = {
   id: string;
@@ -77,7 +77,7 @@ function Pagination({ page, totalPages, onChange }: { page: number; totalPages: 
   );
 }
 
-export default function Settings({ isAdmin, token }: { isAdmin: boolean; token: string }) {
+export default function Settings({ isAdmin }: { isAdmin: boolean }) {
   const [tab, setTab] = useState<Tab>('general');
 
   // ── User settings ──
@@ -88,7 +88,7 @@ export default function Settings({ isAdmin, token }: { isAdmin: boolean; token: 
 
   async function loadUserSettings() {
     try {
-      const data = await apiAuthJson<UserSettings>(`${apiBase}/api/settings`, token);
+      const data = await apiJson<UserSettings>(`${apiBase}/api/settings`);
       setSettingsForm(data);
     } catch { /* keep defaults */ }
   }
@@ -96,7 +96,7 @@ export default function Settings({ isAdmin, token }: { isAdmin: boolean; token: 
   async function saveUserSettings() {
     setSettingsLoading(true); setSettingsSaved(false); setSettingsError('');
     try {
-      const data = await apiAuthJson<UserSettings>(`${apiBase}/api/settings`, token, {
+      const data = await apiJson<UserSettings>(`${apiBase}/api/settings`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(settingsForm),
@@ -122,7 +122,7 @@ export default function Settings({ isAdmin, token }: { isAdmin: boolean; token: 
   function resetForm() { setForm({ id: '', email: '', role: 'STUDENT', firstName: '', lastName: '', occupation: '' }); }
 
   async function loadUsers(page = userPage) {
-    const data = await apiAuthJson<{ items: AdminUser[]; page: number; totalPages: number }>(`${apiBase}/api/admin/users?page=${page - 1}&size=10`, token);
+    const data = await apiJson<{ items: AdminUser[]; page: number; totalPages: number }>(`${apiBase}/api/admin/users?page=${page - 1}&size=10`);
     setUsers(data.items); setUserPage(data.page + 1); setUserTotalPages(data.totalPages || 1);
   }
 
@@ -137,12 +137,12 @@ export default function Settings({ isAdmin, token }: { isAdmin: boolean; token: 
     try {
       const body = JSON.stringify({ email: form.email, firstName: form.firstName || null, lastName: form.lastName || null, occupation: form.occupation || null, role: form.role });
       const opts = { method: isEditing ? 'PUT' : 'POST', headers: { 'Content-Type': 'application/json' }, body };
-      await apiAuthJson(isEditing ? `${apiBase}/api/admin/users/${form.id}` : `${apiBase}/api/admin/users`, token, opts);
+      await apiJson(isEditing ? `${apiBase}/api/admin/users/${form.id}` : `${apiBase}/api/admin/users`, opts);
       resetForm(); await loadUsers(1);
     } finally { setLoading(false); }
   }
 
-  async function removeUser(id: string) { await apiAuthJson(`${apiBase}/api/admin/users/${id}`, token, { method: 'DELETE' }); await loadUsers(userPage); }
+  async function removeUser(id: string) { await apiJson(`${apiBase}/api/admin/users/${id}`, { method: 'DELETE' }); await loadUsers(userPage); }
 
   const generalNavItems = [
     { id: 'general' as Tab, label: 'General', icon: <Cog className="w-4 h-4" /> },

--- a/frontend/src/components/flashcards/FlashcardImportModal.tsx
+++ b/frontend/src/components/flashcards/FlashcardImportModal.tsx
@@ -1,17 +1,16 @@
 import { useEffect, useRef, useState } from 'react';
-import { apiAuthJson, apiBase, getUnitsForSubject } from '../../api';
+import { apiJson, apiBase, getUnitsForSubject } from '../../api';
 
 type Subject = { id: string; name: string; description?: string };
 type Unit = { id: string; name: string };
 type ImportResult = { imported: number; skipped: number; errors: string[] };
 
 type Props = {
-  token: string;
   onClose: () => void;
   onImported: () => void;
 };
 
-export default function FlashcardImportModal({ token, onClose, onImported }: Props) {
+export default function FlashcardImportModal({ onClose, onImported }: Props) {
   const [subjects, setSubjects] = useState<Subject[]>([]);
   const [units, setUnits] = useState<Unit[]>([]);
   const [subjectId, setSubjectId] = useState('');
@@ -27,28 +26,28 @@ export default function FlashcardImportModal({ token, onClose, onImported }: Pro
   // Load all subjects on mount
   useEffect(() => {
     setLoadingSubjects(true);
-    apiAuthJson<Subject[]>(`${apiBase}/api/subjects`, token)
+    apiJson<Subject[]>(`${apiBase}/api/subjects`)
       .then((data) => {
         setSubjects(data ?? []);
         if (data && data.length > 0) setSubjectId(data[0].id);
       })
       .catch(() => setError('No se pudieron cargar las materias.'))
       .finally(() => setLoadingSubjects(false));
-  }, [token]);
+  }, []);
 
   // Load units when subject changes
   useEffect(() => {
     if (!subjectId) { setUnits([]); setUnitId(''); return; }
     setLoadingUnits(true);
     setUnitId('');
-    getUnitsForSubject(token, subjectId)
+    getUnitsForSubject(subjectId)
       .then((data) => {
         setUnits(data ?? []);
         if (data && data.length > 0) setUnitId(data[0].id);
       })
       .catch(() => setUnits([]))
       .finally(() => setLoadingUnits(false));
-  }, [subjectId, token]);
+  }, [subjectId]);
 
   const handleSubmit = async () => {
     const file = fileRef.current?.files?.[0];
@@ -66,18 +65,19 @@ export default function FlashcardImportModal({ token, onClose, onImported }: Pro
         {
           method: 'POST',
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'text/plain; charset=UTF-8',
           },
+          credentials: 'include',
           body: content,
         }
       );
       if (!res.ok) throw new Error(`Error ${res.status}`);
-      const data: ImportResult = await res.json();
+      const data: ImportResult = await res.json() as ImportResult;
       setResult(data);
       if (data.imported > 0) onImported();
-    } catch (e: any) {
-      setError(e.message ?? 'Error al importar.');
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e.message : 'Error al importar.';
+      setError(err);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/rag/DraftList.tsx
+++ b/frontend/src/components/rag/DraftList.tsx
@@ -4,7 +4,6 @@ import { getDrafts, approveDraft, rejectDraft } from '../../api';
 import type { SourceDocument, GeneratedDraft } from '../../types';
 
 interface Props {
-  token: string;
   sources: SourceDocument[];
 }
 
@@ -24,7 +23,7 @@ const STATUS_COLOR: Record<string, string> = {
   REJECTED: 'bg-red-400/15 text-red-600 dark:text-red-400'
 };
 
-export default function DraftList({ token, sources }: Props) {
+export default function DraftList({ sources }: Props) {
   const processed = sources.filter((s) => s.status === 'PROCESSED');
   const [selectedSourceId, setSelectedSourceId] = useState('');
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('GENERATED');
@@ -37,19 +36,20 @@ export default function DraftList({ token, sources }: Props) {
     if (!selectedSourceId) { setDrafts([]); return; }
     setLoading(true);
     setError('');
-    getDrafts(token, selectedSourceId, statusFilter || undefined)
+    getDrafts(selectedSourceId, statusFilter || undefined)
       .then(setDrafts)
       .catch(() => { setError('Error al cargar los borradores.'); setDrafts([]); })
       .finally(() => setLoading(false));
-  }, [selectedSourceId, statusFilter, token]);
+  }, [selectedSourceId, statusFilter]);
 
   async function handleApprove(draftId: string) {
     setActionLoading((prev) => ({ ...prev, [draftId]: true }));
     try {
-      const updated = await approveDraft(token, draftId);
+      const updated = await approveDraft(draftId);
       setDrafts((prev) => prev.map((d) => d.id === draftId ? updated : d));
-    } catch (err: any) {
-      alert(err?.body?.message || 'Error al aprobar la pregunta.');
+    } catch (err: unknown) {
+      const e = err as { body?: { message?: string } };
+      alert(e?.body?.message || 'Error al aprobar la pregunta.');
     } finally {
       setActionLoading((prev) => ({ ...prev, [draftId]: false }));
     }
@@ -58,10 +58,11 @@ export default function DraftList({ token, sources }: Props) {
   async function handleReject(draftId: string) {
     setActionLoading((prev) => ({ ...prev, [draftId]: true }));
     try {
-      const updated = await rejectDraft(token, draftId);
+      const updated = await rejectDraft(draftId);
       setDrafts((prev) => prev.map((d) => d.id === draftId ? updated : d));
-    } catch (err: any) {
-      alert(err?.body?.message || 'Error al rechazar la pregunta.');
+    } catch (err: unknown) {
+      const e = err as { body?: { message?: string } };
+      alert(e?.body?.message || 'Error al rechazar la pregunta.');
     } finally {
       setActionLoading((prev) => ({ ...prev, [draftId]: false }));
     }

--- a/frontend/src/components/rag/QuizGenerateForm.tsx
+++ b/frontend/src/components/rag/QuizGenerateForm.tsx
@@ -4,7 +4,6 @@ import { getUnitsForSubject } from '../../api';
 import type { SourceDocument, GenerateQuizCommand } from '../../types';
 
 interface Props {
-  token: string;
   sources: SourceDocument[];
   subjectId: string;
   onGenerate: (cmd: GenerateQuizCommand) => void;
@@ -17,7 +16,7 @@ const DIFFICULTIES = [
   { value: 'HARD', label: 'Difícil' }
 ] as const;
 
-export default function QuizGenerateForm({ token, sources, subjectId, onGenerate, loading }: Props) {
+export default function QuizGenerateForm({ sources, subjectId, onGenerate, loading }: Props) {
   const processed = sources.filter((s) => s.status === 'PROCESSED');
 
   const [sourceId, setSourceId] = useState('');
@@ -34,11 +33,11 @@ export default function QuizGenerateForm({ token, sources, subjectId, onGenerate
   useEffect(() => {
     if (!subjectId) { setUnits([]); setUnitId(''); return; }
     setUnitsLoading(true);
-    getUnitsForSubject(token, subjectId)
+    getUnitsForSubject(subjectId)
       .then((u) => { setUnits(u); setUnitId(''); })
       .catch(() => setUnits([]))
       .finally(() => setUnitsLoading(false));
-  }, [subjectId, token]);
+  }, [subjectId]);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/frontend/src/components/rag/SourceIndexPreview.tsx
+++ b/frontend/src/components/rag/SourceIndexPreview.tsx
@@ -4,12 +4,11 @@ import type { IndexPreview, SourceDocument, ApprovedUnit } from '../../types';
 
 interface Props {
   preview: IndexPreview;
-  token: string;
   onConfirmed: (doc: SourceDocument) => void;
   onCancel: () => void;
 }
 
-export default function SourceIndexPreview({ preview, token, onConfirmed, onCancel }: Props) {
+export default function SourceIndexPreview({ preview, onConfirmed, onCancel }: Props) {
   const [units, setUnits] = useState<ApprovedUnit[]>(
     preview.detectedUnits.map((u) => ({ headingKey: u.headingKey, name: u.name, description: '' }))
   );
@@ -33,10 +32,11 @@ export default function SourceIndexPreview({ preview, token, onConfirmed, onCanc
     setError('');
     setConfirming(true);
     try {
-      const result = await confirmIndex(token, preview.document.id, valid);
+      const result = await confirmIndex(preview.document.id, valid);
       onConfirmed(result.document);
-    } catch (err: any) {
-      setError(err?.body?.message || 'Error al confirmar el índice.');
+    } catch (err: unknown) {
+      const e = err as { body?: { message?: string } };
+      setError(e?.body?.message || 'Error al confirmar el índice.');
     } finally {
       setConfirming(false);
     }

--- a/frontend/src/components/rag/SourceUpload.tsx
+++ b/frontend/src/components/rag/SourceUpload.tsx
@@ -4,12 +4,11 @@ import type { SourceDocument, IndexPreview } from '../../types';
 import SourceIndexPreview from './SourceIndexPreview';
 
 interface Props {
-  token: string;
   subjectId: string;
   onUploaded: (doc: SourceDocument) => void;
 }
 
-export default function SourceUpload({ token, subjectId, onUploaded }: Props) {
+export default function SourceUpload({ subjectId, onUploaded }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -28,15 +27,16 @@ export default function SourceUpload({ token, subjectId, onUploaded }: Props) {
     setError('');
     setLoading(true);
     try {
-      const result = await uploadSource(token, file, subjectId);
+      const result = await uploadSource(file, subjectId);
       if (result.document.status === 'FAILED') {
         setError('El documento se subió pero no pudo procesarse. Comprueba las API keys del servidor.');
         onUploaded(result.document);
       } else {
         setPreview(result);
       }
-    } catch (err: any) {
-      setError(err?.body?.message || 'Error al subir el documento.');
+    } catch (err: unknown) {
+      const e = err as { body?: { message?: string } };
+      setError(e?.body?.message || 'Error al subir el documento.');
     } finally {
       setLoading(false);
     }
@@ -64,7 +64,6 @@ export default function SourceUpload({ token, subjectId, onUploaded }: Props) {
     return (
       <SourceIndexPreview
         preview={preview}
-        token={token}
         onConfirmed={handleConfirmed}
         onCancel={() => setPreview(null)}
       />

--- a/frontend/src/pages/ExamAttemptPage.tsx
+++ b/frontend/src/pages/ExamAttemptPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import ExamRunner, { Question } from '../components/ExamRunner';
-import { apiAuthJson, apiBase } from '../api';
+import { apiJson, apiBase } from '../api';
 import { timeoutMessage } from '../utils/messages';
 import { ROUTES } from '../constants/routes';
 import type { ExamResult } from '../types';
@@ -14,8 +14,7 @@ type AttemptResponse = {
   finished: boolean;
 };
 
-export default function ExamAttemptPage({ token, onUnauthorized, onFinish }:{
-  token: string;
+export default function ExamAttemptPage({ onUnauthorized, onFinish }:{
   onUnauthorized: () => void;
   onFinish: (result: ExamResult) => void;
 }){
@@ -37,18 +36,18 @@ export default function ExamAttemptPage({ token, onUnauthorized, onFinish }:{
     if (!attemptId) return;
     setLoading(true);
     setError('');
-    apiAuthJson<AttemptResponse>(`${apiBase}/api/exams/attempts/${attemptId}`, token, { timeoutMs: 15000 })
+    apiJson<AttemptResponse>(`${apiBase}/api/exams/attempts/${attemptId}`, { timeoutMs: 15000 })
       .then(data => setAttempt(data))
-      .catch(err => {
-        if (err?.status === 401) onUnauthorized();
-        if (err?.code === 'timeout') {
+      .catch((err: unknown) => {
+        if (err && typeof err === 'object' && 'status' in err && (err as { status: number }).status === 401) onUnauthorized();
+        if (err && typeof err === 'object' && 'code' in err && (err as { code: string }).code === 'timeout') {
           setError(timeoutMessage);
           return;
         }
         setError('No se pudo cargar el intento');
       })
       .finally(() => setLoading(false));
-  }, [attemptId, token, apiBase]);
+  }, [attemptId, apiBase]);
 
   if (!attemptId) return <Navigate to={ROUTES.subjects} replace />;
 
@@ -76,15 +75,15 @@ export default function ExamAttemptPage({ token, onUnauthorized, onFinish }:{
     const current = selections[questionId];
     if (current === answerId) return;
     try {
-      await apiAuthJson(`${apiBase}/api/exams/attempts/${attemptId}/answers/${questionId}`, token, {
+      await apiJson(`${apiBase}/api/exams/attempts/${attemptId}/answers/${questionId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ selectedAnswerId: answerId }),
         timeoutMs: 15000
       });
-    } catch (err: any) {
-      if (err?.status === 401) onUnauthorized();
-      if (err?.code === 'timeout') {
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'status' in err && (err as { status: number }).status === 401) onUnauthorized();
+      if (err && typeof err === 'object' && 'code' in err && (err as { code: string }).code === 'timeout') {
         alert(timeoutMessage);
         return;
       }
@@ -96,7 +95,7 @@ export default function ExamAttemptPage({ token, onUnauthorized, onFinish }:{
     const filtered: Record<string,string> = {};
     Object.entries(payload.selections).forEach(([q, a]) => { if(a) filtered[q] = a; });
     try {
-      const result = await apiAuthJson<ExamResult>(`${apiBase}/api/exams/attempts/${attemptId}/submit`, token, {
+      const result = await apiJson<ExamResult>(`${apiBase}/api/exams/attempts/${attemptId}/submit`, {
         method: 'POST',
         headers: { 'Content-Type':'application/json' },
         body: JSON.stringify({ selections: filtered }),
@@ -105,9 +104,9 @@ export default function ExamAttemptPage({ token, onUnauthorized, onFinish }:{
       sessionStorage.removeItem('akdmia.activeAttemptId');
       onFinish(result);
       navigate(ROUTES.examResult);
-    } catch (err: any) {
-      if (err?.status === 401) onUnauthorized();
-      if (err?.code === 'timeout') {
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'status' in err && (err as { status: number }).status === 401) onUnauthorized();
+      if (err && typeof err === 'object' && 'code' in err && (err as { code: string }).code === 'timeout') {
         alert(timeoutMessage);
         return;
       }

--- a/frontend/src/pages/FlashcardsExamineUnitPage.tsx
+++ b/frontend/src/pages/FlashcardsExamineUnitPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ArrowLeft, ArrowRight, Inbox } from 'flowbite-react-icons/outline';
-import { apiAuthJson, apiBase } from '../api';
+import { apiJson, apiBase } from '../api';
 
 type Flashcard = {
   id: string;
@@ -20,17 +20,15 @@ export default function FlashcardsExamineUnitPage() {
   const [error, setError] = useState('');
   const [index, setIndex] = useState(0);
   const [flipped, setFlipped] = useState(false);
-  const token = localStorage.getItem('ak_token') || '';
-
   useEffect(() => {
     if (!unitId) { setError('Falta el unitId.'); setLoading(false); return; }
     let mounted = true;
-    apiAuthJson<Flashcard[]>(`${apiBase}/api/flashcards?unitId=${unitId}`, token)
+    apiJson<Flashcard[]>(`${apiBase}/api/flashcards?unitId=${unitId}`)
       .then((data) => { if (mounted) setCards(data || []); })
       .catch(() => { if (mounted) setError('No se pudieron cargar las tarjetas.'); })
       .finally(() => { if (mounted) setLoading(false); });
     return () => { mounted = false; };
-  }, [token, unitId]);
+  }, [unitId]);
 
   const card = cards[index];
   const total = cards.length;

--- a/frontend/src/pages/FlashcardsHistoryPage.tsx
+++ b/frontend/src/pages/FlashcardsHistoryPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Inbox } from 'flowbite-react-icons/outline';
-import { apiAuthJson, apiBase } from '../api';
+import { apiJson, apiBase } from '../api';
 import FlashcardsTabs from '../components/flashcards/FlashcardsTabs';
 
 type HistoryItem = {
@@ -26,16 +26,14 @@ export default function FlashcardsHistoryPage() {
   const [items, setItems] = useState<HistoryItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const token = localStorage.getItem('ak_token') || '';
-
   useEffect(() => {
     let mounted = true;
-    apiAuthJson<HistoryItem[]>(`${apiBase}/api/flashcards/history?limit=50`, token)
+    apiJson<HistoryItem[]>(`${apiBase}/api/flashcards/history?limit=50`)
       .then((data) => { if (mounted) setItems(data || []); })
       .catch(() => { if (mounted) setError('No se pudo cargar el historial.'); })
       .finally(() => { if (mounted) setLoading(false); });
     return () => { mounted = false; };
-  }, [token]);
+  }, []);
 
   return (
     <div className="space-y-6">

--- a/frontend/src/pages/FlashcardsPage.tsx
+++ b/frontend/src/pages/FlashcardsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ArrowLeft, ArrowUpFromBracket, Close, CheckCircle, CirclePlus, Refresh, Clock, Inbox } from 'flowbite-react-icons/outline';
-import { apiAuthJson, apiBase, exportFlashcardsBySubject } from '../api';
+import { apiJson, apiBase, exportFlashcardsBySubject } from '../api';
 import FlashcardImportModal from '../components/flashcards/FlashcardImportModal';
 import FlashcardsTabs from '../components/flashcards/FlashcardsTabs';
 import SearchInput from '../components/flashcards/SearchInput';
@@ -36,12 +36,10 @@ export default function FlashcardsPage() {
   const [selectedSubjectId, setSelectedSubjectId] = useState<string | null>(null);
   const [exportError, setExportError] = useState<string>('');
 
-  const token = localStorage.getItem('ak_token') || '';
-
   const loadUnits = () => {
     setLoading(true);
     setError('');
-    apiAuthJson<UnitSummary[]>(`${apiBase}/api/flashcards/units/summary`, token)
+    apiJson<UnitSummary[]>(`${apiBase}/api/flashcards/units/summary`)
       .then((data) => setUnits(data || []))
       .catch(() => setError('No se pudieron cargar las unidades.'))
       .finally(() => setLoading(false));
@@ -51,22 +49,22 @@ export default function FlashcardsPage() {
     let mounted = true;
     setLoading(true);
     setError('');
-    apiAuthJson<UnitSummary[]>(`${apiBase}/api/flashcards/units/summary`, token)
+    apiJson<UnitSummary[]>(`${apiBase}/api/flashcards/units/summary`)
       .then((data) => { if (mounted) setUnits(data || []); })
       .catch(() => { if (mounted) setError('No se pudieron cargar las unidades.'); })
       .finally(() => { if (mounted) setLoading(false); });
     return () => { mounted = false; };
-  }, [token]);
+  }, []);
 
   useEffect(() => {
     let mounted = true;
     setGlobalLoading(true);
-    apiAuthJson<GlobalQueue>(`${apiBase}/api/flashcards/study/queue`, token)
+    apiJson<GlobalQueue>(`${apiBase}/api/flashcards/study/queue`)
       .then((data) => { if (mounted) setGlobalQueue(data || null); })
       .catch(() => {})
       .finally(() => { if (mounted) setGlobalLoading(false); });
     return () => { mounted = false; };
-  }, [token]);
+  }, []);
 
   // Derive subject summaries from unit data
   const subjects = useMemo<SubjectSummary[]>(() => {
@@ -126,7 +124,7 @@ export default function FlashcardsPage() {
     try {
       const res = await fetch(
         `${apiBase}/api/flashcards/export?unitId=${unit.unitId}&format=${format}`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        { credentials: 'include' }
       );
       if (!res.ok) {
         setExportError('No se pudo exportar. Inténtalo de nuevo.');
@@ -149,7 +147,7 @@ export default function FlashcardsPage() {
   const handleSubjectExport = async (subject: SubjectSummary, format: 'csv' | 'json') => {
     setExportError('');
     try {
-      const content = await exportFlashcardsBySubject(token, subject.subjectId, format);
+      const content = await exportFlashcardsBySubject(subject.subjectId, format);
       const blob = new Blob([content], {
         type: format === 'json' ? 'application/json' : 'text/csv',
       });
@@ -315,7 +313,6 @@ export default function FlashcardsPage() {
 
       {showImport && (
         <FlashcardImportModal
-          token={token}
           onClose={() => setShowImport(false)}
           onImported={loadUnits}
         />

--- a/frontend/src/pages/FlashcardsStudyPage.tsx
+++ b/frontend/src/pages/FlashcardsStudyPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ArrowLeft, CircleMinus, CheckCircle, Close, CloseCircle, Refresh, Rocket, Star } from 'flowbite-react-icons/outline';
-import { apiAuthJson, apiBase } from '../api';
+import { apiJson, apiBase } from '../api';
 
 type IntervalHints = { again: string; good: string; easy: string };
 type ReviewState = 'NEW' | 'LEARNING' | 'REVIEW';
@@ -26,13 +26,11 @@ export default function FlashcardsStudyPage() {
   const [answeredCount, setAnsweredCount] = useState(0);
   const [queueCounts, setQueueCounts] = useState({ new: 0, due: 0, learning: 0 });
 
-  const token = localStorage.getItem('ak_token') || '';
-
   const fetchNext = async () => {
-    const data = await apiAuthJson<StudyItem | undefined>(`${apiBase}/api/flashcards/study/next?unitId=${unitId}`, token);
+    const data = await apiJson<StudyItem | undefined>(`${apiBase}/api/flashcards/study/next?unitId=${unitId}`);
     return data || null;
   };
-  const fetchQueue = async () => apiAuthJson<StudyQueueResponse>(`${apiBase}/api/flashcards/study/queue?unitId=${unitId}`, token);
+  const fetchQueue = async () => apiJson<StudyQueueResponse>(`${apiBase}/api/flashcards/study/queue?unitId=${unitId}`);
 
   const currentItem = items[currentIndex];
   const remaining = Math.max(queueCounts.new + queueCounts.due + queueCounts.learning, 0);
@@ -56,7 +54,7 @@ export default function FlashcardsStudyPage() {
       .catch(() => { if (mounted) setError('No se pudo cargar la sesión de estudio.'); })
       .finally(() => { if (mounted) setLoading(false); });
     return () => { mounted = false; };
-  }, [token, unitId]);
+  }, [unitId]);
 
   useEffect(() => {
     if (!loading && remaining === 0 && !currentItem) setFinished(true);
@@ -67,7 +65,7 @@ export default function FlashcardsStudyPage() {
     setSubmitting(true);
     setReviewError(null);
     try {
-      await apiAuthJson(`${apiBase}/api/flashcards/study/review`, token, {
+      await apiJson(`${apiBase}/api/flashcards/study/review`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ flashcardId: currentItem.flashcardId, grade, reviewedAt: new Date().toISOString() } satisfies ReviewRequest)

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -2,7 +2,7 @@ import { Navigate } from 'react-router-dom';
 import Login from '../components/Login';
 import { ROUTES } from '../constants/routes';
 
-export default function LoginPage({ isAuthed, onToken }: { isAuthed: boolean; onToken: (t: string) => void }) {
+export default function LoginPage({ isAuthed, onAuthSuccess }: { isAuthed: boolean; onAuthSuccess: (user: { email: string; role: string }) => void }) {
   if (isAuthed) return <Navigate to={ROUTES.subjects} replace />;
-  return <Login onToken={onToken} />;
+  return <Login onAuthSuccess={onAuthSuccess} />;
 }

--- a/frontend/src/pages/ManagePage.tsx
+++ b/frontend/src/pages/ManagePage.tsx
@@ -1,5 +1,5 @@
 import Management from '../components/Management';
 
-export default function ManagePage({ isAdmin, token, onSubjectsChanged }: { isAdmin: boolean; token: string; onSubjectsChanged?: () => void }) {
-  return <Management isAdmin={isAdmin} token={token} onSubjectsChanged={onSubjectsChanged} />;
+export default function ManagePage({ isAdmin, onSubjectsChanged }: { isAdmin: boolean; onSubjectsChanged?: () => void }) {
+  return <Management isAdmin={isAdmin} onSubjectsChanged={onSubjectsChanged} />;
 }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -7,7 +7,7 @@ const card = 'border border-secondary/25 rounded-2xl p-6';
 const btnPrimary =
   'btn btn-primary rounded-full px-5 py-2 text-sm shadow-sm shadow-primary/15 flex items-center gap-2 disabled:opacity-60';
 
-export default function ProfilePage({ token }: { token: string }) {
+export default function ProfilePage() {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
@@ -17,7 +17,7 @@ export default function ProfilePage({ token }: { token: string }) {
 
   useEffect(() => {
     setLoading(true);
-    getMyProfile(token)
+    getMyProfile()
       .then((profile) => {
         setEmail(profile.email);
         setFirstName(profile.firstName ?? '');
@@ -27,7 +27,7 @@ export default function ProfilePage({ token }: { token: string }) {
         setErrorMsg('No se pudo cargar el perfil.');
       })
       .finally(() => setLoading(false));
-  }, [token]);
+  }, []);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -35,7 +35,7 @@ export default function ProfilePage({ token }: { token: string }) {
     setErrorMsg('');
     setLoading(true);
     try {
-      await updateMyProfile(token, {
+      await updateMyProfile({
         firstName: firstName.trim() || null,
         lastName: lastName.trim() || null,
       });

--- a/frontend/src/pages/RagPage.tsx
+++ b/frontend/src/pages/RagPage.tsx
@@ -10,11 +10,10 @@ import DraftList from '../components/rag/DraftList';
 type Tab = 'sources' | 'generate' | 'drafts';
 
 interface Props {
-  token: string;
   subjects: Subject[];
 }
 
-export default function RagPage({ token, subjects }: Props) {
+export default function RagPage({ subjects }: Props) {
   const [tab, setTab] = useState<Tab>('sources');
   const [selectedSubjectId, setSelectedSubjectId] = useState<string>('');
   const [sources, setSources] = useState<SourceDocument[]>([]);
@@ -27,18 +26,18 @@ export default function RagPage({ token, subjects }: Props) {
   useEffect(() => {
     if (!selectedSubjectId) { setSources([]); return; }
     setSourcesLoading(true);
-    getSources(token, selectedSubjectId)
+    getSources(selectedSubjectId)
       .then(setSources)
       .catch(() => setSources([]))
       .finally(() => setSourcesLoading(false));
-  }, [token, selectedSubjectId]);
+  }, [selectedSubjectId]);
 
   function onUploaded(doc: SourceDocument) {
     setSources((prev) => [doc, ...prev]);
   }
 
   async function onDelete(id: string) {
-    await deleteSource(token, id);
+    await deleteSource(id);
     setSources((prev) => prev.filter((s) => s.id !== id));
   }
 
@@ -47,7 +46,7 @@ export default function RagPage({ token, subjects }: Props) {
     setGenerateError('');
     setResult(null);
     try {
-      const res = await generateQuiz(token, cmd);
+      const res = await generateQuiz(cmd);
       setResult(res);
     } catch (err: any) {
       if (err?.code === 'timeout') {
@@ -125,7 +124,6 @@ export default function RagPage({ token, subjects }: Props) {
                 <section>
                   <h2 className="text-base font-semibold mb-3">Subir documento PDF</h2>
                   <SourceUpload
-                    token={token}
                     subjectId={selectedSubjectId}
                     onUploaded={onUploaded}
                   />
@@ -151,7 +149,6 @@ export default function RagPage({ token, subjects }: Props) {
                   <>
                     <h2 className="text-base font-semibold">Configurar generación</h2>
                     <QuizGenerateForm
-                      token={token}
                       sources={sources}
                       subjectId={selectedSubjectId}
                       onGenerate={onGenerate}
@@ -168,7 +165,7 @@ export default function RagPage({ token, subjects }: Props) {
             {tab === 'drafts' && (
               <div className="space-y-6">
                 <h2 className="text-base font-semibold">Borradores guardados</h2>
-                <DraftList token={token} sources={sources} />
+                <DraftList sources={sources} />
               </div>
             )}
           </div>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -2,7 +2,7 @@ import { Navigate } from 'react-router-dom';
 import Register from '../components/Register';
 import { ROUTES } from '../constants/routes';
 
-export default function RegisterPage({ isAuthed, onToken }: { isAuthed: boolean; onToken: (t: string) => void }) {
+export default function RegisterPage({ isAuthed, onAuthSuccess }: { isAuthed: boolean; onAuthSuccess: (user: { email: string; role: string }) => void }) {
   if (isAuthed) return <Navigate to={ROUTES.subjects} replace />;
-  return <Register onToken={onToken} />;
+  return <Register onAuthSuccess={onAuthSuccess} />;
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import Settings from '../components/Settings';
 
-export default function SettingsPage({ isAdmin, token }: { isAdmin: boolean; token: string }) {
-  return <Settings isAdmin={isAdmin} token={token} />;
+export default function SettingsPage({ isAdmin }: { isAdmin: boolean }) {
+  return <Settings isAdmin={isAdmin} />;
 }

--- a/frontend/src/pages/SubjectsPage.tsx
+++ b/frontend/src/pages/SubjectsPage.tsx
@@ -2,14 +2,13 @@ import { Link } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { formatDuration } from '../utils/format';
 import { Plus, ArrowsRepeat, ClipboardCheck, BookOpen } from 'flowbite-react-icons/outline';
-import { apiAuthJson, apiBase } from '../api';
+import { apiJson, apiBase } from '../api';
 import type { Subject, ExamAttemptSummary } from '../types';
 import { ROUTES } from '../constants/routes';
 
-export default function SubjectsPage({ subjects, activeAttemptId, token, onUnauthorized, onViewResult, onResumeAttempt }: {
+export default function SubjectsPage({ subjects, activeAttemptId, onUnauthorized, onViewResult, onResumeAttempt }: {
   subjects: Subject[];
   activeAttemptId?: string;
-  token: string;
   onUnauthorized: () => void;
   onViewResult: (attemptId: string) => void;
   onResumeAttempt: (attemptId: string) => void;
@@ -31,15 +30,15 @@ export default function SubjectsPage({ subjects, activeAttemptId, token, onUnaut
   useEffect(() => {
     setLoading(true);
     setError('');
-    apiAuthJson<ExamAttemptSummary[]>(`${apiBase}/api/exams/attempts`, token)
+    apiJson<ExamAttemptSummary[]>(`${apiBase}/api/exams/attempts`)
       .then(setHistory)
-      .catch(err => {
-        if (err?.status === 401) onUnauthorized();
+      .catch((err: unknown) => {
+        if (err && typeof err === 'object' && 'status' in err && (err as { status: number }).status === 401) onUnauthorized();
         setError('No se pudo cargar el historial.');
         setHistory([]);
       })
       .finally(() => setLoading(false));
-  }, [token, apiBase]);
+  }, [apiBase]);
 
   return (
     <section className="mb-8">


### PR DESCRIPTION
## Summary

Replaces localStorage JWT storage with httpOnly cookies to prevent XSS token theft. The backend now emits the token as a `Set-Cookie` header on login/register/OAuth2 exchange, and the `JwtAuthFilter` reads the cookie as fallback when no `Authorization` header is present. New `POST /api/auth/logout` and `GET /api/auth/me` endpoints complete the server-side session lifecycle.

On the frontend, all `localStorage` token access is removed. `App.tsx` hydrates auth state on mount via `/api/auth/me`, and all API calls use `credentials: 'include'` so cookies are sent automatically.

## Changes

- **`AuthController`** — cookie emission on login/register/oauth2/exchange; new logout (clears cookie) and me (returns email+role) endpoints
- **`SecurityConfig`** — `JwtAuthFilter` falls back to `ak_token` cookie when no Bearer header; CORS allows `Cookie` header
- **`application.properties`** — `app.cookie.secure` property (true by default, false in dev)
- **`api.ts`** — removed `token` param from all functions; added `credentials: 'include'`; added `getMe()` and `logout()`
- **`App.tsx`** — replaced token state with `authUser`/`authLoading`; hydrates from `/api/auth/me` on mount
- **Login/Register + 10 pages/components** — removed `token` prop and `localStorage` access

## Test plan

- [ ] Backend unit: `AuthControllerCookieTest` (6 scenarios: cookie emission, secure flag, logout, me endpoint)
- [ ] Backend unit: `JwtAuthFilterCookieTest` (4 scenarios: cookie auth, bearer auth, invalid cookie, no auth)
- [ ] Frontend: 132 tests passing

## Coverage

Backend: 68.6% LINE / 55.6% BRANCH (project-wide, pre-existing baseline)
Frontend: 34.09% statements (project-wide, pre-existing baseline)

## Quality Gate

✅ PASSED — 0 new issues

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)