### PR TITLE
💄 style(exam-builder): apply Stitch design

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -248,7 +248,7 @@ export default function App() {
           {toastError}
         </div>
       )}
-      <main className={isFullWidth ? 'pt-[4rem] overflow-x-hidden' : 'max-w-4xl mx-auto p-6 pt-24'}>
+      <main className={isFullWidth ? 'pt-[4rem] overflow-x-hidden' : 'max-w-7xl mx-auto p-6 pt-24'}>
         <Routes>
           <Route path={ROUTES.home} element={<HomePage isAuthed={isAuthed} activeAttemptId={activeAttemptId} />} />
           <Route path={ROUTES.login} element={<LoginPage isAuthed={isAuthed} onAuthSuccess={onAuthSuccess} />} />

--- a/frontend/src/components/ExamBuilder.tsx
+++ b/frontend/src/components/ExamBuilder.tsx
@@ -154,7 +154,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
 
         {/* ── Right column: units ── */}
         <div className="lg:col-span-8">
-          <div className="border border-secondary/25 rounded-3xl p-8">
+          <div className="border border-secondary/25 rounded-3xl p-8 mb-8">
             <div className="flex items-center gap-3 mb-8">
               <ClipboardList className="w-5 h-5 text-primary" />
               <h2 className="text-xl font-bold">Preguntas por unidad</h2>
@@ -218,7 +218,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
             </div>
 
             {totalPages > 1 && (
-              <div className="mt-8 mb-8 flex items-center justify-center gap-4">
+              <div className="mt-8 flex items-center justify-center gap-4">
                 <button
                   onClick={() => setPage(p => p - 1)}
                   disabled={page === 0}

--- a/frontend/src/components/ExamBuilder.tsx
+++ b/frontend/src/components/ExamBuilder.tsx
@@ -92,14 +92,19 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
             {/* Time */}
             <div className="space-y-2">
               <label className="text-sm font-semibold text-text/55">Tiempo total en min</label>
+              <div className="flex items-center gap-2">
+                <svg className="w-4 h-4 text-text/40 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clipRule="evenodd" />
+                </svg>
               <input
                 type="number"
                 min={1}
                 value={time}
                 onChange={e => setTime(Number(e.target.value))}
-                className={inp + ' w-full'}
+                className={inp + ' flex-1'}
                 placeholder="Ej. 60"
               />
+              </div>
             </div>
 
             {/* Random count */}
@@ -196,7 +201,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
                         value={disabled ? 0 : current}
                         onChange={e => setCount(u.id, Number(e.target.value))}
                         disabled={disabled}
-                        className="w-10 text-center bg-transparent border-none focus:ring-0 font-bold text-lg outline-none disabled:opacity-40"
+                        className="w-10 text-center bg-white/50 dark:bg-[#24394c] border border-secondary/30 rounded-lg py-1 font-bold text-base focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-40"
                       />
                       <button
                         onClick={() => setCount(u.id, current + 1)}
@@ -263,9 +268,18 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
               </div>
             </div>
             <div className="h-12 w-px bg-secondary/20 hidden md:block" />
-            <div className="hidden md:flex items-center gap-3">
-              <Play className="w-5 h-5 text-primary" />
-              <span className="text-sm font-medium text-text/55">{time} min configurados</span>
+            <div className="hidden md:flex items-center gap-4">
+              <div className="flex -space-x-3">
+                <div className="w-10 h-10 rounded-full border-2 border-bg bg-primary flex items-center justify-center z-10">
+                  <svg className="w-4 h-4 text-bg" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clipRule="evenodd" />
+                  </svg>
+                </div>
+                <div className="w-10 h-10 rounded-full border-2 border-bg bg-secondary/40 dark:bg-[#1F2E40] flex items-center justify-center text-xs font-bold">
+                  {total()}m
+                </div>
+              </div>
+              <p className="text-sm font-medium text-text/55">Estimación de tiempo</p>
             </div>
           </div>
 

--- a/frontend/src/components/ExamBuilder.tsx
+++ b/frontend/src/components/ExamBuilder.tsx
@@ -185,7 +185,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
                       </div>
                     </div>
 
-                    <div className="flex items-center gap-3 border border-secondary/15 p-2 rounded-2xl self-start sm:self-auto">
+                    <div className="flex items-center gap-3 border border-secondary/15 p-2 rounded-2xl self-center sm:self-auto">
                       <button
                         onClick={() => setCount(u.id, current - 1)}
                         disabled={disabled || current === 0}
@@ -218,7 +218,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
             </div>
 
             {totalPages > 1 && (
-              <div className="mt-8 flex items-center justify-center gap-4">
+              <div className="mt-8 mb-8 flex items-center justify-center gap-4">
                 <button
                   onClick={() => setPage(p => p - 1)}
                   disabled={page === 0}
@@ -228,17 +228,22 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
                   <span className="hidden sm:inline">Anterior</span>
                 </button>
                 <div className="flex gap-2">
-                  {Array.from({ length: totalPages }, (_, i) => (
-                    <button
-                      key={i}
-                      onClick={() => setPage(i)}
-                      className={`w-10 h-10 rounded-lg flex items-center justify-center font-bold transition-all ${
-                        i === page ? 'bg-primary text-bg' : 'hover:bg-secondary/15'
-                      }`}
-                    >
-                      {i + 1}
-                    </button>
-                  ))}
+                  {(() => {
+                    const WINDOW = 4;
+                    const start = Math.max(0, Math.min(page - 1, totalPages - WINDOW));
+                    const end = Math.min(start + WINDOW, totalPages);
+                    return Array.from({ length: end - start }, (_, i) => start + i).map(i => (
+                      <button
+                        key={i}
+                        onClick={() => setPage(i)}
+                        className={`w-10 h-10 rounded-lg flex items-center justify-center font-bold transition-all ${
+                          i === page ? 'bg-primary text-bg' : 'hover:bg-secondary/15'
+                        }`}
+                      >
+                        {i + 1}
+                      </button>
+                    ));
+                  })()}
                 </div>
                 <button
                   onClick={() => setPage(p => p + 1)}

--- a/frontend/src/components/ExamBuilder.tsx
+++ b/frontend/src/components/ExamBuilder.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 import {
   Minus, Plus, Play, AdjustmentsHorizontal, Shuffle,
-  ClipboardList, Lightbulb, ChevronLeft, ChevronRight, ChevronDown,
+  ClipboardList, Lightbulb, ChevronLeft, ChevronRight,
 } from 'flowbite-react-icons/outline';
 import { apiBase, apiJson } from '../api';
 import type { UnitAvailability } from '../types';
 
-const inputUnderline = 'w-full bg-transparent border-0 border-b-2 border-secondary/20 focus:border-primary focus:ring-0 rounded-t-xl px-4 py-3 text-text font-medium transition-colors outline-none';
+const inp = 'bg-white/50 dark:bg-[#24394c] border border-secondary/30 rounded-xl px-4 py-2.5 text-sm text-text placeholder:text-text/35 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50 transition-colors';
 
 export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnauthorized }: {
   subjectId: string;
@@ -21,7 +21,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
   const [availabilityLoading, setAvailabilityLoading] = useState(false);
   const [page, setPage] = useState(0);
   const [randomCount, setRandomCount] = useState(10);
-  const PAGE_SIZE = 10;
+  const PAGE_SIZE = 6;
 
   useEffect(() => {
     const diffQuery = difficulty === 'ALL' ? '' : `&difficulty=${difficulty}`;
@@ -45,7 +45,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
   const totalAvailable = units.reduce((sum, u) => sum + (u.available || 0), 0);
 
   return (
-    <div className="max-w-7xl mx-auto pb-32">
+    <div className="max-w-8xl mx-auto pb-32">
 
       {/* ── Hero ── */}
       <div className="mb-12">
@@ -67,7 +67,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
         <div className="lg:col-span-4 space-y-6">
           <div className="border border-secondary/25 rounded-3xl p-8 flex flex-col gap-6">
             <div className="flex items-center gap-3">
-              <AdjustmentsHorizontal className="w-5 h-5 text-accent" />
+              <AdjustmentsHorizontal className="w-5 h-5 text-primary" />
               <h2 className="text-xl font-bold">Configuración General</h2>
             </div>
 
@@ -77,19 +77,16 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
                 Dificultad
                 {availabilityLoading && <span className="ml-1.5 text-text/35 font-normal">· actualizando…</span>}
               </label>
-              <div className="relative">
-                <select
-                  className={inputUnderline + ' appearance-none pr-10'}
-                  value={difficulty}
-                  onChange={e => setDifficulty(e.target.value as 'EASY' | 'MEDIUM' | 'HARD' | 'ALL')}
-                >
-                  <option value="ALL">Todas</option>
-                  <option value="EASY">Fácil</option>
-                  <option value="MEDIUM">Media</option>
-                  <option value="HARD">Difícil</option>
-                </select>
-                <ChevronDown className="w-4 h-4 absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none text-text/40" />
-              </div>
+              <select
+                className={inp + ' w-full'}
+                value={difficulty}
+                onChange={e => setDifficulty(e.target.value as 'EASY' | 'MEDIUM' | 'HARD' | 'ALL')}
+              >
+                <option value="ALL">Todas</option>
+                <option value="EASY">Fácil</option>
+                <option value="MEDIUM">Media</option>
+                <option value="HARD">Difícil</option>
+              </select>
             </div>
 
             {/* Time */}
@@ -100,7 +97,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
                 min={1}
                 value={time}
                 onChange={e => setTime(Number(e.target.value))}
-                className={inputUnderline}
+                className={inp + ' w-full'}
                 placeholder="Ej. 60"
               />
             </div>
@@ -111,8 +108,8 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
                 Preguntas aleatorias{' '}
                 <span className="text-text/35 font-normal">(máx. {totalAvailable})</span>
               </label>
-              <div className="flex items-center border-b-2 border-secondary/20 focus-within:border-primary rounded-t-xl overflow-hidden transition-colors">
-                <Shuffle className="w-5 h-5 mx-4 text-text/40 shrink-0" />
+              <div className="flex items-center gap-2">
+                <Shuffle className="w-4 h-4 text-text/40 shrink-0" />
                 <input
                   type="number"
                   min={1}
@@ -120,7 +117,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
                   value={randomCount}
                   onChange={e => setRandomCount(Math.max(1, Math.min(Number(e.target.value), totalAvailable || 1)))}
                   disabled={totalAvailable === 0}
-                  className="w-full bg-transparent border-none focus:ring-0 py-3 text-text outline-none disabled:opacity-40"
+                  className={inp + ' flex-1 disabled:opacity-40'}
                 />
               </div>
             </div>
@@ -136,11 +133,11 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
           </div>
 
           {/* Tip card */}
-          <div className="bg-accent/10 rounded-3xl p-6 border border-accent/20">
+          <div className="bg-primary/10 rounded-3xl p-6 border border-primary/20">
             <div className="flex items-start gap-4">
-              <Lightbulb className="w-5 h-5 text-accent shrink-0 mt-0.5" />
+              <Lightbulb className="w-5 h-5 text-primary shrink-0 mt-0.5" />
               <div>
-                <p className="text-accent font-bold mb-1">Tip de estudio</p>
+                <p className="text-primary font-bold mb-1">Tip de estudio</p>
                 <p className="text-sm text-text/60">
                   Configurar exámenes con tiempo reducido ayuda a simular la presión real del examen
                   y mejora tu gestión del tiempo.
@@ -154,7 +151,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
         <div className="lg:col-span-8">
           <div className="border border-secondary/25 rounded-3xl p-8">
             <div className="flex items-center gap-3 mb-8">
-              <ClipboardList className="w-5 h-5 text-accent" />
+              <ClipboardList className="w-5 h-5 text-primary" />
               <h2 className="text-xl font-bold">Preguntas por unidad</h2>
             </div>
 
@@ -168,12 +165,12 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
                     className={`flex items-center justify-between p-6 border rounded-2xl transition-all ${
                       disabled
                         ? 'border-secondary/10 opacity-50'
-                        : 'border-secondary/20 hover:border-accent/30'
+                        : 'border-secondary/20 hover:border-primary/30'
                     }`}
                   >
                     <div className="flex items-center gap-4">
-                      <div className="w-12 h-12 rounded-xl bg-accent/10 flex items-center justify-center shrink-0">
-                        <span className="text-accent font-bold text-sm">{page * PAGE_SIZE + i + 1}</span>
+                      <div className="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center shrink-0">
+                        <span className="text-primary font-bold text-sm">{page * PAGE_SIZE + i + 1}</span>
                       </div>
                       <div>
                         <h3 className="font-bold text-sm">{u.name}</h3>
@@ -187,7 +184,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
                       <button
                         onClick={() => setCount(u.id, current - 1)}
                         disabled={disabled || current === 0}
-                        className="w-8 h-8 rounded-lg flex items-center justify-center border border-secondary/25 hover:border-accent/50 hover:text-accent transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                        className="w-8 h-8 rounded-lg flex items-center justify-center border border-secondary/25 hover:border-primary/50 hover:text-primary transition-all disabled:opacity-40 disabled:cursor-not-allowed"
                         aria-label="Disminuir"
                       >
                         <Minus className="w-3.5 h-3.5" />
@@ -204,7 +201,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
                       <button
                         onClick={() => setCount(u.id, current + 1)}
                         disabled={disabled || current >= (u.available || 0)}
-                        className="w-8 h-8 rounded-lg flex items-center justify-center border border-secondary/25 hover:border-accent/50 hover:text-accent transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                        className="w-8 h-8 rounded-lg flex items-center justify-center border border-secondary/25 hover:border-primary/50 hover:text-primary transition-all disabled:opacity-40 disabled:cursor-not-allowed"
                         aria-label="Aumentar"
                       >
                         <Plus className="w-3.5 h-3.5" />
@@ -231,7 +228,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
                       key={i}
                       onClick={() => setPage(i)}
                       className={`w-10 h-10 rounded-lg flex items-center justify-center font-bold transition-all ${
-                        i === page ? 'bg-accent text-bg' : 'hover:bg-secondary/15'
+                        i === page ? 'bg-primary text-bg' : 'hover:bg-secondary/15'
                       }`}
                     >
                       {i + 1}
@@ -254,20 +251,20 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
 
       {/* ── Sticky bottom bar ── */}
       <div className="fixed bottom-0 left-0 right-0 z-50 bg-bg/90 backdrop-blur-2xl border-t border-secondary/20 px-8 py-6">
-        <div className="max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between gap-6">
+        <div className="max-w-8xl mx-auto flex flex-col md:flex-row items-center justify-between gap-6">
           <div className="flex items-center gap-8">
             <div className="flex flex-col">
               <span className="text-xs font-bold uppercase tracking-widest text-text/40 mb-1">
                 Resumen de selección
               </span>
               <div className="flex items-baseline gap-2">
-                <span className="text-3xl font-black text-accent">{total()}</span>
+                <span className="text-3xl font-black text-primary">{total()}</span>
                 <span className="text-sm font-semibold text-text/55">Total seleccionadas</span>
               </div>
             </div>
             <div className="h-12 w-px bg-secondary/20 hidden md:block" />
             <div className="hidden md:flex items-center gap-3">
-              <Play className="w-5 h-5 text-accent" />
+              <Play className="w-5 h-5 text-primary" />
               <span className="text-sm font-medium text-text/55">{time} min configurados</span>
             </div>
           </div>

--- a/frontend/src/components/ExamBuilder.tsx
+++ b/frontend/src/components/ExamBuilder.tsx
@@ -167,7 +167,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
                 return (
                   <div
                     key={u.id}
-                    className={`flex items-center justify-between p-6 border rounded-2xl transition-all ${
+                    className={`flex flex-col sm:flex-row sm:items-center sm:justify-between p-6 border rounded-2xl transition-all gap-4 ${
                       disabled
                         ? 'border-secondary/10 opacity-50'
                         : 'border-secondary/20 hover:border-primary/30'
@@ -185,7 +185,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
                       </div>
                     </div>
 
-                    <div className="flex items-center gap-3 border border-secondary/15 p-2 rounded-2xl">
+                    <div className="flex items-center gap-3 border border-secondary/15 p-2 rounded-2xl self-start sm:self-auto">
                       <button
                         onClick={() => setCount(u.id, current - 1)}
                         disabled={disabled || current === 0}
@@ -222,10 +222,10 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
                 <button
                   onClick={() => setPage(p => p - 1)}
                   disabled={page === 0}
-                  className="flex items-center gap-2 px-6 py-2 rounded-xl font-semibold text-text/55 hover:bg-secondary/10 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+                  className="flex items-center gap-2 px-3 sm:px-6 py-2 rounded-xl font-semibold text-text/55 hover:bg-secondary/10 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
                 >
                   <ChevronLeft className="w-5 h-5" />
-                  Anterior
+                  <span className="hidden sm:inline">Anterior</span>
                 </button>
                 <div className="flex gap-2">
                   {Array.from({ length: totalPages }, (_, i) => (
@@ -243,9 +243,9 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
                 <button
                   onClick={() => setPage(p => p + 1)}
                   disabled={page >= totalPages - 1}
-                  className="flex items-center gap-2 px-6 py-2 rounded-xl font-semibold text-text/55 hover:bg-secondary/10 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+                  className="flex items-center gap-2 px-3 sm:px-6 py-2 rounded-xl font-semibold text-text/55 hover:bg-secondary/10 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
                 >
-                  Siguiente
+                  <span className="hidden sm:inline">Siguiente</span>
                   <ChevronRight className="w-5 h-5" />
                 </button>
               </div>
@@ -295,7 +295,8 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
               disabled={totalAvailable === 0 || total() === 0}
               className="flex-[2] md:flex-none btn btn-primary px-12 py-4 rounded-3xl font-extrabold text-xl shadow-lg shadow-primary/20 flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              Empezar examen
+              <span className="sm:hidden">Empezar</span>
+              <span className="hidden sm:inline">Empezar examen</span>
             </button>
           </div>
         </div>

--- a/frontend/src/components/ExamBuilder.tsx
+++ b/frontend/src/components/ExamBuilder.tsx
@@ -154,7 +154,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
 
         {/* ── Right column: units ── */}
         <div className="lg:col-span-8">
-          <div className="border border-secondary/25 rounded-3xl p-8 mb-8">
+          <div className="border border-secondary/25 rounded-3xl p-8 mb-10">
             <div className="flex items-center gap-3 mb-8">
               <ClipboardList className="w-5 h-5 text-primary" />
               <h2 className="text-xl font-bold">Preguntas por unidad</h2>

--- a/frontend/src/components/ExamBuilder.tsx
+++ b/frontend/src/components/ExamBuilder.tsx
@@ -201,7 +201,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
                         value={disabled ? 0 : current}
                         onChange={e => setCount(u.id, Number(e.target.value))}
                         disabled={disabled}
-                        className="w-10 text-center bg-white/50 dark:bg-[#24394c] border border-secondary/30 rounded-lg py-1 font-bold text-base focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-40"
+                        className="w-[3.75rem] text-center bg-white/50 dark:bg-[#24394c] border border-secondary/30 rounded-lg py-1 font-bold text-base focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-40"
                       />
                       <button
                         onClick={() => setCount(u.id, current + 1)}
@@ -269,13 +269,13 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
             </div>
             <div className="h-12 w-px bg-secondary/20 hidden md:block" />
             <div className="hidden md:flex items-center gap-4">
-              <div className="flex -space-x-3">
-                <div className="w-10 h-10 rounded-full border-2 border-bg bg-primary flex items-center justify-center z-10">
-                  <svg className="w-4 h-4 text-bg" fill="currentColor" viewBox="0 0 20 20">
+              <div className="flex -space-x-4">
+                <div className="w-12 h-12 rounded-full border-2 border-bg bg-primary flex items-center justify-center z-0">
+                  <svg className="w-5 h-5 text-bg" fill="currentColor" viewBox="0 0 20 20">
                     <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clipRule="evenodd" />
                   </svg>
                 </div>
-                <div className="w-10 h-10 rounded-full border-2 border-bg bg-secondary/40 dark:bg-[#1F2E40] flex items-center justify-center text-xs font-bold">
+                <div className="w-12 h-12 rounded-full border-2 border-bg bg-secondary/40 dark:bg-[#1F2E40] flex items-center justify-center text-sm font-bold z-10">
                   {total()}m
                 </div>
               </div>

--- a/frontend/src/components/ExamBuilder.tsx
+++ b/frontend/src/components/ExamBuilder.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useState } from 'react';
-import { Minus, Plus, Play } from 'flowbite-react-icons/outline';
+import {
+  Minus, Plus, Play, AdjustmentsHorizontal, Shuffle,
+  ClipboardList, Lightbulb, ChevronLeft, ChevronRight, ChevronDown,
+} from 'flowbite-react-icons/outline';
 import { apiBase, apiJson } from '../api';
 import type { UnitAvailability } from '../types';
 
-const inp = 'bg-white/50 dark:bg-[#24394c] border border-secondary/30 rounded-xl px-4 py-2.5 text-sm text-text placeholder:text-text/35 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50 transition-colors';
+const inputUnderline = 'w-full bg-transparent border-0 border-b-2 border-secondary/20 focus:border-primary focus:ring-0 rounded-t-xl px-4 py-3 text-text font-medium transition-colors outline-none';
 
 export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnauthorized }: {
   subjectId: string;
@@ -38,167 +41,253 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
     setRules(prev => ({ ...prev, [id]: Math.max(0, Math.min(count, max)) }));
   }
   function total() { return Object.values(rules).reduce((a, b) => a + (b || 0), 0); }
+  function clearRules() { setRules({}); }
   const totalAvailable = units.reduce((sum, u) => sum + (u.available || 0), 0);
 
   return (
-    <div className="max-w-3xl mx-auto">
+    <div className="max-w-7xl mx-auto pb-32">
 
-      <div className="mb-8">
-        <h1 className="text-3xl font-extrabold tracking-tight mb-1">
+      {/* ── Hero ── */}
+      <div className="mb-12">
+        <h1 className="text-4xl font-extrabold tracking-tight mb-2">
           Configura tu{' '}
           <span className="bg-gradient-to-r from-primary via-accent to-primary bg-clip-text text-transparent">
             examen
           </span>
         </h1>
-        <p className="text-text/55 text-sm">Selecciona las unidades y el número de preguntas de cada una.</p>
+        <p className="text-text/55 max-w-2xl">
+          Diseña una sesión de estudio personalizada ajustando la dificultad, el tiempo y los temas
+          específicos para optimizar tu rendimiento académico.
+        </p>
       </div>
 
-      {/* ── General config ── */}
-      <div className="border border-secondary/25 rounded-2xl p-6 mb-5">
-        <div className="text-xs text-text/50 uppercase tracking-wide font-semibold mb-4">Configuración general</div>
-        <div className="grid sm:grid-cols-2 gap-4">
-          <div>
-            <label className="block text-sm font-medium text-text/70 mb-1.5">Dificultad</label>
-            <div className="flex items-center gap-2">
-              <select
-                className={inp + ' flex-1'}
-                value={difficulty}
-                onChange={e => setDifficulty(e.target.value as 'EASY' | 'MEDIUM' | 'HARD' | 'ALL')}
-              >
-                <option value="ALL">Todas</option>
-                <option value="EASY">Fácil</option>
-                <option value="MEDIUM">Media</option>
-                <option value="HARD">Difícil</option>
-              </select>
-              {availabilityLoading && <span className="text-xs text-text/50 shrink-0">Actualizando...</span>}
-            </div>
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-text/70 mb-1.5">Tiempo total (min)</label>
-            <input
-              type="number"
-              min={1}
-              value={time}
-              onChange={e => setTime(Number(e.target.value))}
-              className={inp + ' w-28'}
-            />
-          </div>
-        </div>
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
 
-        <div className="mt-4 pt-4 border-t border-secondary/20">
-          <div className="flex flex-wrap items-end gap-4">
-            <div className="flex-1 min-w-[160px]">
-              <label className="block text-sm font-medium text-text/70 mb-1.5">
-                Preguntas aleatorias
-                <span className="ml-1.5 text-text/40 font-normal">(máx. {totalAvailable})</span>
+        {/* ── Left column: config + tip ── */}
+        <div className="lg:col-span-4 space-y-6">
+          <div className="border border-secondary/25 rounded-3xl p-8 flex flex-col gap-6">
+            <div className="flex items-center gap-3">
+              <AdjustmentsHorizontal className="w-5 h-5 text-accent" />
+              <h2 className="text-xl font-bold">Configuración General</h2>
+            </div>
+
+            {/* Difficulty */}
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-text/55">
+                Dificultad
+                {availabilityLoading && <span className="ml-1.5 text-text/35 font-normal">· actualizando…</span>}
               </label>
+              <div className="relative">
+                <select
+                  className={inputUnderline + ' appearance-none pr-10'}
+                  value={difficulty}
+                  onChange={e => setDifficulty(e.target.value as 'EASY' | 'MEDIUM' | 'HARD' | 'ALL')}
+                >
+                  <option value="ALL">Todas</option>
+                  <option value="EASY">Fácil</option>
+                  <option value="MEDIUM">Media</option>
+                  <option value="HARD">Difícil</option>
+                </select>
+                <ChevronDown className="w-4 h-4 absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none text-text/40" />
+              </div>
+            </div>
+
+            {/* Time */}
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-text/55">Tiempo total en min</label>
               <input
                 type="number"
                 min={1}
-                max={totalAvailable || 1}
-                value={randomCount}
-                onChange={e => setRandomCount(Math.max(1, Math.min(Number(e.target.value), totalAvailable || 1)))}
-                disabled={totalAvailable === 0}
-                className={inp + ' w-28 disabled:opacity-40'}
+                value={time}
+                onChange={e => setTime(Number(e.target.value))}
+                className={inputUnderline}
+                placeholder="Ej. 60"
               />
             </div>
+
+            {/* Random count */}
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-text/55">
+                Preguntas aleatorias{' '}
+                <span className="text-text/35 font-normal">(máx. {totalAvailable})</span>
+              </label>
+              <div className="flex items-center border-b-2 border-secondary/20 focus-within:border-primary rounded-t-xl overflow-hidden transition-colors">
+                <Shuffle className="w-5 h-5 mx-4 text-text/40 shrink-0" />
+                <input
+                  type="number"
+                  min={1}
+                  max={totalAvailable || 1}
+                  value={randomCount}
+                  onChange={e => setRandomCount(Math.max(1, Math.min(Number(e.target.value), totalAvailable || 1)))}
+                  disabled={totalAvailable === 0}
+                  className="w-full bg-transparent border-none focus:ring-0 py-3 text-text outline-none disabled:opacity-40"
+                />
+              </div>
+            </div>
+
             <button
               onClick={() => onStartRandom({ subjectId, count: randomCount, minutes: time, difficulty: difficulty === 'ALL' ? undefined : difficulty })}
               disabled={totalAvailable === 0 || randomCount < 1}
-              className="btn btn-primary rounded-full px-6 py-2.5 text-sm shadow-lg shadow-primary/20 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="btn btn-primary w-full mt-2 py-4 rounded-3xl font-bold text-lg flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              <Play className="w-4 h-4" />
+              <Play className="w-5 h-5" />
               Examen aleatorio
             </button>
           </div>
+
+          {/* Tip card */}
+          <div className="bg-accent/10 rounded-3xl p-6 border border-accent/20">
+            <div className="flex items-start gap-4">
+              <Lightbulb className="w-5 h-5 text-accent shrink-0 mt-0.5" />
+              <div>
+                <p className="text-accent font-bold mb-1">Tip de estudio</p>
+                <p className="text-sm text-text/60">
+                  Configurar exámenes con tiempo reducido ayuda a simular la presión real del examen
+                  y mejora tu gestión del tiempo.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* ── Right column: units ── */}
+        <div className="lg:col-span-8">
+          <div className="border border-secondary/25 rounded-3xl p-8">
+            <div className="flex items-center gap-3 mb-8">
+              <ClipboardList className="w-5 h-5 text-accent" />
+              <h2 className="text-xl font-bold">Preguntas por unidad</h2>
+            </div>
+
+            <div className="space-y-4">
+              {pagedUnits.map((u, i) => {
+                const disabled = (u.available || 0) === 0;
+                const current = rules[u.id] || 0;
+                return (
+                  <div
+                    key={u.id}
+                    className={`flex items-center justify-between p-6 border rounded-2xl transition-all ${
+                      disabled
+                        ? 'border-secondary/10 opacity-50'
+                        : 'border-secondary/20 hover:border-accent/30'
+                    }`}
+                  >
+                    <div className="flex items-center gap-4">
+                      <div className="w-12 h-12 rounded-xl bg-accent/10 flex items-center justify-center shrink-0">
+                        <span className="text-accent font-bold text-sm">{page * PAGE_SIZE + i + 1}</span>
+                      </div>
+                      <div>
+                        <h3 className="font-bold text-sm">{u.name}</h3>
+                        <p className="text-xs font-semibold text-text/45 uppercase tracking-wider mt-0.5">
+                          {u.available} disponibles
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-3 border border-secondary/15 p-2 rounded-2xl">
+                      <button
+                        onClick={() => setCount(u.id, current - 1)}
+                        disabled={disabled || current === 0}
+                        className="w-8 h-8 rounded-lg flex items-center justify-center border border-secondary/25 hover:border-accent/50 hover:text-accent transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                        aria-label="Disminuir"
+                      >
+                        <Minus className="w-3.5 h-3.5" />
+                      </button>
+                      <input
+                        type="number"
+                        min={0}
+                        max={u.available}
+                        value={disabled ? 0 : current}
+                        onChange={e => setCount(u.id, Number(e.target.value))}
+                        disabled={disabled}
+                        className="w-10 text-center bg-transparent border-none focus:ring-0 font-bold text-lg outline-none disabled:opacity-40"
+                      />
+                      <button
+                        onClick={() => setCount(u.id, current + 1)}
+                        disabled={disabled || current >= (u.available || 0)}
+                        className="w-8 h-8 rounded-lg flex items-center justify-center border border-secondary/25 hover:border-accent/50 hover:text-accent transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                        aria-label="Aumentar"
+                      >
+                        <Plus className="w-3.5 h-3.5" />
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {totalPages > 1 && (
+              <div className="mt-8 flex items-center justify-center gap-4">
+                <button
+                  onClick={() => setPage(p => p - 1)}
+                  disabled={page === 0}
+                  className="flex items-center gap-2 px-6 py-2 rounded-xl font-semibold text-text/55 hover:bg-secondary/10 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+                >
+                  <ChevronLeft className="w-5 h-5" />
+                  Anterior
+                </button>
+                <div className="flex gap-2">
+                  {Array.from({ length: totalPages }, (_, i) => (
+                    <button
+                      key={i}
+                      onClick={() => setPage(i)}
+                      className={`w-10 h-10 rounded-lg flex items-center justify-center font-bold transition-all ${
+                        i === page ? 'bg-accent text-bg' : 'hover:bg-secondary/15'
+                      }`}
+                    >
+                      {i + 1}
+                    </button>
+                  ))}
+                </div>
+                <button
+                  onClick={() => setPage(p => p + 1)}
+                  disabled={page >= totalPages - 1}
+                  className="flex items-center gap-2 px-6 py-2 rounded-xl font-semibold text-text/55 hover:bg-secondary/10 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+                >
+                  Siguiente
+                  <ChevronRight className="w-5 h-5" />
+                </button>
+              </div>
+            )}
+          </div>
         </div>
       </div>
 
-      {/* ── Units ── */}
-      <div className="border border-secondary/25 rounded-2xl p-6 mb-5">
-        <div className="text-xs text-text/50 uppercase tracking-wide font-semibold mb-4">Preguntas por unidad</div>
-        <div className="grid gap-3">
-          {pagedUnits.map(u => {
-            const disabled = (u.available || 0) === 0;
-            const current = rules[u.id] || 0;
-            return (
-              <div
-                key={u.id}
-                className={`flex items-center justify-between rounded-xl px-4 py-3 border transition-colors ${
-                  disabled ? 'border-secondary/15 opacity-50' : 'border-secondary/25'
-                }`}
-              >
-                <div>
-                  <div className="font-semibold text-sm">{u.name}</div>
-                  <div className="text-xs text-text/45 mt-0.5">{u.available} disponibles</div>
-                </div>
-                <div className="flex items-center gap-2">
-                  <button
-                    onClick={() => setCount(u.id, current - 1)}
-                    disabled={disabled || current === 0}
-                    className="w-8 h-8 rounded-full border border-secondary/30 flex items-center justify-center hover:border-secondary/60 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                    aria-label="Disminuir"
-                  >
-                    <Minus className="w-3.5 h-3.5" />
-                  </button>
-                  <input
-                    type="number"
-                    min={0}
-                    max={u.available}
-                    value={disabled ? 0 : current}
-                    onChange={e => setCount(u.id, Number(e.target.value))}
-                    disabled={disabled}
-                    className="w-14 text-center bg-white/50 dark:bg-[#24394c] border border-secondary/30 rounded-lg py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-40"
-                  />
-                  <button
-                    onClick={() => setCount(u.id, current + 1)}
-                    disabled={disabled || current >= (u.available || 0)}
-                    className="w-8 h-8 rounded-full border border-secondary/30 flex items-center justify-center hover:border-secondary/60 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                    aria-label="Aumentar"
-                  >
-                    <Plus className="w-3.5 h-3.5" />
-                  </button>
-                </div>
+      {/* ── Sticky bottom bar ── */}
+      <div className="fixed bottom-0 left-0 right-0 z-50 bg-bg/90 backdrop-blur-2xl border-t border-secondary/20 px-8 py-6">
+        <div className="max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between gap-6">
+          <div className="flex items-center gap-8">
+            <div className="flex flex-col">
+              <span className="text-xs font-bold uppercase tracking-widest text-text/40 mb-1">
+                Resumen de selección
+              </span>
+              <div className="flex items-baseline gap-2">
+                <span className="text-3xl font-black text-accent">{total()}</span>
+                <span className="text-sm font-semibold text-text/55">Total seleccionadas</span>
               </div>
-            );
-          })}
-        </div>
-        {totalPages > 1 && (
-          <div className="flex items-center justify-between mt-4 pt-4 border-t border-secondary/20">
+            </div>
+            <div className="h-12 w-px bg-secondary/20 hidden md:block" />
+            <div className="hidden md:flex items-center gap-3">
+              <Play className="w-5 h-5 text-accent" />
+              <span className="text-sm font-medium text-text/55">{time} min configurados</span>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-4 w-full md:w-auto">
             <button
-              onClick={() => setPage(p => p - 1)}
-              disabled={page === 0}
-              className="px-3 py-1.5 rounded-lg border border-secondary/30 text-sm hover:border-secondary/60 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              onClick={clearRules}
+              className="flex-1 md:flex-none px-8 py-4 rounded-3xl font-bold text-text/55 hover:bg-secondary/15 transition-all"
             >
-              ← Anterior
+              Limpiar
             </button>
-            <span className="text-xs text-text/50">
-              Página {page + 1} de {totalPages}
-            </span>
             <button
-              onClick={() => setPage(p => p + 1)}
-              disabled={page >= totalPages - 1}
-              className="px-3 py-1.5 rounded-lg border border-secondary/30 text-sm hover:border-secondary/60 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              onClick={() => onStart({ unitCounts: rules, minutes: time, difficulty: difficulty === 'ALL' ? undefined : difficulty })}
+              disabled={totalAvailable === 0 || total() === 0}
+              className="flex-[2] md:flex-none btn btn-primary px-12 py-4 rounded-3xl font-extrabold text-xl shadow-lg shadow-primary/20 flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              Siguiente →
+              Empezar examen
             </button>
           </div>
-        )}
-      </div>
-
-      {/* ── Footer ── */}
-      <div className="flex items-center justify-between">
-        <div className="text-sm text-text/60">
-          Total seleccionadas: <span className="text-text font-bold text-base">{total()}</span>
         </div>
-        <button
-          onClick={() => onStart({ unitCounts: rules, minutes: time, difficulty: difficulty === 'ALL' ? undefined : difficulty })}
-          disabled={totalAvailable === 0 || total() === 0}
-          className="btn btn-primary rounded-full px-8 py-3 text-base shadow-lg shadow-primary/20 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          <Play className="w-5 h-5" />
-          Empezar examen
-        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/ExamBuilder.tsx
+++ b/frontend/src/components/ExamBuilder.tsx
@@ -154,7 +154,7 @@ export default function ExamBuilder({ subjectId, onStart, onStartRandom, onUnaut
 
         {/* ── Right column: units ── */}
         <div className="lg:col-span-8">
-          <div className="border border-secondary/25 rounded-3xl p-8 mb-10">
+          <div className="border border-secondary/25 rounded-3xl p-8 mb-20">
             <div className="flex items-center gap-3 mb-8">
               <ClipboardList className="w-5 h-5 text-primary" />
               <h2 className="text-xl font-bold">Preguntas por unidad</h2>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -116,15 +116,27 @@ export default function NavbarComponent({ isAuthed, isAdmin, user, onLogout, onP
 
         {/* Right: theme toggle + user menu / mobile burger */}
         <div className="flex items-center gap-2">
-          <button
-            className={`theme-toggle ${isDark ? 'dark' : 'light'}`}
-            onClick={toggleTheme}
-            aria-label="cambiar tema"
-          >
-            <span className="theme-thumb" />
-            <span className="theme-icon" aria-hidden>☾</span>
-            <span className="theme-icon" aria-hidden>☀︎</span>
-          </button>
+          {/* Theme toggle pill */}
+          <div className="flex items-center bg-secondary/15 rounded-full p-1 gap-0.5">
+            <button
+              onClick={toggleTheme}
+              aria-label="Tema oscuro"
+              className={`p-1.5 rounded-full transition-all ${isDark ? 'bg-bg shadow-sm text-primary' : 'text-text/40 hover:text-text/60'}`}
+            >
+              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+              </svg>
+            </button>
+            <button
+              onClick={toggleTheme}
+              aria-label="Tema claro"
+              className={`p-1.5 rounded-full transition-all ${!isDark ? 'bg-bg shadow-sm text-yellow-500' : 'text-text/40 hover:text-text/60'}`}
+            >
+              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clipRule="evenodd" />
+              </svg>
+            </button>
+          </div>
 
           {/* Desktop user menu */}
           {isAuthed && user && (

--- a/frontend/src/components/UserMenuDropdown.tsx
+++ b/frontend/src/components/UserMenuDropdown.tsx
@@ -34,12 +34,12 @@ export function UserMenuDropdown({ user, isAdmin, onProfile, onSettings, onLogou
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen(prev => !prev)}
-        className="flex items-center justify-center w-8 h-8 rounded-full bg-primary/15 text-primary text-sm font-semibold hover:bg-primary/25 transition-colors"
+        className="flex items-center justify-center w-10 h-10 rounded-full bg-primary/15 text-primary text-sm font-semibold hover:bg-primary/25 transition-colors"
         aria-label="User menu"
         aria-expanded={open}
       >
         {user.avatarUrl ? (
-          <img src={user.avatarUrl} alt={user.initials} className="w-8 h-8 rounded-full object-cover" />
+          <img src={user.avatarUrl} alt={user.initials} className="w-10 h-10 rounded-full object-cover" />
         ) : (
           user.initials
         )}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -6,6 +6,9 @@ export default {
   content: ["./src/**/*.{js,ts,jsx,tsx,html}", "./node_modules/flowbite-react/**/*.js"],
   theme: {
     extend: {
+      maxWidth: {
+        '8xl': '88rem',
+      },
       colors: {
         bg: "rgb(var(--bg) / <alpha-value>)",
         text: "rgb(var(--text) / <alpha-value>)",


### PR DESCRIPTION
## Summary

- Layout migrado a grid 12 columnas (4 col config / 8 col unidades), de `max-w-3xl` columna única
- Inputs al estilo underline (`border-b-2`) en lugar de caja completa, con foco en `border-primary`
- Footer inline reemplazado por **sticky bottom bar** (`fixed bottom-0`, backdrop-blur) con resumen de selección, tiempo y botones de acción
- Tip card de estudio en la columna izquierda
- Paginación con chips numéricos, activo destacado en `accent`
- Nueva acción **Limpiar** que resetea todas las reglas
- Toda la lógica de estado (`units`, `rules`, `time`, `difficulty`, `randomCount`, `page`) sin cambios

## Test plan

- [ ] Levantar frontend (`npm run dev`) y navegar a un subject → Configurar examen
- [ ] Verificar layout en pantalla ancha (≥1024px): dos columnas 4/8
- [ ] Verificar layout en móvil: columna única apilada
- [ ] Sticky bar visible al hacer scroll en lista larga de unidades
- [ ] Selector de dificultad actualiza disponibilidad de preguntas
- [ ] Botón **Examen aleatorio** arranca con los parámetros correctos
- [ ] Botón **Limpiar** resetea todos los contadores
- [ ] Botón **Empezar examen** deshabilitado si total = 0
- [ ] Paginación funciona (página activa destacada en accent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)