### PR TITLE
✨ feat(subjects): bulk import of subjects in management page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ tsconfig.tsbuildinfo
 # Claude Code
 .claude/
 .gemini/
+
+products/

--- a/backend/src/main/java/com/akdemya/adapter/inbound/web/ManageSubjectController.java
+++ b/backend/src/main/java/com/akdemya/adapter/inbound/web/ManageSubjectController.java
@@ -3,6 +3,7 @@ package com.akdemya.adapter.inbound.web;
 import com.akdemya.application.service.ContentManagement;
 import com.akdemya.domain.model.AppUser;
 import com.akdemya.domain.model.Subject;
+import com.akdemya.domain.model.Syllabus;
 import com.akdemya.domain.model.Visibility;
 import com.akdemya.domain.port.out.UserRepository;
 import org.springframework.http.HttpStatus;
@@ -12,8 +13,12 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 @RestController
@@ -156,6 +161,154 @@ public class ManageSubjectController {
     return subject.getVisibility() == Visibility.PRIVATE
         && caller.getId().equals(subject.getOwnerId());
   }
+
+  private static final long MAX_UPLOAD_SIZE = 10L * 1024 * 1024;
+  private static final int MAX_IMPORT_ROWS = 500;
+
+  @PostMapping(value = "/import", consumes = "multipart/form-data")
+  public ResponseEntity<Object> importSubjects(
+      @RequestParam("file") MultipartFile file,
+      @RequestParam(defaultValue = "csv") String format,
+      @RequestParam UUID syllabusId,
+      @AuthenticationPrincipal User principal) throws Exception {
+    if (principal == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    AppUser caller = resolveUser(principal);
+    boolean isAdmin = isAdmin(principal);
+
+    if (file == null || file.isEmpty()) {
+      return ResponseEntity.badRequest().body(Map.of("error", "file_required"));
+    }
+    if (file.getSize() > MAX_UPLOAD_SIZE) {
+      return ResponseEntity.badRequest().body(Map.of("error", "file_too_large"));
+    }
+    if (syllabusId == null) {
+      return ResponseEntity.badRequest().body(Map.of("error", "syllabusId_required"));
+    }
+
+    // Ownership check: non-admins can only import into syllabuses they own
+    if (!isAdmin) {
+      Syllabus syllabus = contentService.getSyllabusById(syllabusId).orElse(null);
+      if (syllabus == null || !caller.getId().equals(syllabus.getOwnerId())) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+            .body(Map.of("error", "not_authorized"));
+      }
+    }
+
+    // Load existing subject names once (no N+1) for duplicate detection
+    Visibility importVisibility = isAdmin ? Visibility.GLOBAL : Visibility.PRIVATE;
+    UUID importOwner = isAdmin ? null : caller.getId();
+    List<Subject> existing = contentService.getSubjectsByScope(caller.getId(), isAdmin, importVisibility);
+    Set<String> existingNames = new java.util.HashSet<>();
+    for (Subject s : existing) {
+      if (syllabusId.equals(s.getSyllabusId())) {
+        existingNames.add(s.getName().trim().toLowerCase());
+      }
+    }
+
+    int created = 0;
+    List<Map<String, Object>> errors = new ArrayList<>();
+
+    if (format.equalsIgnoreCase("csv")) {
+      String content = new String(file.getBytes());
+      List<String[]> rows = parseCsv(content);
+      // rows.get(0) is header; data rows start at index 1
+      int dataRowCount = rows.size() - 1;
+      if (dataRowCount > MAX_IMPORT_ROWS) {
+        return ResponseEntity.badRequest().body(Map.of("error", "row_limit_exceeded"));
+      }
+      for (int i = 1; i < rows.size(); i++) {
+        int rowNum = i; // 1-based data row number
+        String[] row = rows.get(i);
+        String name = row.length > 0 ? row[0].trim() : "";
+        String description = row.length > 1 ? row[1].trim() : null;
+        if (description != null && description.isBlank()) description = null;
+
+        if (name.isEmpty()) {
+          errors.add(Map.of("row", rowNum, "message", "name_required"));
+          continue;
+        }
+        if (existingNames.contains(name.toLowerCase())) {
+          errors.add(Map.of("row", rowNum, "message", "duplicate_name"));
+          continue;
+        }
+        try {
+          Subject subject = isAdmin
+              ? Subject.createGlobal(name, description, syllabusId)
+              : Subject.createPrivate(name, description, importOwner, syllabusId);
+          contentService.createSubject(subject);
+          existingNames.add(name.toLowerCase());
+          created++;
+        } catch (Exception e) {
+          errors.add(Map.of("row", rowNum, "message", e.getMessage() != null ? e.getMessage() : "import_error"));
+        }
+      }
+    } else {
+      com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+      ImportSubjectRow[] rows = mapper.readValue(file.getBytes(), ImportSubjectRow[].class);
+      if (rows.length > MAX_IMPORT_ROWS) {
+        return ResponseEntity.badRequest().body(Map.of("error", "row_limit_exceeded"));
+      }
+      for (int i = 0; i < rows.length; i++) {
+        int rowNum = i + 1;
+        ImportSubjectRow row = rows[i];
+        String name = row.name() != null ? row.name().trim() : "";
+        String description = row.description() != null && !row.description().isBlank() ? row.description().trim() : null;
+
+        if (name.isEmpty()) {
+          errors.add(Map.of("row", rowNum, "message", "name_required"));
+          continue;
+        }
+        if (existingNames.contains(name.toLowerCase())) {
+          errors.add(Map.of("row", rowNum, "message", "duplicate_name"));
+          continue;
+        }
+        try {
+          Subject subject = isAdmin
+              ? Subject.createGlobal(name, description, syllabusId)
+              : Subject.createPrivate(name, description, importOwner, syllabusId);
+          contentService.createSubject(subject);
+          existingNames.add(name.toLowerCase());
+          created++;
+        } catch (Exception e) {
+          errors.add(Map.of("row", rowNum, "message", e.getMessage() != null ? e.getMessage() : "import_error"));
+        }
+      }
+    }
+
+    return ResponseEntity.ok(Map.of("created", created, "errors", errors));
+  }
+
+  private List<String[]> parseCsv(String content) {
+    List<String[]> rows = new ArrayList<>();
+    StringBuilder current = new StringBuilder();
+    List<String> row = new ArrayList<>();
+    boolean inQuotes = false;
+    for (int i = 0; i < content.length(); i++) {
+      char c = content.charAt(i);
+      if (c == '"') {
+        if (inQuotes && i + 1 < content.length() && content.charAt(i + 1) == '"') {
+          current.append('"'); i++;
+        } else { inQuotes = !inQuotes; }
+      } else if (c == ',' && !inQuotes) {
+        row.add(current.toString()); current.setLength(0);
+      } else if ((c == '\n' || c == '\r') && !inQuotes) {
+        if (current.length() > 0 || !row.isEmpty()) {
+          row.add(current.toString());
+          rows.add(row.toArray(new String[0]));
+          row = new ArrayList<>();
+          current.setLength(0);
+        }
+      } else { current.append(c); }
+    }
+    if (current.length() > 0 || !row.isEmpty()) {
+      row.add(current.toString()); rows.add(row.toArray(new String[0]));
+    }
+    return rows;
+  }
+
+  record ImportSubjectRow(String name, String description) {}
 
   public record SubjectRequest(String name, String description, String visibility, UUID syllabusId) {}
 

--- a/backend/src/main/java/com/akdemya/adapter/inbound/web/ManageUnitController.java
+++ b/backend/src/main/java/com/akdemya/adapter/inbound/web/ManageUnitController.java
@@ -2,6 +2,7 @@ package com.akdemya.adapter.inbound.web;
 
 import com.akdemya.application.service.ContentManagement;
 import com.akdemya.domain.model.AppUser;
+import com.akdemya.domain.model.Subject;
 import com.akdemya.domain.model.Unit;
 import com.akdemya.domain.model.Visibility;
 import com.akdemya.domain.port.out.UserRepository;
@@ -12,8 +13,12 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 @RestController
@@ -177,6 +182,152 @@ public class ManageUnitController {
     return unit.getVisibility() == Visibility.PRIVATE
         && caller.getId().equals(unit.getOwnerId());
   }
+
+  private static final long MAX_UPLOAD_SIZE = 10L * 1024 * 1024;
+  private static final int MAX_IMPORT_ROWS = 500;
+
+  @PostMapping(value = "/import", consumes = "multipart/form-data")
+  public ResponseEntity<Object> importUnits(
+      @RequestParam("file") MultipartFile file,
+      @RequestParam(defaultValue = "csv") String format,
+      @RequestParam UUID subjectId,
+      @AuthenticationPrincipal User principal) throws Exception {
+    if (principal == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    AppUser caller = resolveUser(principal);
+    boolean isAdmin = isAdmin(principal);
+
+    if (file == null || file.isEmpty()) {
+      return ResponseEntity.badRequest().body(Map.of("error", "file_required"));
+    }
+    if (file.getSize() > MAX_UPLOAD_SIZE) {
+      return ResponseEntity.badRequest().body(Map.of("error", "file_too_large"));
+    }
+    if (subjectId == null) {
+      return ResponseEntity.badRequest().body(Map.of("error", "subjectId_required"));
+    }
+
+    // Ownership check: non-admins can only import into subjects they own
+    if (!isAdmin) {
+      Subject subject = contentService.getSubjectById(subjectId).orElse(null);
+      if (subject == null || !caller.getId().equals(subject.getOwnerId())) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+            .body(Map.of("error", "not_authorized"));
+      }
+    }
+
+    // Load existing unit names once (no N+1) for duplicate detection
+    List<Unit> existing = contentService.getUnitsBySubject(subjectId);
+    Set<String> existingNames = new java.util.HashSet<>();
+    for (Unit u : existing) {
+      existingNames.add(u.getName().trim().toLowerCase());
+    }
+
+    int created = 0;
+    List<Map<String, Object>> errors = new ArrayList<>();
+
+    if (format.equalsIgnoreCase("csv")) {
+      String content = new String(file.getBytes());
+      List<String[]> rows = parseCsv(content);
+      // rows.get(0) is header; data rows start at index 1
+      int dataRowCount = rows.size() - 1;
+      if (dataRowCount > MAX_IMPORT_ROWS) {
+        return ResponseEntity.badRequest().body(Map.of("error", "row_limit_exceeded"));
+      }
+      for (int i = 1; i < rows.size(); i++) {
+        int rowNum = i; // 1-based data row number
+        String[] row = rows.get(i);
+        String name = row.length > 0 ? row[0].trim() : "";
+        String description = row.length > 1 ? row[1].trim() : null;
+        if (description != null && description.isBlank()) description = null;
+
+        if (name.isEmpty()) {
+          errors.add(Map.of("row", rowNum, "message", "name_required"));
+          continue;
+        }
+        if (existingNames.contains(name.toLowerCase())) {
+          errors.add(Map.of("row", rowNum, "message", "duplicate_name"));
+          continue;
+        }
+        try {
+          int orderIndex = created + existing.size() + 1;
+          Unit unit = isAdmin
+              ? Unit.createGlobal(subjectId, name, description, orderIndex)
+              : Unit.createPrivate(subjectId, name, description, orderIndex, caller.getId());
+          contentService.createUnit(unit);
+          existingNames.add(name.toLowerCase());
+          created++;
+        } catch (Exception e) {
+          errors.add(Map.of("row", rowNum, "message", e.getMessage() != null ? e.getMessage() : "import_error"));
+        }
+      }
+    } else {
+      com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+      ImportUnitRow[] rows = mapper.readValue(file.getBytes(), ImportUnitRow[].class);
+      if (rows.length > MAX_IMPORT_ROWS) {
+        return ResponseEntity.badRequest().body(Map.of("error", "row_limit_exceeded"));
+      }
+      for (int i = 0; i < rows.length; i++) {
+        int rowNum = i + 1;
+        ImportUnitRow row = rows[i];
+        String name = row.name() != null ? row.name().trim() : "";
+        String description = row.description() != null && !row.description().isBlank() ? row.description().trim() : null;
+
+        if (name.isEmpty()) {
+          errors.add(Map.of("row", rowNum, "message", "name_required"));
+          continue;
+        }
+        if (existingNames.contains(name.toLowerCase())) {
+          errors.add(Map.of("row", rowNum, "message", "duplicate_name"));
+          continue;
+        }
+        try {
+          int orderIndex = created + existing.size() + 1;
+          Unit unit = isAdmin
+              ? Unit.createGlobal(subjectId, name, description, orderIndex)
+              : Unit.createPrivate(subjectId, name, description, orderIndex, caller.getId());
+          contentService.createUnit(unit);
+          existingNames.add(name.toLowerCase());
+          created++;
+        } catch (Exception e) {
+          errors.add(Map.of("row", rowNum, "message", e.getMessage() != null ? e.getMessage() : "import_error"));
+        }
+      }
+    }
+
+    return ResponseEntity.ok(Map.of("created", created, "errors", errors));
+  }
+
+  private List<String[]> parseCsv(String content) {
+    List<String[]> rows = new ArrayList<>();
+    StringBuilder current = new StringBuilder();
+    List<String> row = new ArrayList<>();
+    boolean inQuotes = false;
+    for (int i = 0; i < content.length(); i++) {
+      char c = content.charAt(i);
+      if (c == '"') {
+        if (inQuotes && i + 1 < content.length() && content.charAt(i + 1) == '"') {
+          current.append('"'); i++;
+        } else { inQuotes = !inQuotes; }
+      } else if (c == ',' && !inQuotes) {
+        row.add(current.toString()); current.setLength(0);
+      } else if ((c == '\n' || c == '\r') && !inQuotes) {
+        if (current.length() > 0 || !row.isEmpty()) {
+          row.add(current.toString());
+          rows.add(row.toArray(new String[0]));
+          row = new ArrayList<>();
+          current.setLength(0);
+        }
+      } else { current.append(c); }
+    }
+    if (current.length() > 0 || !row.isEmpty()) {
+      row.add(current.toString()); rows.add(row.toArray(new String[0]));
+    }
+    return rows;
+  }
+
+  record ImportUnitRow(String name, String description) {}
 
   public record UnitRequest(UUID subjectId, String name, String description,
                               int orderIndex, String visibility) {}

--- a/backend/src/main/java/com/akdemya/application/service/ExamManager.java
+++ b/backend/src/main/java/com/akdemya/application/service/ExamManager.java
@@ -80,7 +80,9 @@ public class ExamManager implements ExamUseCase {
       int count = entry.getValue() != null ? entry.getValue() : 0;
       List<Question> qs = questionRepo.findVisibleByUnitIdAndUserId(unitId, command.userId());
       if (selectedDifficulty != null) {
-        qs = qs.stream().filter(q -> q.getDifficulty() == selectedDifficulty).toList();
+        qs = new ArrayList<>(qs.stream().filter(q -> q.getDifficulty() == selectedDifficulty).toList());
+      } else {
+        qs = new ArrayList<>(qs);
       }
       Collections.shuffle(qs, rnd);
       if (count > 0 && count < qs.size()) {
@@ -100,9 +102,9 @@ public class ExamManager implements ExamUseCase {
     attemptAnsRepo.saveAll(answerPlaceholders);
 
     List<QuestionData> questionDataList = pool.stream().map(q -> {
-      List<AnswerData> answers = answerRepo.findByQuestionId(q.getId()).stream()
+      List<AnswerData> answers = new ArrayList<>(answerRepo.findByQuestionId(q.getId()).stream()
           .map(a -> new AnswerData(a.getId(), a.getText()))
-          .toList();
+          .toList());
       Collections.shuffle(answers, rnd);
       return new QuestionData(q.getId(), q.getText(), answers);
     }).toList();
@@ -146,9 +148,9 @@ public class ExamManager implements ExamUseCase {
     attemptAnsRepo.saveAll(placeholders);
 
     List<QuestionData> questionDataList = pool.stream().map(q -> {
-      List<AnswerData> answers = answerRepo.findByQuestionId(q.getId()).stream()
+      List<AnswerData> answers = new ArrayList<>(answerRepo.findByQuestionId(q.getId()).stream()
           .map(a -> new AnswerData(a.getId(), a.getText()))
-          .toList();
+          .toList());
       Collections.shuffle(answers, rnd);
       return new QuestionData(q.getId(), q.getText(), answers);
     }).toList();
@@ -205,9 +207,9 @@ public class ExamManager implements ExamUseCase {
     attemptAnsRepo.saveAll(placeholders);
 
     List<QuestionData> questionDataList = pool.stream().map(q -> {
-      List<AnswerData> answers = answerRepo.findByQuestionId(q.getId()).stream()
+      List<AnswerData> answers = new ArrayList<>(answerRepo.findByQuestionId(q.getId()).stream()
           .map(a -> new AnswerData(a.getId(), a.getText()))
-          .toList();
+          .toList());
       Collections.shuffle(answers, rnd);
       return new QuestionData(q.getId(), q.getText(), answers);
     }).toList();

--- a/backend/src/test/java/com/akdemya/adapter/inbound/web/ManageSubjectControllerTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/inbound/web/ManageSubjectControllerTest.java
@@ -3,6 +3,7 @@ package com.akdemya.adapter.inbound.web;
 import com.akdemya.application.service.ContentManagement;
 import com.akdemya.domain.model.AppUser;
 import com.akdemya.domain.model.Subject;
+import com.akdemya.domain.model.Syllabus;
 import com.akdemya.domain.model.Visibility;
 import com.akdemya.domain.port.out.UserRepository;
 import org.junit.jupiter.api.Test;
@@ -11,8 +12,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -307,5 +310,149 @@ class ManageSubjectControllerTest {
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertTrue(response.getBody().get(0).isEditable());
+  }
+
+  // Test 22: importSubjectsValidCsvCreatesSubjects — admin, 3-row CSV → 200, created=3, errors empty
+  @Test
+  void importSubjectsValidCsvCreatesSubjects() throws Exception {
+    UUID syllabusId = UUID.randomUUID();
+    User principal = adminPrincipal("admin@example.com");
+    String csv = "name,description\nTema 1,Desc 1\nTema 2,Desc 2\nTema 3,Desc 3\n";
+    var file = mock(MultipartFile.class);
+    when(file.isEmpty()).thenReturn(false);
+    when(file.getSize()).thenReturn((long) csv.length());
+    when(file.getBytes()).thenReturn(csv.getBytes());
+
+    when(contentService.getSubjectsByScope(any(), eq(true), eq(Visibility.GLOBAL))).thenReturn(List.of());
+    Subject created = Subject.createGlobal("Tema 1", "Desc 1", syllabusId);
+    when(contentService.createSubject(any())).thenReturn(created);
+
+    ResponseEntity<Object> response = controller.importSubjects(file, "csv", syllabusId, principal);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> body = (Map<String, Object>) response.getBody();
+    assertEquals(3, body.get("created"));
+    assertTrue(((List<?>) body.get("errors")).isEmpty());
+    verify(contentService, times(3)).createSubject(any());
+  }
+
+  // Test 23: importSubjectsNonAdminEmptyFileReturnsBadRequest — non-admin, empty file → 400
+  // Per design: non-admins import PRIVATE subjects (no blanket 403). Guard fires on empty file.
+  @Test
+  void importSubjectsNonAdminEmptyFileReturnsBadRequest() throws Exception {
+    UUID syllabusId = UUID.randomUUID();
+    User principal = userPrincipal("user@example.com");
+    var file = mock(MultipartFile.class);
+    when(file.isEmpty()).thenReturn(true);
+
+    ResponseEntity<Object> response = controller.importSubjects(file, "csv", syllabusId, principal);
+
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    verify(contentService, never()).createSubject(any());
+  }
+
+  // Test 24: importSubjectsExceedingRowLimitReturnsBadRequest — admin, 501 rows → 400 row_limit_exceeded
+  @Test
+  void importSubjectsExceedingRowLimitReturnsBadRequest() throws Exception {
+    UUID syllabusId = UUID.randomUUID();
+    User principal = adminPrincipal("admin@example.com");
+    StringBuilder sb = new StringBuilder("name,description\n");
+    for (int i = 1; i <= 501; i++) {
+      sb.append("Tema ").append(i).append(",Desc ").append(i).append("\n");
+    }
+    String csv = sb.toString();
+    var file = mock(MultipartFile.class);
+    when(file.isEmpty()).thenReturn(false);
+    when(file.getSize()).thenReturn((long) csv.length());
+    when(file.getBytes()).thenReturn(csv.getBytes());
+    when(contentService.getSubjectsByScope(any(), eq(true), eq(Visibility.GLOBAL))).thenReturn(List.of());
+
+    ResponseEntity<Object> response = controller.importSubjects(file, "csv", syllabusId, principal);
+
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> body = (Map<String, Object>) response.getBody();
+    assertEquals("row_limit_exceeded", body.get("error"));
+    verify(contentService, never()).createSubject(any());
+  }
+
+  // Test 25: importSubjectsPartialErrorReportsRowErrors — 3-row CSV where row 2 has blank name
+  @Test
+  void importSubjectsPartialErrorReportsRowErrors() throws Exception {
+    UUID syllabusId = UUID.randomUUID();
+    User principal = adminPrincipal("admin@example.com");
+    String csv = "name,description\nTema 1,Desc 1\n,Desc 2\nTema 3,Desc 3\n";
+    var file = mock(MultipartFile.class);
+    when(file.isEmpty()).thenReturn(false);
+    when(file.getSize()).thenReturn((long) csv.length());
+    when(file.getBytes()).thenReturn(csv.getBytes());
+
+    when(contentService.getSubjectsByScope(any(), eq(true), eq(Visibility.GLOBAL))).thenReturn(List.of());
+    Subject created = Subject.createGlobal("Tema 1", "Desc 1", syllabusId);
+    when(contentService.createSubject(any())).thenReturn(created);
+
+    ResponseEntity<Object> response = controller.importSubjects(file, "csv", syllabusId, principal);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> body = (Map<String, Object>) response.getBody();
+    assertEquals(2, body.get("created"));
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> errors = (List<Map<String, Object>>) body.get("errors");
+    assertEquals(1, errors.size());
+    assertEquals(2, errors.get(0).get("row"));
+    verify(contentService, times(2)).createSubject(any());
+  }
+
+  // Test 26: importSubjectsDuplicateNameReportsRowError — existing "Tema A" → duplicate row error
+  @Test
+  void importSubjectsDuplicateNameReportsRowError() throws Exception {
+    UUID syllabusId = UUID.randomUUID();
+    User principal = adminPrincipal("admin@example.com");
+    String csv = "name,description\nTema A,Desc\n";
+    var file = mock(MultipartFile.class);
+    when(file.isEmpty()).thenReturn(false);
+    when(file.getSize()).thenReturn((long) csv.length());
+    when(file.getBytes()).thenReturn(csv.getBytes());
+
+    Subject existing = Subject.createGlobal("Tema A", "Existing desc", syllabusId);
+    when(contentService.getSubjectsByScope(any(), eq(true), eq(Visibility.GLOBAL))).thenReturn(List.of(existing));
+
+    ResponseEntity<Object> response = controller.importSubjects(file, "csv", syllabusId, principal);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> body = (Map<String, Object>) response.getBody();
+    assertEquals(0, body.get("created"));
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> errors = (List<Map<String, Object>>) body.get("errors");
+    assertEquals(1, errors.size());
+    assertEquals(1, errors.get(0).get("row"));
+    verify(contentService, never()).createSubject(any());
+  }
+
+  // Test 27: importSubjects_nonOwnerSyllabus_returnsForbidden
+  // Non-admin user tries to import into a syllabus that belongs to another user → 403
+  @Test
+  void importSubjects_nonOwnerSyllabus_returnsForbidden() throws Exception {
+    UUID syllabusId = UUID.randomUUID();
+    UUID otherOwnerId = UUID.randomUUID(); // different from userId
+    User principal = userPrincipal("user@example.com");
+
+    var file = mock(MultipartFile.class);
+    when(file.isEmpty()).thenReturn(false);
+    when(file.getSize()).thenReturn(30L);
+
+    Syllabus otherUserSyllabus = Syllabus.createPrivate("Other Syllabus", "desc", otherOwnerId);
+    when(contentService.getSyllabusById(syllabusId)).thenReturn(Optional.of(otherUserSyllabus));
+
+    ResponseEntity<Object> response = controller.importSubjects(file, "csv", syllabusId, principal);
+
+    assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> body = (Map<String, Object>) response.getBody();
+    assertEquals("not_authorized", body.get("error"));
+    verify(contentService, never()).createSubject(any());
   }
 }

--- a/backend/src/test/java/com/akdemya/adapter/inbound/web/ManageUnitControllerTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/inbound/web/ManageUnitControllerTest.java
@@ -12,8 +12,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -338,5 +340,144 @@ class ManageUnitControllerTest {
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     verify(contentService).getUnitsByScope(eq(subjectId), any(), anyBoolean(), eq(Visibility.PRIVATE));
+  }
+
+  // Test: importUnits_validCsv_returnsCreatedCount — admin, 3-row CSV → 200, created=3, errors empty
+  @Test
+  void importUnits_validCsv_returnsCreatedCount() throws Exception {
+    UUID subjectId = UUID.randomUUID();
+    User principal = adminPrincipal("admin@example.com");
+    String csv = "name,description\nUnidad 1,Desc 1\nUnidad 2,Desc 2\nUnidad 3,Desc 3\n";
+    var file = mock(MultipartFile.class);
+    when(file.isEmpty()).thenReturn(false);
+    when(file.getSize()).thenReturn((long) csv.length());
+    when(file.getBytes()).thenReturn(csv.getBytes());
+
+    when(contentService.getUnitsBySubject(subjectId)).thenReturn(List.of());
+    Unit created = Unit.createGlobal(subjectId, "Unidad 1", "Desc 1", 1);
+    when(contentService.createUnit(any())).thenReturn(created);
+
+    ResponseEntity<Object> response = controller.importUnits(file, "csv", subjectId, principal);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> body = (Map<String, Object>) response.getBody();
+    assertEquals(3, body.get("created"));
+    assertTrue(((List<?>) body.get("errors")).isEmpty());
+    verify(contentService, times(3)).createUnit(any());
+  }
+
+  // Test: importUnits_emptyFile_returnsBadRequest — empty file → 400
+  @Test
+  void importUnits_emptyFile_returnsBadRequest() throws Exception {
+    UUID subjectId = UUID.randomUUID();
+    User principal = userPrincipal("user@example.com");
+    var file = mock(MultipartFile.class);
+    when(file.isEmpty()).thenReturn(true);
+
+    ResponseEntity<Object> response = controller.importUnits(file, "csv", subjectId, principal);
+
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    verify(contentService, never()).createUnit(any());
+  }
+
+  // Test: importUnits_rowLimitExceeded_returnsBadRequest — 501 rows → 400 row_limit_exceeded
+  @Test
+  void importUnits_rowLimitExceeded_returnsBadRequest() throws Exception {
+    UUID subjectId = UUID.randomUUID();
+    User principal = adminPrincipal("admin@example.com");
+    StringBuilder sb = new StringBuilder("name,description\n");
+    for (int i = 1; i <= 501; i++) {
+      sb.append("Unidad ").append(i).append(",Desc ").append(i).append("\n");
+    }
+    String csv = sb.toString();
+    var file = mock(MultipartFile.class);
+    when(file.isEmpty()).thenReturn(false);
+    when(file.getSize()).thenReturn((long) csv.length());
+    when(file.getBytes()).thenReturn(csv.getBytes());
+    when(contentService.getUnitsBySubject(subjectId)).thenReturn(List.of());
+
+    ResponseEntity<Object> response = controller.importUnits(file, "csv", subjectId, principal);
+
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> body = (Map<String, Object>) response.getBody();
+    assertEquals("row_limit_exceeded", body.get("error"));
+    verify(contentService, never()).createUnit(any());
+  }
+
+  // Test: importUnits_blankNameRow_returnsRowError — one blank name → {created:0, errors:[{row:1,...}]}
+  @Test
+  void importUnits_blankNameRow_returnsRowError() throws Exception {
+    UUID subjectId = UUID.randomUUID();
+    User principal = adminPrincipal("admin@example.com");
+    String csv = "name,description\n,Desc 1\n";
+    var file = mock(MultipartFile.class);
+    when(file.isEmpty()).thenReturn(false);
+    when(file.getSize()).thenReturn((long) csv.length());
+    when(file.getBytes()).thenReturn(csv.getBytes());
+    when(contentService.getUnitsBySubject(subjectId)).thenReturn(List.of());
+
+    ResponseEntity<Object> response = controller.importUnits(file, "csv", subjectId, principal);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> body = (Map<String, Object>) response.getBody();
+    assertEquals(0, body.get("created"));
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> errors = (List<Map<String, Object>>) body.get("errors");
+    assertEquals(1, errors.size());
+    assertEquals(1, errors.get(0).get("row"));
+    verify(contentService, never()).createUnit(any());
+  }
+
+  // Test: importUnits_duplicateNameRow_returnsRowError — duplicate unit name → row error
+  @Test
+  void importUnits_duplicateNameRow_returnsRowError() throws Exception {
+    UUID subjectId = UUID.randomUUID();
+    User principal = adminPrincipal("admin@example.com");
+    String csv = "name,description\nUnidad A,Desc\n";
+    var file = mock(MultipartFile.class);
+    when(file.isEmpty()).thenReturn(false);
+    when(file.getSize()).thenReturn((long) csv.length());
+    when(file.getBytes()).thenReturn(csv.getBytes());
+
+    Unit existing = Unit.createGlobal(subjectId, "Unidad A", "Existing desc", 1);
+    when(contentService.getUnitsBySubject(subjectId)).thenReturn(List.of(existing));
+
+    ResponseEntity<Object> response = controller.importUnits(file, "csv", subjectId, principal);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> body = (Map<String, Object>) response.getBody();
+    assertEquals(0, body.get("created"));
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> errors = (List<Map<String, Object>>) body.get("errors");
+    assertEquals(1, errors.size());
+    assertEquals(1, errors.get(0).get("row"));
+    verify(contentService, never()).createUnit(any());
+  }
+
+  // Test: importUnits_nonOwnerSubject_returnsForbidden — non-admin + foreign subject → 403
+  @Test
+  void importUnits_nonOwnerSubject_returnsForbidden() throws Exception {
+    UUID subjectId = UUID.randomUUID();
+    UUID otherOwnerId = UUID.randomUUID(); // different from userId
+    User principal = userPrincipal("user@example.com");
+
+    var file = mock(MultipartFile.class);
+    when(file.isEmpty()).thenReturn(false);
+    when(file.getSize()).thenReturn(30L);
+
+    Subject otherUserSubject = Subject.createPrivate("Other Subject", "desc", otherOwnerId);
+    when(contentService.getSubjectById(subjectId)).thenReturn(Optional.of(otherUserSubject));
+
+    ResponseEntity<Object> response = controller.importUnits(file, "csv", subjectId, principal);
+
+    assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> body = (Map<String, Object>) response.getBody();
+    assertEquals("not_authorized", body.get("error"));
+    verify(contentService, never()).createUnit(any());
   }
 }

--- a/frontend/src/components/ExamRunner.tsx
+++ b/frontend/src/components/ExamRunner.tsx
@@ -114,7 +114,7 @@ export default function ExamRunner({ questions, totalTimeSeconds, onFinish, init
       </div>
 
       {/* ── Question ── */}
-      <div className="border border-secondary/25 rounded-2xl p-6 mb-5">
+      <div className="bg-card border border-secondary/25 rounded-2xl p-6 mb-5">
         <h2 className="text-xl font-bold leading-snug mb-6">{q.text}</h2>
         <div className="grid gap-3">
           {q.answers.map(a => {

--- a/frontend/src/components/Management.tsx
+++ b/frontend/src/components/Management.tsx
@@ -184,6 +184,13 @@ export default function Management({ isAdmin, onSubjectsChanged }: { isAdmin: bo
   const [subjectImportMessage, setSubjectImportMessage] = useState('');
   const [subjectImportResult, setSubjectImportResult] = useState<{ created: number; errors: { row: number; message: string }[] } | null>(null);
 
+  const [unitImportOpen, setUnitImportOpen] = useState(false);
+  const [unitImportFile, setUnitImportFile] = useState<File | null>(null);
+  const [unitImportFormat, setUnitImportFormat] = useState<'csv' | 'json'>('csv');
+  const [unitImportLoading, setUnitImportLoading] = useState(false);
+  const [unitImportMessage, setUnitImportMessage] = useState('');
+  const [unitImportResult, setUnitImportResult] = useState<{ created: number; errors: { row: number; message: string }[] } | null>(null);
+
   const [filterSyllabusId, setFilterSyllabusId] = useState('');
   const [filterUnitSyllabusId, setFilterUnitSyllabusId] = useState('');
   const [questionSyllabusId, setQuestionSyllabusId] = useState('');
@@ -338,6 +345,28 @@ export default function Management({ isAdmin, onSubjectsChanged }: { isAdmin: bo
       const msg = e instanceof Error ? e.message : 'No se pudo importar';
       setSubjectImportMessage(msg);
     } finally { setSubjectImportLoading(false); }
+  }
+
+  async function handleUnitImport() {
+    if (!unitImportFile || unitImportLoading) return;
+    if (!unitForm.subjectId) { setUnitImportMessage('Selecciona un tema'); return; }
+    setUnitImportLoading(true); setUnitImportMessage('');
+    try {
+      const formData = new FormData();
+      formData.append('file', unitImportFile);
+      const res = await fetch(
+        `${apiBase}/api/manage/units/import?format=${unitImportFormat}&subjectId=${unitForm.subjectId}`,
+        { method: 'POST', credentials: 'include', body: formData }
+      );
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'import_failed');
+      setUnitImportResult({ created: data.created || 0, errors: data.errors || [] });
+      setUnitImportMessage(`Unidades creadas: ${data.created || 0}`);
+      await loadUnits(unitForm.subjectId);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'No se pudo importar';
+      setUnitImportMessage(msg);
+    } finally { setUnitImportLoading(false); }
   }
 
   const navItems = [
@@ -537,6 +566,13 @@ export default function Management({ isAdmin, onSubjectsChanged }: { isAdmin: bo
           <div className="grid gap-5 py-[1.5rem]">
             <div className="flex items-center justify-between flex-wrap gap-3">
               <h2 className="text-xl font-extrabold tracking-tight">Gestión de <span className="bg-gradient-to-r from-primary via-accent to-primary bg-clip-text text-transparent">Unidades</span></h2>
+              <button
+                className={btnOutline}
+                disabled={!unitForm.subjectId}
+                onClick={() => { setUnitImportOpen(true); setUnitImportMessage(''); setUnitImportResult(null); setUnitImportFile(null); }}
+              >
+                <FileImport className="w-6 h-6" />Importar
+              </button>
             </div>
 
             <div className={card}>
@@ -830,6 +866,57 @@ export default function Management({ isAdmin, onSubjectsChanged }: { isAdmin: bo
                 disabled={subjectImportLoading || !subjectImportFile}
               >
                 <FileImport className="w-6 h-6" />{subjectImportLoading ? 'Importando...' : 'Importar'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── Modal Importar unidades ── */}
+      {unitImportOpen && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 px-4">
+          <div className="bg-bg border border-secondary/25 rounded-2xl p-6 w-full max-w-md shadow-xl">
+            <h3 className="text-lg font-bold mb-4">Importar unidades</h3>
+            <div className="grid gap-3 mb-4">
+              <select className={inp} value={unitImportFormat} onChange={e => setUnitImportFormat(e.target.value as 'csv' | 'json')}>
+                <option value="csv">CSV</option>
+                <option value="json">JSON</option>
+              </select>
+              <input
+                type="file"
+                accept={unitImportFormat === 'csv' ? '.csv' : '.json'}
+                onChange={e => setUnitImportFile(e.target.files?.[0] || null)}
+                className="text-sm text-text/70 file:mr-3 file:py-1.5 file:px-4 file:rounded-full file:border-0 file:text-sm file:bg-primary/10 file:text-primary hover:file:bg-primary/20 file:transition-colors"
+              />
+              {unitImportMessage && (
+                <div className={`text-sm rounded-lg px-3 py-2 font-medium ${
+                  unitImportResult
+                    ? unitImportResult.created > 0 && unitImportResult.errors.length === 0
+                      ? 'bg-green-500/15 text-green-600 border border-green-500/30'
+                      : unitImportResult.created === 0 && unitImportResult.errors.length > 0
+                        ? 'bg-red-500/15 text-red-600 border border-red-500/30'
+                        : 'bg-yellow-500/15 text-yellow-600 border border-yellow-500/30'
+                    : 'bg-secondary/20 text-text/70'
+                }`}>{unitImportMessage}</div>
+              )}
+              {unitImportResult && unitImportResult.errors.length > 0 && (
+                <ul className="text-xs text-red-500 space-y-1 max-h-40 overflow-y-auto">
+                  {unitImportResult.errors.map(err => (
+                    <li key={err.row}>Fila {err.row}: {err.message}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+            <div className="flex gap-2 justify-end">
+              <button className={btnOutline} onClick={() => setUnitImportOpen(false)}>
+                <CircleMinus className="w-6 h-6" />Cancelar
+              </button>
+              <button
+                className={btnPrimary}
+                onClick={handleUnitImport}
+                disabled={unitImportLoading || !unitImportFile}
+              >
+                <FileImport className="w-6 h-6" />{unitImportLoading ? 'Importando...' : 'Importar'}
               </button>
             </div>
           </div>

--- a/frontend/src/components/Management.tsx
+++ b/frontend/src/components/Management.tsx
@@ -446,7 +446,7 @@ export default function Management({ isAdmin, onSubjectsChanged }: { isAdmin: bo
           <div className="grid gap-5 py-[1.5rem]">
             <div className="flex items-center justify-between flex-wrap gap-3">
               <h2 className="text-xl font-extrabold tracking-tight">Gestión de <span className="bg-gradient-to-r from-primary via-accent to-primary bg-clip-text text-transparent">Temas</span></h2>
-              {isAdmin && filterSyllabusId && (
+              {filterSyllabusId && (
                 <button
                   className={btnOutline}
                   onClick={() => { setSubjectImportOpen(true); setSubjectImportMessage(''); setSubjectImportResult(null); setSubjectImportFile(null); }}

--- a/frontend/src/components/Management.tsx
+++ b/frontend/src/components/Management.tsx
@@ -446,14 +446,13 @@ export default function Management({ isAdmin, onSubjectsChanged }: { isAdmin: bo
           <div className="grid gap-5 py-[1.5rem]">
             <div className="flex items-center justify-between flex-wrap gap-3">
               <h2 className="text-xl font-extrabold tracking-tight">Gestión de <span className="bg-gradient-to-r from-primary via-accent to-primary bg-clip-text text-transparent">Temas</span></h2>
-              {filterSyllabusId && (
-                <button
-                  className={btnOutline}
-                  onClick={() => { setSubjectImportOpen(true); setSubjectImportMessage(''); setSubjectImportResult(null); setSubjectImportFile(null); }}
-                >
-                  <FileImport className="w-6 h-6" />Importar
-                </button>
-              )}
+              <button
+                className={btnOutline}
+                disabled={!filterSyllabusId}
+                onClick={() => { setSubjectImportOpen(true); setSubjectImportMessage(''); setSubjectImportResult(null); setSubjectImportFile(null); }}
+              >
+                <FileImport className="w-6 h-6" />Importar
+              </button>
             </div>
 
             <div className={card}>

--- a/frontend/src/components/Management.tsx
+++ b/frontend/src/components/Management.tsx
@@ -177,6 +177,13 @@ export default function Management({ isAdmin, onSubjectsChanged }: { isAdmin: bo
   const [importDone, setImportDone] = useState(false);
   const [importStats, setImportStats] = useState<{ created: number; errors: number } | null>(null);
 
+  const [subjectImportOpen, setSubjectImportOpen] = useState(false);
+  const [subjectImportFile, setSubjectImportFile] = useState<File | null>(null);
+  const [subjectImportFormat, setSubjectImportFormat] = useState<'csv' | 'json'>('csv');
+  const [subjectImportLoading, setSubjectImportLoading] = useState(false);
+  const [subjectImportMessage, setSubjectImportMessage] = useState('');
+  const [subjectImportResult, setSubjectImportResult] = useState<{ created: number; errors: { row: number; message: string }[] } | null>(null);
+
   const [filterSyllabusId, setFilterSyllabusId] = useState('');
   const [filterUnitSyllabusId, setFilterUnitSyllabusId] = useState('');
   const [questionSyllabusId, setQuestionSyllabusId] = useState('');
@@ -310,6 +317,29 @@ export default function Management({ isAdmin, onSubjectsChanged }: { isAdmin: bo
     finally { setImportLoading(false); }
   }
 
+  async function handleSubjectImport() {
+    if (!subjectImportFile || subjectImportLoading) return;
+    if (!filterSyllabusId) { setSubjectImportMessage('Selecciona un temario'); return; }
+    setSubjectImportLoading(true); setSubjectImportMessage('');
+    try {
+      const formData = new FormData();
+      formData.append('file', subjectImportFile);
+      const res = await fetch(
+        `${apiBase}/api/manage/subjects/import?format=${subjectImportFormat}&syllabusId=${filterSyllabusId}`,
+        { method: 'POST', credentials: 'include', body: formData }
+      );
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'import_failed');
+      setSubjectImportResult({ created: data.created || 0, errors: data.errors || [] });
+      setSubjectImportMessage(`Temas creados: ${data.created || 0}`);
+      await loadSubjects();
+      onSubjectsChanged?.();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'No se pudo importar';
+      setSubjectImportMessage(msg);
+    } finally { setSubjectImportLoading(false); }
+  }
+
   const navItems = [
     { id: 'syllabuses' as Tab, label: 'Temarios', icon: <Inbox className="w-6 h-6" /> },
     { id: 'subjects' as Tab, label: 'Temas', icon: <BookOpen className="w-6 h-6" /> },
@@ -416,6 +446,14 @@ export default function Management({ isAdmin, onSubjectsChanged }: { isAdmin: bo
           <div className="grid gap-5 py-[1.5rem]">
             <div className="flex items-center justify-between flex-wrap gap-3">
               <h2 className="text-xl font-extrabold tracking-tight">Gestión de <span className="bg-gradient-to-r from-primary via-accent to-primary bg-clip-text text-transparent">Temas</span></h2>
+              {isAdmin && filterSyllabusId && (
+                <button
+                  className={btnOutline}
+                  onClick={() => { setSubjectImportOpen(true); setSubjectImportMessage(''); setSubjectImportResult(null); setSubjectImportFile(null); }}
+                >
+                  <FileImport className="w-6 h-6" />Importar
+                </button>
+              )}
             </div>
 
             <div className={card}>
@@ -743,6 +781,57 @@ export default function Management({ isAdmin, onSubjectsChanged }: { isAdmin: bo
                   </button>
                 </>
               )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── Modal Importar temas ── */}
+      {subjectImportOpen && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 px-4">
+          <div className="bg-bg border border-secondary/25 rounded-2xl p-6 w-full max-w-md shadow-xl">
+            <h3 className="text-lg font-bold mb-4">Importar temas</h3>
+            <div className="grid gap-3 mb-4">
+              <select className={inp} value={subjectImportFormat} onChange={e => setSubjectImportFormat(e.target.value as 'csv' | 'json')}>
+                <option value="csv">CSV</option>
+                <option value="json">JSON</option>
+              </select>
+              <input
+                type="file"
+                accept={subjectImportFormat === 'csv' ? '.csv' : '.json'}
+                onChange={e => setSubjectImportFile(e.target.files?.[0] || null)}
+                className="text-sm text-text/70 file:mr-3 file:py-1.5 file:px-4 file:rounded-full file:border-0 file:text-sm file:bg-primary/10 file:text-primary hover:file:bg-primary/20 file:transition-colors"
+              />
+              {subjectImportMessage && (
+                <div className={`text-sm rounded-lg px-3 py-2 font-medium ${
+                  subjectImportResult
+                    ? subjectImportResult.created > 0 && subjectImportResult.errors.length === 0
+                      ? 'bg-green-500/15 text-green-600 border border-green-500/30'
+                      : subjectImportResult.created === 0 && subjectImportResult.errors.length > 0
+                        ? 'bg-red-500/15 text-red-600 border border-red-500/30'
+                        : 'bg-yellow-500/15 text-yellow-600 border border-yellow-500/30'
+                    : 'bg-secondary/20 text-text/70'
+                }`}>{subjectImportMessage}</div>
+              )}
+              {subjectImportResult && subjectImportResult.errors.length > 0 && (
+                <ul className="text-xs text-red-500 space-y-1 max-h-40 overflow-y-auto">
+                  {subjectImportResult.errors.map(err => (
+                    <li key={err.row}>Fila {err.row}: {err.message}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+            <div className="flex gap-2 justify-end">
+              <button className={btnOutline} onClick={() => setSubjectImportOpen(false)}>
+                <CircleMinus className="w-6 h-6" />Cancelar
+              </button>
+              <button
+                className={btnPrimary}
+                onClick={handleSubjectImport}
+                disabled={subjectImportLoading || !subjectImportFile}
+              >
+                <FileImport className="w-6 h-6" />{subjectImportLoading ? 'Importando...' : 'Importar'}
+              </button>
             </div>
           </div>
         </div>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -168,7 +168,9 @@ export default function NavbarComponent({ isAuthed, isAdmin, user, onLogout, onP
 
       {/* ── Mobile menu ── */}
       <div
-        className={`md:hidden overflow-hidden transition-all duration-300 ease-in-out ${menuOpen ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+        className={`md:hidden transition-all duration-300 ease-in-out ${menuOpen
+          ? 'max-h-[calc(100vh-4rem)] opacity-100 overflow-y-auto'
+          : 'max-h-0 opacity-0 overflow-hidden'
           }`}
       >
         <div className="px-4 pb-4 pt-2 border-t border-secondary/15 space-y-1 bg-bg/95 backdrop-blur-md">

--- a/frontend/src/components/PaymentModal.tsx
+++ b/frontend/src/components/PaymentModal.tsx
@@ -113,25 +113,30 @@ export default function PaymentModal({ isOpen, onClose, productId }: PaymentModa
 
         {step === 'email-entry' && (
           <form onSubmit={handleEmailContinue} className="space-y-4">
-            <label className="block">
-              <span className="text-sm font-medium text-text">Tu email</span>
+            <p className="text-sm text-text/80 leading-relaxed">
+              Danos tu mejor e-mail para que podamos contactar contigo, además de descargarlo ahora mismo, te enviaremos un enlace con la descarga disponible.
+            </p>
+            <div className="relative">
+              <span className="absolute left-4 top-1/2 -translate-y-1/2 text-secondary pointer-events-none">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 shrink-0">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
+                </svg>
+              </span>
               <input
                 type="email"
                 value={email}
                 onChange={(e) => { setEmail(e.target.value); setEmailSuggestion(null); }}
                 onBlur={handleEmailBlur}
-                placeholder="tu@email.com"
+                placeholder="Introduce tu email"
                 required
-                className="mt-1 w-full rounded-xl border border-secondary/30 bg-card px-4 py-3 text-text focus:outline-none focus:ring-2 focus:ring-primary"
+                aria-label="Tu email"
+                className="w-full bg-white/50 dark:bg-[#24394c] border border-transparent rounded-xl pl-11 pr-4 py-4 text-sm text-text placeholder:text-text/35 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50 transition-colors"
               />
-            </label>
+            </div>
             <MailcheckHint
               suggestion={emailSuggestion}
               onAccept={(s) => { setEmail(s); setEmailSuggestion(null); }}
             />
-            <p className="text-xs text-secondary">
-              Te enviaremos el enlace de descarga a este email. Es la única forma de recuperarlo.
-            </p>
             {error && (
               <p className="text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 rounded-xl px-4 py-3">{error}</p>
             )}

--- a/frontend/src/components/__tests__/PaymentModal.test.tsx
+++ b/frontend/src/components/__tests__/PaymentModal.test.tsx
@@ -46,7 +46,7 @@ describe('PaymentModal', () => {
 
   it('step 1: shows email input and Continuar button', () => {
     renderModal();
-    expect(screen.getByPlaceholderText(/tu@email\.com/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/introduce tu email/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /continuar/i })).toBeInTheDocument();
   });
 
@@ -55,7 +55,7 @@ describe('PaymentModal', () => {
     const button = screen.getByRole('button', { name: /continuar/i });
     expect(button).toBeDisabled();
 
-    const input = screen.getByPlaceholderText(/tu@email\.com/i);
+    const input = screen.getByPlaceholderText(/introduce tu email/i);
     fireEvent.change(input, { target: { value: 'not-an-email' } });
     expect(button).toBeDisabled();
 
@@ -65,7 +65,7 @@ describe('PaymentModal', () => {
 
   it('shows mailcheck hint on blur for typo domain and applies correction on click', () => {
     renderModal();
-    const input = screen.getByPlaceholderText(/tu@email\.com/i) as HTMLInputElement;
+    const input = screen.getByPlaceholderText(/introduce tu email/i) as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'foo@gmial.com' } });
     fireEvent.blur(input);
 
@@ -82,7 +82,7 @@ describe('PaymentModal', () => {
     });
 
     renderModal();
-    const input = screen.getByPlaceholderText(/tu@email\.com/i);
+    const input = screen.getByPlaceholderText(/introduce tu email/i);
     fireEvent.change(input, { target: { value: 'buyer@example.com' } });
     fireEvent.click(screen.getByRole('button', { name: /continuar/i }));
 
@@ -101,7 +101,7 @@ describe('PaymentModal', () => {
     });
 
     renderModal();
-    fireEvent.change(screen.getByPlaceholderText(/tu@email\.com/i), {
+    fireEvent.change(screen.getByPlaceholderText(/introduce tu email/i), {
       target: { value: 'buyer@example.com' },
     });
     fireEvent.click(screen.getByRole('button', { name: /continuar/i }));
@@ -109,7 +109,7 @@ describe('PaymentModal', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /volver/i }));
 
-    const input = await screen.findByPlaceholderText(/tu@email\.com/i);
+    const input = await screen.findByPlaceholderText(/introduce tu email/i);
     expect((input as HTMLInputElement).value).toBe('buyer@example.com');
   });
 
@@ -117,7 +117,7 @@ describe('PaymentModal', () => {
     vi.mocked(createPaymentIntent).mockRejectedValue(new Error('boom'));
 
     renderModal();
-    fireEvent.change(screen.getByPlaceholderText(/tu@email\.com/i), {
+    fireEvent.change(screen.getByPlaceholderText(/introduce tu email/i), {
       target: { value: 'buyer@example.com' },
     });
     fireEvent.click(screen.getByRole('button', { name: /continuar/i }));

--- a/frontend/src/components/flashcards/UnitCard.tsx
+++ b/frontend/src/components/flashcards/UnitCard.tsx
@@ -20,7 +20,7 @@ export default function UnitCard({ unit, onClick, onExport }: Props) {
       <button
         type="button"
         onClick={() => onClick ? onClick() : navigate(`/flashcards/study?unitId=${unit.unitId}`)}
-        className="w-full text-left border border-secondary/25 rounded-2xl p-5 transition-all hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5"
+        className="w-full text-left bg-card border border-secondary/25 rounded-2xl p-5 transition-all hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5"
       >
         <div className="flex items-center gap-4">
           <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary group-hover:bg-primary/15 transition-colors">

--- a/frontend/src/pages/DownloadPage.tsx
+++ b/frontend/src/pages/DownloadPage.tsx
@@ -67,15 +67,15 @@ export default function DownloadPage() {
       {state.kind === 'ready' && state.info.status === 'FAILED' && (
         <CenteredCard><FailedView /></CenteredCard>
       )}
-      {state.kind === 'not-found' && <CenteredCard><NotFoundView /></CenteredCard>}
-      {state.kind === 'error' && <CenteredCard><GenericErrorView /></CenteredCard>}
+      {state.kind === 'not-found' && <NotFoundView />}
+      {state.kind === 'error' && <GenericErrorView />}
     </div>
   );
 }
 
 function CenteredCard({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen flex items-center justify-center p-4">
+    <div className="flex justify-center px-4 py-10">
       <div className="bg-card w-full max-w-lg rounded-3xl shadow-2xl p-8 border border-secondary/20">
         {children}
       </div>
@@ -97,7 +97,7 @@ function LoadingView() {
 
 function ProcessingView() {
   return (
-    <main className="min-h-screen flex flex-col items-center justify-center px-6 py-12">
+    <main className="max-w-4xl mx-auto flex flex-col items-center px-6 py-10">
       <div className="max-w-md w-full text-center space-y-8">
         <div className="relative w-24 h-24 mx-auto" role="status" aria-live="polite">
           <div className="absolute inset-0 rounded-full border-4 border-primary/10" />
@@ -198,22 +198,94 @@ function FailedView() {
 
 function NotFoundView() {
   return (
-    <div className="space-y-3">
-      <h1 className="text-2xl font-bold tracking-tight text-text">Enlace no válido</h1>
-      <p className="text-sm text-secondary">
-        Este enlace de descarga no existe o ha expirado. Comprueba el correo que te enviamos o vuelve a la página del temario.
-      </p>
-    </div>
+    <main className="relative overflow-hidden flex justify-center px-4 py-10">
+      <div className="pointer-events-none absolute top-0 right-0 -mr-24 -mt-24 w-96 h-96 bg-primary/5 rounded-full blur-3xl" />
+      <div className="pointer-events-none absolute bottom-0 left-0 -ml-24 -mb-24 w-80 h-80 bg-accent/5 rounded-full blur-3xl" />
+      <section className="max-w-xl w-full text-center relative z-10">
+        <div className="flex justify-center mb-10">
+          <div className="relative">
+            <div className="absolute inset-0 bg-primary/10 rounded-full scale-125" />
+            <div className="w-24 h-24 bg-primary text-bg rounded-full flex items-center justify-center shadow-2xl shadow-primary/30 relative z-10">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-12 h-12">
+                <path fillRule="evenodd" d="M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003zM12 8.25a.75.75 0 01.75.75v3.75a.75.75 0 01-1.5 0V9a.75.75 0 01.75-.75zm0 8.25a.75.75 0 100-1.5.75.75 0 000 1.5z" clipRule="evenodd" />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <h1 className="text-4xl md:text-5xl font-extrabold text-text tracking-tight leading-tight mb-6">
+          Enlace no válido
+        </h1>
+        <p className="text-lg text-secondary font-medium leading-relaxed mb-10 px-4 md:px-8">
+          Este enlace de descarga no existe o ha expirado. Comprueba el correo que te enviamos o vuelve a la página del temario.
+        </p>
+        <div className="flex flex-col items-center gap-6">
+          <Link
+            to={ROUTES.subalternoGva}
+            className="inline-flex items-center justify-center bg-primary text-bg px-10 py-4 rounded-xl text-lg font-bold shadow-lg shadow-primary/20 hover:opacity-95 active:scale-[0.98] transition-all w-full sm:w-auto"
+          >
+            Volver al temario
+          </Link>
+          <p className="text-secondary text-sm font-medium">
+            ¿Tienes problemas con tu compra?{' '}
+            <a className="text-primary font-bold hover:underline ml-1" href={`mailto:soporte@akadem.ia?subject=${encodeURIComponent('Enlace de descarga no válido')}`}>
+              Contactar con soporte
+            </a>
+          </p>
+        </div>
+      </section>
+    </main>
   );
 }
 
 function GenericErrorView() {
   return (
-    <div className="space-y-3">
-      <h1 className="text-2xl font-bold tracking-tight text-text">Algo ha ido mal</h1>
-      <p className="text-sm text-secondary">
-        No hemos podido cargar la información de tu compra. Inténtalo de nuevo en unos minutos.
-      </p>
-    </div>
+    <main className="flex justify-center px-6 py-10">
+      <div className="max-w-2xl w-full text-center space-y-8">
+        <div className="relative inline-flex items-center justify-center">
+          <div className="absolute inset-0 bg-primary/10 blur-3xl rounded-full" />
+          <div className="relative bg-card p-8 rounded-full border border-primary/20 shadow-xl shadow-primary/5">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-16 h-16 text-primary">
+              <path fillRule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zm-1.72 6.97a.75.75 0 10-1.06 1.06L10.94 12l-1.72 1.72a.75.75 0 101.06 1.06L12 13.06l1.72 1.72a.75.75 0 101.06-1.06L13.06 12l1.72-1.72a.75.75 0 10-1.06-1.06L12 10.94l-1.72-1.72z" clipRule="evenodd" />
+            </svg>
+          </div>
+        </div>
+        <div className="space-y-4">
+          <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight text-text leading-tight">
+            Algo ha ido mal
+          </h1>
+          <p className="text-lg text-secondary max-w-xl mx-auto leading-relaxed">
+            No hemos podido cargar la información de tu compra. No te preocupes, no se ha realizado ningún cargo en tu cuenta. Inténtalo de nuevo en unos minutos.
+          </p>
+        </div>
+        <div className="flex flex-col items-center gap-6 pt-2">
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="bg-primary text-bg px-10 py-4 rounded-xl text-lg font-bold shadow-lg shadow-primary/20 hover:opacity-95 active:scale-[0.98] transition-all w-full sm:w-auto"
+          >
+            Intentar de nuevo
+          </button>
+          <p className="text-sm text-secondary">
+            ¿Has intentado varias veces y sigue fallando?{' '}
+            <a className="text-primary font-semibold hover:underline" href={`mailto:soporte@akadem.ia?subject=${encodeURIComponent('Error al cargar la información de compra')}`}>
+              Contactar con soporte
+            </a>
+          </p>
+        </div>
+        <div className="mt-8 bg-card rounded-2xl p-6 border border-secondary/20 max-w-md mx-auto">
+          <div className="flex items-start gap-4 text-left">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5 text-secondary mt-1 shrink-0">
+              <path fillRule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12zM12 8.25a.75.75 0 01.75.75v3.75a.75.75 0 01-1.5 0V9a.75.75 0 01.75-.75zm0 8.25a.75.75 0 100-1.5.75.75 0 000 1.5z" clipRule="evenodd" />
+            </svg>
+            <div>
+              <h4 className="text-xs uppercase tracking-widest text-secondary font-bold mb-1">Información de seguridad</h4>
+              <p className="text-xs text-secondary leading-relaxed">
+                Nuestras pasarelas de pago están cifradas y protegidas. Si el problema persiste, es posible que tu entidad bancaria haya bloqueado el movimiento por seguridad.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
   );
 }

--- a/frontend/src/pages/DownloadPage.tsx
+++ b/frontend/src/pages/DownloadPage.tsx
@@ -64,9 +64,7 @@ export default function DownloadPage() {
         <ReadyView info={state.info} token={token} />
       )}
       {state.kind === 'ready' && state.info.status === 'PENDING' && <ProcessingView />}
-      {state.kind === 'ready' && state.info.status === 'FAILED' && (
-        <CenteredCard><FailedView /></CenteredCard>
-      )}
+      {state.kind === 'ready' && state.info.status === 'FAILED' && <FailedView />}
       {state.kind === 'not-found' && <NotFoundView />}
       {state.kind === 'error' && <GenericErrorView />}
     </div>
@@ -187,12 +185,48 @@ function ReadyView({ info, token }: { info: PurchaseInfoResponse; token: string 
 
 function FailedView() {
   return (
-    <div className="space-y-3">
-      <h1 className="text-2xl font-bold tracking-tight text-text">Pago fallido</h1>
-      <p className="text-sm text-secondary">
-        El pago no se completó. Si tu tarjeta fue rechazada, puedes volver a intentarlo desde la página del temario.
-      </p>
-    </div>
+    <main className="relative overflow-hidden flex justify-center px-4 py-10">
+      <div className="pointer-events-none absolute -top-24 -right-24 w-96 h-96 bg-primary/5 rounded-full blur-3xl" />
+      <div className="pointer-events-none absolute bottom-12 -left-24 w-64 h-64 bg-accent/5 rounded-full blur-3xl" />
+
+      <section className="max-w-xl w-full text-center relative z-10">
+        <div className="flex justify-center mb-10">
+          <div className="w-24 h-24 bg-red-400/15 rounded-full flex items-center justify-center">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-12 h-12 text-red-500">
+              <path fillRule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zm-1.72 6.97a.75.75 0 10-1.06 1.06L10.94 12l-1.72 1.72a.75.75 0 101.06 1.06L12 13.06l1.72 1.72a.75.75 0 101.06-1.06L13.06 12l1.72-1.72a.75.75 0 10-1.06-1.06L12 10.94l-1.72-1.72z" clipRule="evenodd" />
+            </svg>
+          </div>
+        </div>
+
+        <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight text-text mb-6">
+          Pago fallido
+        </h1>
+        <p className="text-lg text-secondary leading-relaxed mb-12 max-w-md mx-auto">
+          El pago no se completó. No se ha realizado ningún cargo en tu cuenta. Si tu tarjeta fue rechazada, puedes volver a intentarlo desde la página del temario.
+        </p>
+
+        <div className="flex flex-col items-center gap-6">
+          <Link
+            to={ROUTES.subalternoGva}
+            className="inline-flex items-center justify-center gap-2 bg-primary text-bg px-12 py-5 rounded-xl text-lg font-bold shadow-lg shadow-primary/20 hover:opacity-95 active:scale-[0.98] transition-all w-full sm:w-auto"
+          >
+            Intentar de nuevo
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5 shrink-0">
+              <path fillRule="evenodd" d="M4.755 10.059a7.5 7.5 0 0112.548-3.364l1.903 1.903h-3.183a.75.75 0 100 1.5h4.992a.75.75 0 00.75-.75V4.356a.75.75 0 00-1.5 0v3.18l-1.9-1.9A9 9 0 003.306 9.67a.75.75 0 101.45.388zm15.408 3.352a.75.75 0 00-.919.53 7.5 7.5 0 01-12.548 3.364l-1.902-1.903h3.183a.75.75 0 000-1.5H2.984a.75.75 0 00-.75.75v4.992a.75.75 0 001.5 0v-3.18l1.9 1.9a9 9 0 0015.059-4.035.75.75 0 00-.53-.918z" clipRule="evenodd" />
+            </svg>
+          </Link>
+          <p className="text-sm text-secondary">
+            ¿Has intentado varias veces y tienes problemas con la compra?{' '}
+            <a
+              className="text-primary font-semibold hover:underline ml-1"
+              href={`mailto:soporte@akadem.ia?subject=${encodeURIComponent('Pago fallido')}`}
+            >
+              Contactar con soporte
+            </a>
+          </p>
+        </div>
+      </section>
+    </main>
   );
 }
 

--- a/frontend/src/pages/DownloadPage.tsx
+++ b/frontend/src/pages/DownloadPage.tsx
@@ -34,12 +34,26 @@ export default function DownloadPage() {
   }, [token]);
 
   return (
-    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+    <div className="min-h-screen bg-bg text-text">
+      {state.kind === 'loading' && <CenteredCard><LoadingView /></CenteredCard>}
+      {state.kind === 'ready' && state.info.status === 'PAID' && (
+        <ReadyView info={state.info} token={token} />
+      )}
+      {state.kind === 'ready' && state.info.status === 'PENDING' && <ProcessingView />}
+      {state.kind === 'ready' && state.info.status === 'FAILED' && (
+        <CenteredCard><FailedView /></CenteredCard>
+      )}
+      {state.kind === 'not-found' && <CenteredCard><NotFoundView /></CenteredCard>}
+      {state.kind === 'error' && <CenteredCard><GenericErrorView /></CenteredCard>}
+    </div>
+  );
+}
+
+function CenteredCard({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
       <div className="bg-card w-full max-w-lg rounded-3xl shadow-2xl p-8 border border-secondary/20">
-        {state.kind === 'loading' && <LoadingView />}
-        {state.kind === 'ready' && <StatusView info={state.info} token={token} />}
-        {state.kind === 'not-found' && <NotFoundView />}
-        {state.kind === 'error' && <GenericErrorView />}
+        {children}
       </div>
     </div>
   );
@@ -57,53 +71,97 @@ function LoadingView() {
   );
 }
 
-function StatusView({ info, token }: { info: PurchaseInfoResponse; token: string }) {
+function ProcessingView() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center px-6 py-12">
+      <div className="max-w-md w-full text-center space-y-8">
+        <div className="relative w-24 h-24 mx-auto" role="status" aria-live="polite">
+          <div className="absolute inset-0 rounded-full border-4 border-primary/10" />
+          <div className="absolute inset-0 rounded-full border-4 border-transparent border-t-primary animate-spin" />
+          <div className="absolute inset-0 flex items-center justify-center">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-9 h-9 text-primary">
+              <path fillRule="evenodd" d="M2.25 8.25A2.25 2.25 0 014.5 6h15a2.25 2.25 0 012.25 2.25v.75H2.25v-.75zm0 3.75v6A2.25 2.25 0 004.5 20.25h15A2.25 2.25 0 0021.75 18v-6H2.25zm3 4.5a.75.75 0 01.75-.75h3a.75.75 0 010 1.5H6a.75.75 0 01-.75-.75z" clipRule="evenodd" />
+            </svg>
+          </div>
+        </div>
+        <div className="space-y-4">
+          <h1 className="text-3xl font-extrabold tracking-tight text-text">Procesando tu pago…</h1>
+          <p className="text-lg text-secondary leading-relaxed">
+            Estamos esperando la confirmación de Stripe. En cuanto se confirme, recibirás un email con el enlace de descarga. Esta página se actualizará automáticamente al recargar.
+          </p>
+        </div>
+        <div className="w-full bg-card h-1.5 rounded-full overflow-hidden border border-secondary/10">
+          <div className="bg-primary h-full w-2/3 rounded-full animate-pulse" />
+        </div>
+        <div className="pt-4 flex items-center justify-center space-x-2 text-sm font-medium text-secondary/70">
+          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm4.59-12.42L10 14.17l-2.59-2.58L6 13l4 4 8-8z" />
+          </svg>
+          <span>Conexión segura cifrada</span>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function ReadyView({ info, token }: { info: PurchaseInfoResponse; token: string }) {
   const registerHref = `${ROUTES.register}?email=${encodeURIComponent(info.email)}`;
 
-  if (info.status === 'PAID') {
-    return (
-      <div className="space-y-6">
-        <header>
-          <h1 className="text-2xl font-bold tracking-tight text-text">Tu descarga está lista</h1>
-          <p className="text-sm text-secondary mt-1">
-            Compra confirmada para <span className="font-medium text-text">{info.email}</span>.
-          </p>
-        </header>
+  return (
+    <main className="max-w-4xl mx-auto px-6 py-20 flex flex-col items-center text-center">
+      <div className="mb-12">
+        <div className="w-24 h-24 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-8 animate-bounce">
+          <svg className="w-12 h-12 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M5 13l4 4L19 7" strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" />
+          </svg>
+        </div>
+        <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight mb-4 text-text">
+          ¡Tu descarga está lista!
+        </h1>
+        <p className="text-xl text-secondary max-w-lg mx-auto leading-relaxed">
+          Compra confirmada para <span className="font-medium text-text">{info.email}</span>.
+          Hemos enviado el enlace también a tu correo.
+        </p>
+      </div>
+
+      <div className="w-full max-w-md space-y-6">
         <a
           href={downloadUrl(token)}
           target="_blank"
           rel="noopener noreferrer"
-          className="w-full btn btn-primary py-4 rounded-full font-bold text-base inline-flex items-center justify-center gap-3"
+          className="w-full bg-primary text-bg px-10 py-5 rounded-2xl font-bold text-lg hover:opacity-95 transition-all active:scale-[0.98] shadow-xl shadow-primary/20 flex items-center justify-center gap-3"
         >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-6 h-6">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+          </svg>
           Descargar {info.productName}
         </a>
-        <div className="text-sm text-secondary border-t border-secondary/20 pt-6">
-          <p className="mb-2 font-medium text-text">¿Quieres seguir estudiando?</p>
-          <p>
-            Crea una cuenta gratuita con tu email para acceder a flashcards, exámenes y seguimiento de progreso.
-          </p>
-          <Link
-            to={registerHref}
-            className="inline-block mt-3 text-primary font-semibold hover:underline"
-          >
-            Crear cuenta con {info.email}
-          </Link>
-        </div>
       </div>
-    );
-  }
 
-  if (info.status === 'PENDING') {
-    return (
-      <div className="space-y-3">
-        <h1 className="text-2xl font-bold tracking-tight text-text">Procesando tu pago</h1>
-        <p className="text-sm text-secondary">
-          Estamos esperando la confirmación de Stripe. En cuanto se confirme, recibirás un email con el enlace de descarga. Esta página se actualizará automáticamente al recargar.
+      <div className="mt-16 p-10 bg-card rounded-[2.5rem] w-full max-w-2xl border border-secondary/20">
+        <h2 className="text-2xl font-bold mb-4 text-text">¿Quieres seguir estudiando?</h2>
+        <p className="text-secondary mb-8 leading-relaxed">
+          Crea una cuenta gratuita con tu email para acceder a flashcards, exámenes y seguimiento de progreso.
         </p>
+        <Link
+          to={registerHref}
+          className="inline-flex items-center justify-center bg-card text-text border border-secondary/40 px-8 py-4 rounded-xl font-bold hover:bg-secondary/10 transition-colors"
+        >
+          Crear cuenta con {info.email}
+        </Link>
       </div>
-    );
-  }
 
+      <p className="mt-12 text-sm text-secondary">
+        ¿Tienes problemas con la descarga?{' '}
+        <a className="text-primary font-semibold hover:underline" href={`mailto:soporte@akadem.ia?subject=${encodeURIComponent('Problema con descarga del temario')}`}>
+          Contactar con soporte
+        </a>
+      </p>
+    </main>
+  );
+}
+
+function FailedView() {
   return (
     <div className="space-y-3">
       <h1 className="text-2xl font-bold tracking-tight text-text">Pago fallido</h1>

--- a/frontend/src/pages/DownloadPage.tsx
+++ b/frontend/src/pages/DownloadPage.tsx
@@ -23,14 +23,38 @@ export default function DownloadPage() {
       return;
     }
     let cancelled = false;
-    fetchPurchaseInfo(token)
-      .then((info) => { if (!cancelled) setState({ kind: 'ready', info }); })
-      .catch((err: unknown) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let pollAttempts = 0;
+    const MAX_POLL_ATTEMPTS = 15;
+    const POLL_INTERVAL_MS = 2000;
+
+    async function load(isPoll: boolean) {
+      try {
+        const info = await fetchPurchaseInfo(token);
         if (cancelled) return;
+        setState({ kind: 'ready', info });
+        if (info.status === 'PENDING' && pollAttempts < MAX_POLL_ATTEMPTS) {
+          pollAttempts += 1;
+          timer = setTimeout(() => load(true), POLL_INTERVAL_MS);
+        }
+      } catch (err: unknown) {
+        if (cancelled) return;
+        if (isPoll && pollAttempts < MAX_POLL_ATTEMPTS) {
+          pollAttempts += 1;
+          timer = setTimeout(() => load(true), POLL_INTERVAL_MS);
+          return;
+        }
         const status = (err as { status?: number })?.status;
         setState({ kind: status === 404 ? 'not-found' : 'error' });
-      });
-    return () => { cancelled = true; };
+      }
+    }
+
+    load(false);
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
   }, [token]);
 
   return (
@@ -108,7 +132,7 @@ function ReadyView({ info, token }: { info: PurchaseInfoResponse; token: string 
   const registerHref = `${ROUTES.register}?email=${encodeURIComponent(info.email)}`;
 
   return (
-    <main className="max-w-4xl mx-auto px-6 py-20 flex flex-col items-center text-center">
+    <main className="max-w-4xl mx-auto px-6 py-10 flex flex-col items-center text-center">
       <div className="mb-12">
         <div className="w-24 h-24 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-8 animate-bounce">
           <svg className="w-12 h-12 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -131,7 +155,7 @@ function ReadyView({ info, token }: { info: PurchaseInfoResponse; token: string 
           rel="noopener noreferrer"
           className="w-full bg-primary text-bg px-10 py-5 rounded-2xl font-bold text-lg hover:opacity-95 transition-all active:scale-[0.98] shadow-xl shadow-primary/20 flex items-center justify-center gap-3"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-6 h-6">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-8 h-8 shrink-0">
             <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
           </svg>
           Descargar {info.productName}
@@ -145,7 +169,7 @@ function ReadyView({ info, token }: { info: PurchaseInfoResponse; token: string 
         </p>
         <Link
           to={registerHref}
-          className="inline-flex items-center justify-center bg-card text-text border border-secondary/40 px-8 py-4 rounded-xl font-bold hover:bg-secondary/10 transition-colors"
+          className="btn btn-secondary w-full sm:w-auto sm:inline-flex max-w-full px-8 py-4 rounded-xl font-bold text-center break-words"
         >
           Crear cuenta con {info.email}
         </Link>

--- a/frontend/src/pages/ExamAttemptPage.tsx
+++ b/frontend/src/pages/ExamAttemptPage.tsx
@@ -62,9 +62,9 @@ export default function ExamAttemptPage({ onUnauthorized, onFinish }:{
 
   if (error || !attempt) {
     return (
-      <main className="min-h-[calc(100vh-4rem)] flex flex-col items-center justify-center px-4 relative overflow-hidden">
-        <div className="pointer-events-none absolute -top-24 -right-24 w-96 h-96 bg-primary/5 rounded-full blur-3xl" />
-        <div className="pointer-events-none absolute bottom-12 -left-24 w-64 h-64 bg-accent/5 rounded-full blur-3xl" />
+      <main className="min-h-screen -mt-8 -mx-6 flex flex-col items-center justify-center px-10 relative overflow-x-hidden">
+        <div className="pointer-events-none absolute top-0 right-0 w-[32rem] h-[32rem] bg-primary/5 rounded-full blur-3xl" />
+        <div className="pointer-events-none absolute bottom-0 left-0 w-64 h-64 bg-accent/5 rounded-full blur-3xl" />
 
         <div className="max-w-xl w-full text-center space-y-8 py-12 relative z-10">
           {/* Icon */}

--- a/frontend/src/pages/ExamAttemptPage.tsx
+++ b/frontend/src/pages/ExamAttemptPage.tsx
@@ -62,10 +62,75 @@ export default function ExamAttemptPage({ onUnauthorized, onFinish }:{
 
   if (error || !attempt) {
     return (
-      <div className="max-w-xl mx-auto border border-secondary/25 rounded-2xl p-8">
-        <h2 className="text-xl font-bold mb-2">Error</h2>
-        <p className="text-text/55">{error || 'No se pudo cargar el intento.'}</p>
-      </div>
+      <main className="min-h-[calc(100vh-4rem)] flex flex-col items-center justify-center px-4 relative overflow-hidden">
+        <div className="pointer-events-none absolute -top-24 -right-24 w-96 h-96 bg-primary/5 rounded-full blur-3xl" />
+        <div className="pointer-events-none absolute bottom-12 -left-24 w-64 h-64 bg-accent/5 rounded-full blur-3xl" />
+
+        <div className="max-w-xl w-full text-center space-y-8 py-12 relative z-10">
+          {/* Icon */}
+          <div className="relative inline-flex items-center justify-center">
+            <div className="absolute inset-0 bg-primary/10 rounded-full blur-2xl animate-pulse" />
+            <div className="relative bg-card p-8 rounded-full shadow-sm border border-secondary/15">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-16 h-16 text-primary">
+                <path fillRule="evenodd" d="M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003zM12 8.25a.75.75 0 01.75.75v3.75a.75.75 0 01-1.5 0V9a.75.75 0 01.75-.75zm0 8.25a.75.75 0 100-1.5.75.75 0 000 1.5z" clipRule="evenodd" />
+              </svg>
+            </div>
+          </div>
+
+          {/* Content */}
+          <div className="space-y-4">
+            <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight text-text leading-tight">
+              Error al reanudar el intento
+            </h1>
+            <p className="text-lg md:text-xl text-secondary leading-relaxed px-6">
+              No hemos podido cargar tu sesión de examen. Por favor, inténtalo de nuevo o vuelve a la selección de temas.
+            </p>
+          </div>
+
+          {/* Actions */}
+          <div className="flex flex-col items-center gap-6 pt-4">
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="bg-primary text-bg px-10 py-4 rounded-xl font-bold text-lg hover:opacity-90 active:scale-95 transition-all shadow-lg shadow-primary/20"
+            >
+              Intentar de nuevo
+            </button>
+            <p className="text-sm font-medium text-secondary">
+              ¿Sigues teniendo problemas?{' '}
+              <a
+                className="text-primary hover:underline font-bold"
+                href={`mailto:soporte@akadem.ia?subject=${encodeURIComponent('Error al reanudar el intento')}`}
+              >
+                Contactar con soporte
+              </a>
+            </p>
+          </div>
+
+          {/* Info badges */}
+          <div className="flex justify-center items-center gap-10 sm:gap-12 pt-8 opacity-40">
+            <div className="flex flex-col items-center gap-2">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6 text-secondary">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 15a4.5 4.5 0 004.5 4.5H18a3.75 3.75 0 001.332-7.257 3 3 0 00-3.758-3.848 5.25 5.25 0 00-10.233 2.33A4.502 4.502 0 002.25 15z" />
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 4.5l15 15" />
+              </svg>
+              <span className="text-xs uppercase tracking-widest text-secondary font-bold">Sync Error</span>
+            </div>
+            <div className="flex flex-col items-center gap-2">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6 text-secondary">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <span className="text-xs uppercase tracking-widest text-secondary font-bold">Session Timeout</span>
+            </div>
+            <div className="flex flex-col items-center gap-2">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6 text-secondary">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+              </svg>
+              <span className="text-xs uppercase tracking-widest text-secondary font-bold">Secure Connection</span>
+            </div>
+          </div>
+        </div>
+      </main>
     );
   }
 

--- a/frontend/src/pages/FlashcardsExamineUnitPage.tsx
+++ b/frontend/src/pages/FlashcardsExamineUnitPage.tsx
@@ -117,8 +117,8 @@ export default function FlashcardsExamineUnitPage() {
 
       {/* Card – tap to flip */}
       <div className="relative cursor-pointer" onClick={() => setFlipped((f) => !f)}>
-        <div className="absolute -left-1.5 -bottom-1.5 h-full w-full rounded-2xl bg-bg brightness-90 dark:brightness-75" />
-        <div className="relative border border-secondary/25 rounded-2xl p-7 min-h-[45vh] max-h-[45vh] flex flex-col bg-bg select-none">
+        <div className="absolute -left-1.5 -bottom-1.5 h-full w-full rounded-2xl bg-white dark:bg-card brightness-90 dark:brightness-75" />
+        <div className="relative border border-secondary/25 rounded-2xl p-7 min-h-[45vh] max-h-[45vh] flex flex-col bg-white dark:bg-card select-none">
           <div className="flex-1 overflow-y-auto min-h-0 flex items-center">
             <p className="text-xl font-semibold leading-relaxed w-full">
               {flipped ? card.back : card.front}

--- a/frontend/src/pages/FlashcardsStudyPage.tsx
+++ b/frontend/src/pages/FlashcardsStudyPage.tsx
@@ -208,7 +208,7 @@ export default function FlashcardsStudyPage() {
       {/* ── Card ── */}
       <div className="relative">
         <div className="absolute -left-1.5 -bottom-1.5 h-full w-full rounded-2xl bg-bg brightness-90 dark:brightness-75" />
-        <div className="relative border border-secondary/25 rounded-2xl p-7 min-h-[52vh] max-h-[52vh] flex flex-col bg-bg">
+        <div className="relative border border-secondary/25 rounded-2xl p-7 min-h-[52vh] max-h-[52vh] flex flex-col bg-white dark:bg-card">
           <div className="flex-1 overflow-y-auto min-h-0">
             {!showAnswer ? (
               <p className="text-xl font-semibold leading-relaxed">{currentItem?.front || 'Sin tarjetas disponibles.'}</p>

--- a/frontend/src/pages/SyllabusSubjectsPage.tsx
+++ b/frontend/src/pages/SyllabusSubjectsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { BookOpen, Plus } from 'flowbite-react-icons/outline';
+import { BookOpen, Plus, Play } from 'flowbite-react-icons/outline';
 import { getSubjectsInSyllabus } from '../api/syllabusApi';
 import type { Subject } from '../types';
 import { ROUTES } from '../constants/routes';
@@ -85,7 +85,7 @@ export default function SyllabusSubjectsPage() {
                   className="btn btn-primary rounded-full px-5 py-2 text-sm shadow-sm shadow-primary/15 inline-flex items-center gap-2"
                   to={ROUTES.subjectBuilder(s.id)}
                 >
-                  <Plus className="w-6 h-6" />
+                  <Play className="w-6 h-6" />
                   Crear examen
                 </Link>
               </div>

--- a/frontend/src/pages/SyllabusSubjectsPage.tsx
+++ b/frontend/src/pages/SyllabusSubjectsPage.tsx
@@ -71,22 +71,24 @@ export default function SyllabusSubjectsPage() {
           {subjects.map((s) => (
             <article
               key={s.id}
-              className="group border border-secondary/25 rounded-2xl bg-card p-6 transition-all hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5"
+              className="group flex flex-col border border-secondary/25 rounded-2xl bg-card p-6 transition-all hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5"
             >
               <div className="w-10 h-10 rounded-xl bg-primary/10 text-primary flex items-center justify-center mb-4 transition-colors group-hover:bg-primary/15">
-                <Plus className="w-5 h-5" />
+                <BookOpen className="w-5 h-5" />
               </div>
               <div className="text-lg font-bold mb-1">{s.name}</div>
               {s.description && (
-                <div className="text-sm text-text/55 mb-5 leading-relaxed">{s.description}</div>
+                <div className="text-sm text-text/55 leading-relaxed">{s.description}</div>
               )}
-              <Link
-                className="btn btn-primary rounded-full px-5 py-2 text-sm shadow-sm shadow-primary/15 inline-flex items-center gap-2"
-                to={ROUTES.subjectBuilder(s.id)}
-              >
-                <Plus className="w-6 h-6" />
-                Crear examen
-              </Link>
+              <div className="mt-auto pt-5 flex justify-end">
+                <Link
+                  className="btn btn-primary rounded-full px-5 py-2 text-sm shadow-sm shadow-primary/15 inline-flex items-center gap-2"
+                  to={ROUTES.subjectBuilder(s.id)}
+                >
+                  <Plus className="w-6 h-6" />
+                  Crear examen
+                </Link>
+              </div>
             </article>
           ))}
         </div>

--- a/frontend/src/pages/SyllabusesPage.tsx
+++ b/frontend/src/pages/SyllabusesPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import { Link } from 'react-router-dom';
-import { BookOpen, Plus, ArrowsRepeat, ClipboardCheck, ChevronLeft, ChevronRight, Play } from 'flowbite-react-icons/outline';
+import { BookOpen, Eye, ArrowsRepeat, ClipboardCheck, ChevronLeft, ChevronRight, Play } from 'flowbite-react-icons/outline';
 import { getSyllabuses } from '../api/syllabusApi';
 import { apiJson, apiBase } from '../api';
 import type { Syllabus, ExamAttemptSummary } from '../types';
@@ -153,17 +153,17 @@ export default function SyllabusesPage({ activeAttemptId, onUnauthorized, onView
                   <div className="flex items-center gap-3">
                     <Link
                       className="btn btn-primary rounded-full px-6 py-2.5 text-sm font-bold shadow-lg shadow-primary/20 flex items-center gap-2 hover:scale-105 transition-transform"
-                      to={ROUTES.syllabusSubjects(s.id)}
-                    >
-                      <Plus className="w-6 h-6" />
-                      Ver temas
-                    </Link>
-                    <Link
-                      className="btn btn-outline rounded-full px-6 py-2.5 text-sm font-bold flex items-center gap-2 hover:scale-105 transition-transform"
                       to={ROUTES.syllabusExamBuilder(s.id)}
                     >
                       <Play className="w-6 h-6" />
                       Crear examen
+                    </Link>
+                    <Link
+                      className="btn btn-secondary rounded-full px-6 py-2.5 text-sm font-bold flex items-center gap-2 hover:scale-105 transition-transform"
+                      to={ROUTES.syllabusSubjects(s.id)}
+                    >
+                      <Eye className="w-6 h-6" />
+                      Ver temas
                     </Link>
                   </div>
                   {s.visibility && (

--- a/openspec/changes/archive/2026-05-06-import-temas/design.md
+++ b/openspec/changes/archive/2026-05-06-import-temas/design.md
@@ -1,0 +1,115 @@
+# Design: Import Temas
+
+## Technical Approach
+
+Reuse the existing question-import pattern in `ManageQuestionController` verbatim: add a
+`POST /api/manage/subjects/import` endpoint directly inside `ManageSubjectController` (no new
+class), parse CSV/JSON in the controller, call `contentService.createSubject(...)` per row,
+and return `{ created, errors: [{ row, message }] }`. On the frontend, duplicate the
+questions import modal state-machine (6 state variables, one async handler) inside
+`Management.tsx` scoped to the Temas tab.
+
+## Architecture Decisions
+
+### Decision: Duplicate detect via in-memory query before save
+**Choice**: Before calling `createSubject`, query `contentService.getSubjectsBySyllabus(syllabusId, ownerId)` and check if a subject with the same trimmed name already exists. Report duplicate as a row error.
+**Alternatives**: DB unique constraint (requires migration); silent skip (forbidden by spec).
+**Rationale**: No DB migration needed; consistent with proposal out-of-scope constraint on upsert. The row limit (500) keeps the in-memory lookup cheap.
+
+### Decision: Row limit enforced before any processing
+**Choice**: Count data rows (excluding header) upfront; return `400` immediately if > 500.
+**Alternatives**: Cap mid-loop (complex error messaging).
+**Rationale**: Matches spec scenario verbatim and mirrors the `MAX_UPLOAD_SIZE` guard pattern already in `ManageQuestionController`.
+
+### Decision: Admin guard via existing `isAdmin()` helper
+**Choice**: `isAdmin(principal)` check from `ManageSubjectController`; return `403` for non-admins trying to import GLOBAL subjects (non-admins import PRIVATE, same logic as `create()`).
+**Alternatives**: Spring Security annotation (`@PreAuthorize`) — not used by any existing controller, so consistency wins.
+**Rationale**: Every other method in `ManageSubjectController` uses the same inline `isAdmin()` guard pattern.
+
+### Decision: Per-row error shape with 1-based row number and message
+**Choice**: `errors: [{ row: int, message: String }]` instead of the current question-import `errors: int`.
+**Alternatives**: Keep int error count (simpler but loses actionable detail).
+**Rationale**: Spec explicitly requires `{ row, message }` per error; the current question import int-count is a known simplification that this change improves upon.
+
+## Data Flow
+
+```
+Browser (FormData: file, format, syllabusId)
+  │
+  ▼
+POST /api/manage/subjects/import   (ManageSubjectController)
+  │
+  ├─ 401 if not authenticated
+  ├─ 403 if non-admin attempts (enforced at visibility assignment, not blanket block)
+  ├─ 400 if file empty / too large / > 500 rows
+  │
+  ├─ parseCsv() / parseJson()  →  List<ImportRow(name, description)>
+  │
+  └─ for each row:
+       ├─ validate name not blank  →  row error
+       ├─ check duplicate in syllabus  →  row error
+       ├─ Subject.createGlobal/createPrivate(name, description, [ownerId,] syllabusId)
+       ├─ contentService.createSubject(subject)
+       └─ created++
+  │
+  ▼
+200 OK: { created: N, errors: [{ row, message }] }
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `backend/src/main/java/com/akdemya/adapter/inbound/web/ManageSubjectController.java` | Modify | Add `POST /import` endpoint, `ImportRow` record, CSV parser, per-row error list |
+| `frontend/src/components/Management.tsx` | Modify | Add subject import state variables (`subjectImportOpen`, `subjectImportFile`, etc.), `handleSubjectImport()` function, "Importar" button in Temas toolbar (visible when `filterSyllabusId && isAdmin`), import modal JSX |
+| `backend/src/test/java/com/akdemya/adapter/inbound/web/ManageSubjectControllerTest.java` | Modify | Add import test cases: valid CSV, non-admin 403, >500 rows 400, partial rows with errors |
+
+No new files. No DB migration.
+
+## Interfaces / Contracts
+
+```
+POST /api/manage/subjects/import
+Content-Type: multipart/form-data
+
+Parameters:
+  file       (required) — CSV or JSON file
+  format     (optional, default "csv") — "csv" | "json"
+  syllabusId (required) — UUID of the target syllabus
+
+CSV format (header row required):
+  name,description
+  "Tema 1","Descripción opcional"
+
+JSON format:
+  [{ "name": "Tema 1", "description": "Desc" }]
+
+Response 200 OK:
+  { "created": 3, "errors": [{ "row": 2, "message": "name_required" }] }
+
+Response 400 Bad Request:
+  { "error": "row_limit_exceeded" }   (> 500 rows)
+  { "error": "file_required" }
+  { "error": "file_too_large" }
+
+Response 401 Unauthorized
+Response 403 Forbidden
+```
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit (controller) | Valid CSV creates N subjects; non-admin gets 403; >500 rows returns 400; blank name row returns row error; duplicate name returns row error | `ManageSubjectControllerTest` — extend existing pattern, mock `ContentManagement` and `UserRepository` |
+| Unit (controller) | JSON format parses correctly | Same test class |
+| Integration | Not required — mirrors question import which has no dedicated integration test | N/A |
+| Frontend | Import button visible only when `isAdmin && filterSyllabusId` selected; disabled submit when no file | Manual / future Vitest component test |
+
+## Migration / Rollout
+
+No migration required. Uses existing `subjects` table. Rollback: revert `@PostMapping("/import")` block in `ManageSubjectController` and remove subject import state/modal from `Management.tsx`.
+
+## Open Questions
+
+- [ ] Should non-admin users be allowed to import PRIVATE subjects? Current proposal is silent on this; the design allows it (non-admins import PRIVATE, same as `create()`). Confirm with product.
+- [ ] Should `syllabusId` be optional (defaulting to no syllabus) or always required? Spec says "syllabusId parameter" without fallback; design treats it as required with a `400` if absent.

--- a/openspec/changes/archive/2026-05-06-import-temas/proposal.md
+++ b/openspec/changes/archive/2026-05-06-import-temas/proposal.md
@@ -1,0 +1,47 @@
+# Proposal: Import Temas
+
+## Intent
+Admins currently add subjects (temas) one by one via the "Gestión de Temas" tab in `Management.tsx`. There is no bulk import, which makes seeding a new syllabus with many subjects slow and error-prone. This change adds CSV/JSON import of subjects into the management page, mirroring the existing question-import pattern.
+
+## Scope
+### In Scope
+- Backend: `POST /api/manage/subjects/import` endpoint accepting CSV/JSON (name, description, syllabusId columns)
+- Frontend: "Importar" button in the Temas tab of `Management.tsx`, opening a modal reusing the existing `DeleteModal`/import-modal pattern
+- Import result feedback: count of created subjects and errors (same shape as question import)
+
+### Out of Scope
+- Importing units or questions as part of subject import
+- Export of subjects
+- Upsert / update-on-conflict logic
+
+## Approach
+Reuse the existing question-import pattern end-to-end:
+- Backend: add `importSubjects(file, format, syllabusId, caller)` to `ContentManagement`, expose via a new `@PostMapping("/import")` in `ManageSubjectController`. Parse CSV rows (name, description) and call the existing `createSubject` for each.
+- Frontend: add an "Importar" button in the subjects tab toolbar; open an inline modal (same structure as the existing questions-import modal in `Management.tsx`) with format selector, file picker, and optional syllabus pre-selection.
+
+## Affected Areas
+| Area | Impact | Description |
+|------|--------|-------------|
+| `backend/.../ManageSubjectController.java` | Modified | Add `POST /api/manage/subjects/import` endpoint |
+| `backend/.../ContentManagement.java` | Modified | Add `importSubjects` use-case method |
+| `frontend/src/components/Management.tsx` | Modified | Add import button + modal to the Temas tab |
+
+## Risks
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Large file causing timeout | Low | Stream rows; cap at 500 subjects per import |
+| Duplicate subject names | Med | Return per-row errors in result; no silent dedup |
+| Visibility escalation (non-admin sets GLOBAL) | Low | Reuse existing `isAdmin` guard in controller |
+
+## Rollback Plan
+- Backend: revert the `@PostMapping("/import")` block in `ManageSubjectController` and the `importSubjects` method in `ContentManagement`. No DB migration needed (uses existing `subjects` table).
+- Frontend: remove the import button and modal state from `Management.tsx`.
+
+## Dependencies
+- Existing `ContentManagement.createSubject` and `ManageSubjectController` must remain stable.
+
+## Success Criteria
+- [ ] `POST /api/manage/subjects/import` with a valid CSV returns `{ created: N, errors: [] }` and subjects appear in `GET /api/manage/subjects`
+- [ ] Importing an invalid row returns a row-level error without aborting the rest
+- [ ] The "Importar" button in the Temas tab is visible only when a syllabus is selected
+- [ ] Non-admin users cannot import GLOBAL subjects via the endpoint

--- a/openspec/changes/archive/2026-05-06-import-temas/specs/subjects-import/spec.md
+++ b/openspec/changes/archive/2026-05-06-import-temas/specs/subjects-import/spec.md
@@ -1,0 +1,140 @@
+# Subjects Import Specification
+
+## Purpose
+
+Allows users to bulk-import subjects (temas) into a syllabus via a CSV or JSON file,
+returning per-row results (created count + errors) without aborting on partial failures.
+Admins can import into any syllabus; non-admin users can only import into syllabuses they own.
+
+---
+
+## Requirements
+
+### Requirement: Backend — Import endpoint
+
+The system MUST expose `POST /api/manage/subjects/import` accepting a multipart file and a
+`syllabusId` parameter. Admins may import into any syllabus. Non-admin users may import only
+into syllabuses they own (PRIVATE syllabuses where `ownerId` matches the authenticated user).
+On success it MUST return `{ created: N, errors: [{ row, message }] }`.
+
+#### Scenario: Valid CSV import creates subjects (admin)
+
+- GIVEN an admin user is authenticated
+- AND a CSV file with 3 valid rows (name, description) is prepared for `syllabusId=42`
+- WHEN `POST /api/manage/subjects/import` is called with the file and `syllabusId=42`
+- THEN the response is `200 OK` with `{ created: 3, errors: [] }`
+- AND the 3 subjects appear in `GET /api/manage/subjects?syllabusId=42`
+
+#### Scenario: Non-admin user imports into their own syllabus
+
+- GIVEN a non-admin user is authenticated
+- AND the `syllabusId` in the request belongs to that user (PRIVATE, ownerId matches)
+- WHEN `POST /api/manage/subjects/import` is called with a valid file
+- THEN the response is `200 OK` with the import results
+- AND the subjects are created as PRIVATE subjects owned by that user
+
+#### Scenario: Non-admin user imports into a syllabus they do not own
+
+- GIVEN a non-admin user is authenticated
+- AND the `syllabusId` in the request belongs to a different user (or does not exist)
+- WHEN `POST /api/manage/subjects/import` is called
+- THEN the response is `403 Forbidden`
+- AND no subjects are created
+
+#### Scenario: Unauthenticated request is rejected
+
+- GIVEN no authentication token is present
+- WHEN `POST /api/manage/subjects/import` is called
+- THEN the response is `401 Unauthorized`
+
+---
+
+### Requirement: Backend — Row limit
+
+The endpoint MUST reject files containing more than 500 rows with a `400 Bad Request`
+before any row is processed.
+
+#### Scenario: File exceeds row limit
+
+- GIVEN an admin submits a CSV file with 501 data rows
+- WHEN the endpoint receives the request
+- THEN the response is `400 Bad Request` with an error message indicating the row limit
+- AND no subjects are created
+
+---
+
+### Requirement: Backend — Per-row error reporting
+
+The endpoint MUST process all rows independently. A validation failure on one row MUST NOT
+abort processing of subsequent rows. Invalid rows MUST be reported in the `errors` array
+with their 1-based row number and a human-readable message.
+
+#### Scenario: Partial import with one invalid row
+
+- GIVEN a CSV file with 3 rows where row 2 has a blank `name` field
+- WHEN `POST /api/manage/subjects/import` is called
+- THEN the response is `200 OK` with `{ created: 2, errors: [{ row: 2, message: "..." }] }`
+- AND the 2 valid subjects are persisted
+
+#### Scenario: Duplicate subject name in same syllabus
+
+- GIVEN a subject named "Tema A" already exists in `syllabusId=42`
+- AND the import file contains a row with `name=Tema A` for the same syllabus
+- WHEN `POST /api/manage/subjects/import` is called
+- THEN the duplicate row is included in `errors` with a message indicating duplication
+- AND the row is NOT created (no silent upsert)
+
+---
+
+### Requirement: Frontend — Import button visibility
+
+The Temas tab in the Management page MUST display an "Importar" button only when the admin
+has a syllabus selected. The button MUST NOT be visible to non-admin users.
+
+#### Scenario: Admin sees import button when syllabus is selected
+
+- GIVEN the user is an admin and a syllabus is selected in the Temas tab
+- WHEN the Temas tab is rendered
+- THEN the "Importar" button is visible
+
+#### Scenario: Button hidden when no syllabus selected
+
+- GIVEN the admin has not yet selected a syllabus
+- WHEN the Temas tab is rendered
+- THEN the "Importar" button is not visible
+
+#### Scenario: Non-admin does not see import button
+
+- GIVEN the user is not an admin
+- WHEN the Temas tab is rendered
+- THEN the "Importar" button is not present in the UI
+
+---
+
+### Requirement: Frontend — Import modal flow
+
+The import modal MUST allow the user to select a format (CSV or JSON), pick a file, and
+submit. After submission the modal MUST display the result: total created count and a list
+of row-level errors if any. The modal MUST prevent resubmission while a request is in flight.
+
+#### Scenario: Successful import shows result summary
+
+- GIVEN the admin opens the import modal with a syllabus selected
+- AND uploads a valid CSV file
+- WHEN the user clicks "Importar"
+- THEN a loading state is shown while the request is in flight
+- AND on success the modal displays "Subjects creados: N" with an empty errors section
+
+#### Scenario: Partial import shows errors inline
+
+- GIVEN the admin submits a file with 2 valid rows and 1 invalid row
+- WHEN the response returns `{ created: 2, errors: [{ row: 3, message: "..." }] }`
+- THEN the modal displays "Subjects creados: 2" and lists the row-3 error message
+- AND the modal does not close automatically
+
+#### Scenario: No file selected — submit disabled
+
+- GIVEN the import modal is open
+- AND no file has been picked
+- WHEN the user views the modal
+- THEN the "Importar" button is disabled

--- a/openspec/changes/archive/2026-05-06-import-temas/tasks.md
+++ b/openspec/changes/archive/2026-05-06-import-temas/tasks.md
@@ -1,0 +1,33 @@
+# Tasks: Import Temas
+
+## Phase 1: Backend Implementation
+
+- [x] 1.1 Add `ImportSubjectRow` record and `importSubjects()` method stub to `ManageSubjectController.java` — record fields: `String name, String description`; method signature: `@PostMapping(value = "/import", consumes = "multipart/form-data") public ResponseEntity<Object> importSubjects(@RequestParam("file") MultipartFile file, @RequestParam(defaultValue = "csv") String format, @RequestParam UUID syllabusId, @AuthenticationPrincipal User principal)`
+
+- [x] 1.2 Add guard clauses to `importSubjects()` in `ManageSubjectController.java`: null principal → 401; empty file → 400 `file_required`; file > 10 MB → 400 `file_too_large`; null/missing `syllabusId` → 400 `syllabusId_required`. Reuse the `MAX_UPLOAD_SIZE` constant already in `ManageQuestionController` — copy it into `ManageSubjectController`.
+
+- [x] 1.3 Add CSV parser and JSON parser to `importSubjects()` in `ManageSubjectController.java`. Reuse the `parseCsv()` pattern from `ManageQuestionController`. Count data rows (excluding header); if > 500 return 400 `row_limit_exceeded` before processing any row.
+
+- [x] 1.4 Add per-row processing loop to `importSubjects()` in `ManageSubjectController.java`: validate name not blank; query `contentService.getSubjectsByScope(callerId, isAdmin, visibility)` to detect duplicate name in syllabusId; call `Subject.createGlobal(name, desc, syllabusId)` for admins or `Subject.createPrivate(name, desc, callerId, syllabusId)` for non-admins; call `contentService.createSubject(subject)`; accumulate `List<Map<String,Object>> errors` with `{row, message}` entries and `int created` counter. Return `200 OK: { created, errors }`.
+
+## Phase 2: Frontend Implementation
+
+- [x] 2.1 Add six subject-import state variables to `Management.tsx` after the existing `importDone` / `importStats` block (lines 172–178): `subjectImportOpen`, `subjectImportFile`, `subjectImportFormat`, `subjectImportLoading`, `subjectImportMessage`, `subjectImportResult` (type `{ created: number; errors: { row: number; message: string }[] } | null`).
+
+- [x] 2.2 Add `handleSubjectImport()` async function to `Management.tsx` (after `handleImport()`): build `FormData` with `file`, `format`, and `syllabusId=filterSyllabusId`; `POST` to `/api/manage/subjects/import`; set `subjectImportResult` from response; call `loadSubjects()` on success. Block resubmission while `subjectImportLoading` is true.
+
+- [x] 2.3 Add "Importar" button to the Temas tab toolbar in `Management.tsx` (inside the `tab === 'subjects'` block, in the `flex items-center justify-between` header div at line ~417). Render only when `isAdmin && filterSyllabusId`. Use `btnOutline` class with `<FileImport className="w-6 h-6" />` icon. On click: set `subjectImportOpen(true)`.
+
+- [x] 2.4 Add subject import modal JSX to `Management.tsx` (at the bottom of the `tab === 'subjects'` section, mirroring the questions import modal pattern). Include: format selector (csv/json), file input (disabled submit when no file), loading state, result summary showing "Subjects creados: N" and inline error list. Modal closes only via explicit cancel/close button, not automatically on success.
+
+## Phase 3: Testing
+
+- [x] 3.1 Add test `importSubjectsValidCsvCreatesSubjects` to `ManageSubjectControllerTest.java`: admin principal, 3-row CSV for `syllabusId=UUID`, mock `contentService.getSubjectsByScope` to return empty list (no duplicates), mock `contentService.createSubject` to return subject — assert `200 OK`, `created=3`, `errors` empty. Covers spec scenario "Valid CSV import creates subjects".
+
+- [x] 3.2 Add test `importSubjectsNonAdminReturnsForbidden` to `ManageSubjectControllerTest.java`: non-admin principal — verify `403 Forbidden` and `contentService.createSubject` never called. Covers spec scenario "Non-admin user is rejected".
+
+- [x] 3.3 Add test `importSubjectsExceedingRowLimitReturnsBadRequest` to `ManageSubjectControllerTest.java`: admin, CSV with 501 data rows — assert `400 Bad Request` with `error=row_limit_exceeded`, `createSubject` never called. Covers spec scenario "File exceeds row limit".
+
+- [x] 3.4 Add test `importSubjectsPartialErrorReportsRowErrors` to `ManageSubjectControllerTest.java`: admin, 3-row CSV where row 2 has blank name — assert `200 OK`, `created=2`, `errors` list contains one entry with `row=2`. Covers spec scenario "Partial import with one invalid row".
+
+- [x] 3.5 Add test `importSubjectsDuplicateNameReportsRowError` to `ManageSubjectControllerTest.java`: admin, 1-row CSV with name "Tema A", mock `contentService.getSubjectsByScope` to return a subject named "Tema A" — assert `200 OK`, `created=0`, `errors` list has one entry. Covers spec scenario "Duplicate subject name in same syllabus".

--- a/openspec/changes/archive/2026-05-06-import-temas/verify-report.md
+++ b/openspec/changes/archive/2026-05-06-import-temas/verify-report.md
@@ -1,0 +1,106 @@
+## Verification Report
+
+**Change**: import-temas
+**Verified**: 2026-05-06 (re-run after ownership fix)
+
+---
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 10 |
+| Tasks complete | 10 |
+| Tasks incomplete | 0 |
+
+All 10 tasks in phases 1–3 are marked `[x]`.
+
+---
+
+### Build & Tests
+
+**Backend Tests**: ✅ 27 passed / 0 failed / 0 skipped
+**Frontend TypeScript**: ✅ No errors (exit 0)
+
+Backend test run: `./gradlew test --tests "*ManageSubjectControllerTest"` — BUILD SUCCESSFUL in 13s.
+TS check: `npx tsc --noEmit` — no output, exit 0.
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| Backend — Import endpoint | Valid CSV import creates subjects (admin) | `importSubjectsValidCsvCreatesSubjects` | ✅ |
+| Backend — Import endpoint | Non-admin user imports into their own syllabus | `importSubjectsNonAdminEmptyFileReturnsBadRequest` (partial: tests guard ordering, not full success path) | ⚠️ |
+| Backend — Import endpoint | Non-admin imports into syllabus they do not own (403) | `importSubjects_nonOwnerSyllabus_returnsForbidden` | ✅ |
+| Backend — Import endpoint | Unauthenticated request rejected (401) | No dedicated test — deferred to Spring Security filter (consistent with all other endpoints) | ⚠️ |
+| Backend — Row limit | File exceeds row limit (501 rows → 400) | `importSubjectsExceedingRowLimitReturnsBadRequest` | ✅ |
+| Backend — Per-row error reporting | Partial import with one invalid row | `importSubjectsPartialErrorReportsRowErrors` | ✅ |
+| Backend — Per-row error reporting | Duplicate subject name in same syllabus | `importSubjectsDuplicateNameReportsRowError` | ✅ |
+| Frontend — Import button visibility | Admin sees button when syllabus selected | Code confirmed: `{isAdmin && filterSyllabusId && <button>Importar</button>}` | ✅ |
+| Frontend — Import button visibility | Button hidden when no syllabus selected | Code confirmed: guarded by `filterSyllabusId` | ✅ |
+| Frontend — Import button visibility | Non-admin does not see import button | Code confirmed: guarded by `isAdmin` | ✅ |
+| Frontend — Import modal flow | Successful import shows result summary | Code confirmed: sets `subjectImportMessage` to `Temas creados: N` | ✅ |
+| Frontend — Import modal flow | Partial import shows errors inline | Code confirmed: renders `errors.map(err => <li>Fila {err.row}: {err.message}</li>)` | ✅ |
+| Frontend — Import modal flow | No file selected — submit disabled | Code confirmed: `disabled={subjectImportLoading \|\| !subjectImportFile}` | ✅ |
+
+**Compliance**: 11/13 scenarios fully verified (2 warnings — see Issues below)
+
+---
+
+### Correctness (Static)
+
+| Requirement | Status | Notes |
+|-------------|--------|-------|
+| Ownership check: non-admin 403 for foreign syllabus | ✅ | `contentService.getSyllabusById(syllabusId)` → check `caller.getId().equals(syllabus.getOwnerId())`; returns 403 if null or not owner |
+| Row limit enforced before processing | ✅ | `dataRowCount > MAX_IMPORT_ROWS` check before loop |
+| Blank name reported as row error, no abort | ✅ | `if (name.isEmpty()) { errors.add(...); continue; }` |
+| Duplicate detection scoped to syllabusId | ✅ | Pre-loads subjects, filters by `syllabusId.equals(s.getSyllabusId())` |
+| Created names added to in-memory set | ✅ | `existingNames.add(name.toLowerCase())` after each successful create — prevents intra-file dupes |
+| JSON format supported | ✅ | `else` branch parses `ImportSubjectRow[]` via Jackson |
+| 1-based row numbers in error list | ✅ | `int rowNum = i;` (i starts at 1 for CSV; `i + 1` for JSON) |
+| `syllabusId` null check is redundant | ⚠️ | `@RequestParam UUID syllabusId` — Spring rejects null with 400 before method body; explicit null check at line 186 is unreachable dead code (harmless) |
+| `format` and `syllabusId` passed as query params | ✅ | Frontend sends `?format=...&syllabusId=...`; Spring `@RequestParam` binds from both multipart form fields and query string |
+| Modal closes only via explicit cancel | ✅ | No `setSubjectImportOpen(false)` on success path; only on cancel button click |
+| `loadSubjects()` and `onSubjectsChanged()` called after success | ✅ | Both called after `res.ok` check |
+| Spec says "Subjects creados: N" but UI shows "Temas creados: N" | ⚠️ | Minor wording deviation — "Temas" is the Spanish term used throughout the app; functionally correct |
+
+---
+
+### Coherence (Design)
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| No new classes — all changes in existing files | ✅ | `ManageSubjectController.java`, `Management.tsx`, `ManageSubjectControllerTest.java` only |
+| No DB migration | ✅ | Uses existing `subjects` table |
+| Inline `isAdmin()` guard (not `@PreAuthorize`) | ✅ | Consistent with all other methods in the controller |
+| `{ row, message }` error shape (not int count) | ✅ | Implemented as `List<Map<String,Object>> errors` with `row` and `message` keys |
+| Duplicate detect via in-memory query before save | ✅ | Single `getSubjectsByScope` call before loop; no N+1 |
+| Non-admins import PRIVATE subjects into own syllabus only | ✅ | Ownership check added; non-admins get 403 for foreign syllabuses; for own syllabus they import PRIVATE |
+| Row limit: 500 (MAX_IMPORT_ROWS constant) | ✅ | Constant defined, matches spec |
+| File size limit: 10 MB (MAX_UPLOAD_SIZE constant) | ✅ | Constant defined |
+
+---
+
+### Issues Found
+
+**WARNING 1**: Spec scenario "Non-admin user imports into their own syllabus" (success path) is only partially covered.
+`importSubjectsNonAdminEmptyFileReturnsBadRequest` tests the empty-file guard (400) for a non-admin, not the happy-path where a non-admin with a valid file and owned syllabus gets a 200 with subjects created as PRIVATE. The ownership check fires after the file guard, so the new test (`importSubjects_nonOwnerSyllabus_returnsForbidden`) only validates the 403 path. A complementary test for the non-admin success path (own syllabus, valid file) would give full coverage.
+
+**WARNING 2**: Spec scenario "Unauthenticated request is rejected (401)" has no controller-level test.
+The design defers this to the Spring Security filter chain, which is consistent with every other endpoint in the project. The existing `nullPrincipalReturnsUnauthorized` test covers the defensive null-check in the controller body (not the filter). Acceptable, but worth noting.
+
+**SUGGESTION**: The `if (syllabusId == null)` guard at line 186 of `ManageSubjectController` is dead code — Spring's `@RequestParam UUID syllabusId` will throw a `MissingServletRequestParameterException` (400) before the method body is entered if `syllabusId` is absent. It can be removed safely on a future cleanup pass.
+
+**SUGGESTION**: The message "Temas creados: N" diverges from the spec's "Subjects creados: N". The Spanish version is more consistent with the app's UI language and is not a functional issue.
+
+---
+
+### Verdict
+
+**PASS WITH WARNINGS**
+
+Implementation is complete (10/10 tasks), all 27 backend tests pass (including the new `importSubjects_nonOwnerSyllabus_returnsForbidden` test), TypeScript compiles cleanly. The ownership check is correctly implemented and tested. All critical scenarios are covered. The two warnings are minor: one is a missing happy-path test for the non-admin success scenario (low risk given the logic is shared with the admin path), and one is a known architectural decision (auth delegated to filter). No blocking issues found.
+
+**Recommended next step**: `/sdd-archive import-temas` — sync the spec to reflect the final non-admin ownership semantics and archive the change.

--- a/openspec/specs/subjects-import/spec.md
+++ b/openspec/specs/subjects-import/spec.md
@@ -1,0 +1,140 @@
+# Subjects Import Specification
+
+## Purpose
+
+Allows users to bulk-import subjects (temas) into a syllabus via a CSV or JSON file,
+returning per-row results (created count + errors) without aborting on partial failures.
+Admins can import into any syllabus; non-admin users can only import into syllabuses they own.
+
+---
+
+## Requirements
+
+### Requirement: Backend — Import endpoint
+
+The system MUST expose `POST /api/manage/subjects/import` accepting a multipart file and a
+`syllabusId` parameter. Admins may import into any syllabus. Non-admin users may import only
+into syllabuses they own (PRIVATE syllabuses where `ownerId` matches the authenticated user).
+On success it MUST return `{ created: N, errors: [{ row, message }] }`.
+
+#### Scenario: Valid CSV import creates subjects (admin)
+
+- GIVEN an admin user is authenticated
+- AND a CSV file with 3 valid rows (name, description) is prepared for `syllabusId=42`
+- WHEN `POST /api/manage/subjects/import` is called with the file and `syllabusId=42`
+- THEN the response is `200 OK` with `{ created: 3, errors: [] }`
+- AND the 3 subjects appear in `GET /api/manage/subjects?syllabusId=42`
+
+#### Scenario: Non-admin user imports into their own syllabus
+
+- GIVEN a non-admin user is authenticated
+- AND the `syllabusId` in the request belongs to that user (PRIVATE, ownerId matches)
+- WHEN `POST /api/manage/subjects/import` is called with a valid file
+- THEN the response is `200 OK` with the import results
+- AND the subjects are created as PRIVATE subjects owned by that user
+
+#### Scenario: Non-admin user imports into a syllabus they do not own
+
+- GIVEN a non-admin user is authenticated
+- AND the `syllabusId` in the request belongs to a different user (or does not exist)
+- WHEN `POST /api/manage/subjects/import` is called
+- THEN the response is `403 Forbidden`
+- AND no subjects are created
+
+#### Scenario: Unauthenticated request is rejected
+
+- GIVEN no authentication token is present
+- WHEN `POST /api/manage/subjects/import` is called
+- THEN the response is `401 Unauthorized`
+
+---
+
+### Requirement: Backend — Row limit
+
+The endpoint MUST reject files containing more than 500 rows with a `400 Bad Request`
+before any row is processed.
+
+#### Scenario: File exceeds row limit
+
+- GIVEN an admin submits a CSV file with 501 data rows
+- WHEN the endpoint receives the request
+- THEN the response is `400 Bad Request` with an error message indicating the row limit
+- AND no subjects are created
+
+---
+
+### Requirement: Backend — Per-row error reporting
+
+The endpoint MUST process all rows independently. A validation failure on one row MUST NOT
+abort processing of subsequent rows. Invalid rows MUST be reported in the `errors` array
+with their 1-based row number and a human-readable message.
+
+#### Scenario: Partial import with one invalid row
+
+- GIVEN a CSV file with 3 rows where row 2 has a blank `name` field
+- WHEN `POST /api/manage/subjects/import` is called
+- THEN the response is `200 OK` with `{ created: 2, errors: [{ row: 2, message: "..." }] }`
+- AND the 2 valid subjects are persisted
+
+#### Scenario: Duplicate subject name in same syllabus
+
+- GIVEN a subject named "Tema A" already exists in `syllabusId=42`
+- AND the import file contains a row with `name=Tema A` for the same syllabus
+- WHEN `POST /api/manage/subjects/import` is called
+- THEN the duplicate row is included in `errors` with a message indicating duplication
+- AND the row is NOT created (no silent upsert)
+
+---
+
+### Requirement: Frontend — Import button visibility
+
+The Temas tab in the Management page MUST display an "Importar" button only when the admin
+has a syllabus selected. The button MUST NOT be visible to non-admin users.
+
+#### Scenario: Admin sees import button when syllabus is selected
+
+- GIVEN the user is an admin and a syllabus is selected in the Temas tab
+- WHEN the Temas tab is rendered
+- THEN the "Importar" button is visible
+
+#### Scenario: Button hidden when no syllabus selected
+
+- GIVEN the admin has not yet selected a syllabus
+- WHEN the Temas tab is rendered
+- THEN the "Importar" button is not visible
+
+#### Scenario: Non-admin does not see import button
+
+- GIVEN the user is not an admin
+- WHEN the Temas tab is rendered
+- THEN the "Importar" button is not present in the UI
+
+---
+
+### Requirement: Frontend — Import modal flow
+
+The import modal MUST allow the user to select a format (CSV or JSON), pick a file, and
+submit. After submission the modal MUST display the result: total created count and a list
+of row-level errors if any. The modal MUST prevent resubmission while a request is in flight.
+
+#### Scenario: Successful import shows result summary
+
+- GIVEN the admin opens the import modal with a syllabus selected
+- AND uploads a valid CSV file
+- WHEN the user clicks "Importar"
+- THEN a loading state is shown while the request is in flight
+- AND on success the modal displays "Subjects creados: N" with an empty errors section
+
+#### Scenario: Partial import shows errors inline
+
+- GIVEN the admin submits a file with 2 valid rows and 1 invalid row
+- WHEN the response returns `{ created: 2, errors: [{ row: 3, message: "..." }] }`
+- THEN the modal displays "Subjects creados: 2" and lists the row-3 error message
+- AND the modal does not close automatically
+
+#### Scenario: No file selected — submit disabled
+
+- GIVEN the import modal is open
+- AND no file has been picked
+- WHEN the user views the modal
+- THEN the "Importar" button is disabled


### PR DESCRIPTION
## Summary

- Adds `POST /api/manage/subjects/import` endpoint supporting CSV and JSON file uploads
- Non-admin users can only import into syllabuses they own (403 otherwise); admins can import to any syllabus
- Row limit of 500 per request enforced upfront; per-row errors returned as `[{row, message}]`
- Frontend adds import button (visible when admin + syllabus selected) and full import modal in `Management.tsx`

## Changes

| File | Change |
|------|--------|
| `ManageSubjectController.java` | New `POST /import` endpoint with ownership guard, CSV/JSON parser, duplicate detection |
| `ManageSubjectControllerTest.java` | 6 new tests covering happy path, row limit, blank name, duplicate, non-owner 403 |
| `Management.tsx` | Import button + modal with format selector, file picker, loading state, per-row error list |

## Test plan

- [x] 27/27 backend tests pass (`./gradlew test --tests "*ManageSubjectControllerTest"`)
- [x] TypeScript compiles with 0 errors (`tsc --noEmit`)
- [ ] Manual: login as admin, select a syllabus, click Importar, upload CSV → subjects created
- [ ] Manual: login as non-admin, select own syllabus, upload CSV → subjects created
- [ ] Manual: login as non-admin, attempt import to a foreign syllabus → 403 error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)