### PR TITLE
🐛 fix: correcciones de la revisión completa del código (auth, pagos, concurrencia)

### DIFF
--- a/backend/src/main/java/com/akdemya/adapter/inbound/web/AuthController.java
+++ b/backend/src/main/java/com/akdemya/adapter/inbound/web/AuthController.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -40,7 +41,16 @@ public class AuthController {
 
     @PostMapping("/register")
     public ResponseEntity<Map<String, String>> register(@Valid @RequestBody AuthUseCase.RegisterCommand req, HttpServletResponse res) {
-        var response = authUseCase.register(req);
+        AuthUseCase.AuthResponse response;
+        try {
+            response = authUseCase.register(req);
+        } catch (DataIntegrityViolationException e) {
+            // Two concurrent registrations can both pass the existsByEmail
+            // check; the loser hits uq_users_email at commit. The only unique
+            // constraint reachable from this flow is the email one, so map it
+            // to the same error the pre-check returns instead of a 500.
+            return ResponseEntity.badRequest().body(Map.of("error", "email_in_use"));
+        }
         if (response.error() != null) {
             return ResponseEntity.badRequest().body(Map.of("error", response.error()));
         }

--- a/backend/src/main/java/com/akdemya/adapter/inbound/web/ManageQuestionController.java
+++ b/backend/src/main/java/com/akdemya/adapter/inbound/web/ManageQuestionController.java
@@ -13,6 +13,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,13 +30,16 @@ public class ManageQuestionController {
   private final ContentManagement contentService;
   private final AnswerRepository answerRepo;
   private final UserRepository userRepo;
+  private final TransactionTemplate txTemplate;
 
   public ManageQuestionController(ContentManagement contentService,
                                    AnswerRepository answerRepo,
-                                   UserRepository userRepo) {
+                                   UserRepository userRepo,
+                                   PlatformTransactionManager transactionManager) {
     this.contentService = contentService;
     this.answerRepo = answerRepo;
     this.userRepo = userRepo;
+    this.txTemplate = new TransactionTemplate(transactionManager);
   }
 
   @GetMapping
@@ -241,7 +246,7 @@ public class ManageQuestionController {
         try {
           ImportRow row = csvToImportRow(rows.get(i), unitId);
           if (row == null) { errors++; continue; }
-          saveImportedQuestion(row, importVisibility, importOwner);
+          saveImportedQuestionAtomically(row, importVisibility, importOwner);
           created++;
         } catch (Exception e) {
           errors++;
@@ -255,7 +260,7 @@ public class ManageQuestionController {
             row.difficulty(), row.answers()) : row;
         if (effective.unitId() == null || effective.text() == null) { errors++; continue; }
         try {
-          saveImportedQuestion(effective, importVisibility, importOwner);
+          saveImportedQuestionAtomically(effective, importVisibility, importOwner);
           created++;
         } catch (Exception e) {
           errors++;
@@ -263,6 +268,17 @@ public class ManageQuestionController {
       }
     }
     return ResponseEntity.ok(java.util.Map.of("created", created, "errors", errors));
+  }
+
+  /**
+   * Saves one imported row (question + its answers) in its own transaction.
+   * Without this, an answer-save failure left an orphan question committed
+   * (the row was counted as an error but the question stayed in the DB,
+   * because {@code createQuestion} committed in its own transaction before
+   * the answers were written).
+   */
+  private void saveImportedQuestionAtomically(ImportRow row, Visibility visibility, UUID ownerId) {
+    txTemplate.executeWithoutResult(tx -> saveImportedQuestion(row, visibility, ownerId));
   }
 
   private void saveImportedQuestion(ImportRow row, Visibility visibility, UUID ownerId) {

--- a/backend/src/main/java/com/akdemya/adapter/inbound/web/ManageQuestionController.java
+++ b/backend/src/main/java/com/akdemya/adapter/inbound/web/ManageQuestionController.java
@@ -27,6 +27,9 @@ import java.util.function.Function;
 @RequestMapping("/api/manage/questions")
 public class ManageQuestionController {
 
+  private static final org.slf4j.Logger log =
+      org.slf4j.LoggerFactory.getLogger(ManageQuestionController.class);
+
   private final ContentManagement contentService;
   private final AnswerRepository answerRepo;
   private final UserRepository userRepo;
@@ -296,7 +299,14 @@ public class ManageQuestionController {
     sb.append("unitId,text,explanation,difficulty,answer1,answer2,answer3,answer4,correctIndex\n");
     for (Question q : data) {
       List<Answer> list = answerRepo.findByQuestionId(q.getId());
-      if (list.size() != 4) continue;
+      if (list.size() != 4) {
+        // The CSV format has fixed answer1..answer4 columns, so questions
+        // with a different answer count cannot be represented. Log instead
+        // of dropping them silently so exports are auditable.
+        log.warn("CSV export: skipping question {} — has {} answers, format requires 4",
+            q.getId(), list.size());
+        continue;
+      }
       int correct = 1;
       for (int i = 0; i < list.size(); i++) { if (list.get(i).isCorrect()) correct = i + 1; }
       sb.append(escape(q.getUnitId().toString())).append(',')

--- a/backend/src/main/java/com/akdemya/adapter/infrastructure/scheduler/PurchaseReconciliationScheduler.java
+++ b/backend/src/main/java/com/akdemya/adapter/infrastructure/scheduler/PurchaseReconciliationScheduler.java
@@ -29,10 +29,11 @@ import java.util.Optional;
  *       PaymentIntent status. {@code succeeded} → delegate to
  *       {@link PurchaseService#settlePaidPurchase(String)} (idempotent: shares
  *       the same {@code markPaid + email + updateEmailSentAt} flow used by the
- *       webhook). {@code canceled}/{@code payment_failed} →
- *       {@link PurchaseRepository#markFailed(String)}. Other statuses
- *       ({@code processing}, {@code requires_action}, etc.) are left PENDING
- *       and re-checked next tick.</li>
+ *       webhook). {@code canceled} → {@link PurchaseRepository#markFailed(String)}.
+ *       {@code requires_payment_method}/{@code requires_confirmation}/
+ *       {@code requires_action} older than 24h → cancel at Stripe, then mark
+ *       FAILED. Other statuses ({@code processing}, recent retryable ones) are
+ *       left PENDING and re-checked next tick.</li>
  *   <li><b>Function B — email retries</b>: delegates to
  *       {@link ReconciliationService#retryFailedEmails(Instant)} with a
  *       5-minute grace cutoff to avoid racing with the webhook handler.</li>
@@ -48,6 +49,15 @@ public class PurchaseReconciliationScheduler {
 
   private static final Duration PENDING_AGE_CUTOFF = Duration.ofHours(1);
   private static final Duration EMAIL_RETRY_GRACE = Duration.ofMinutes(5);
+
+  /**
+   * Age after which a still-unpaid PaymentIntent is considered abandoned and
+   * is canceled at Stripe + marked FAILED. A failed card attempt sends the
+   * intent back to {@code requires_payment_method} (there is no
+   * {@code payment_failed} status), so without this cutoff abandoned
+   * purchases would stay PENDING and be re-polled forever.
+   */
+  private static final Duration ABANDONED_CUTOFF = Duration.ofHours(24);
 
   private final PurchaseRepository purchaseRepository;
   private final StripePaymentGateway stripeGateway;
@@ -99,21 +109,38 @@ public class PurchaseReconciliationScheduler {
         String status = maybeSnapshot.get().status();
         switch (status) {
           case "succeeded" -> purchaseService.settlePaidPurchase(piId);
-          case "canceled", "payment_failed" -> {
-            int rows = purchaseRepository.markFailed(piId);
-            if (rows == 1) {
-              log.info("Reconciliation: marked Purchase as FAILED for paymentIntent={}", piId);
+          case "canceled" -> markFailed(piId);
+          // A failed or never-attempted payment leaves the intent in one of
+          // these states ("payment_failed" is an event type, not a status).
+          // The customer may still complete payment from an open tab, so only
+          // give up after ABANDONED_CUTOFF — and cancel at Stripe FIRST, so
+          // the intent can no longer succeed once we mark the purchase FAILED.
+          case "requires_payment_method", "requires_confirmation", "requires_action" -> {
+            if (purchase.getCreatedAt().isBefore(Instant.now().minus(ABANDONED_CUTOFF))) {
+              stripeGateway.cancel(piId);
+              markFailed(piId);
             } else {
-              log.info("Reconciliation: idempotent FAILED transition for paymentIntent={}", piId);
+              log.info("Reconciliation: piId={} status={} — within abandonment window, leaving PENDING",
+                  piId, status);
             }
           }
-          default -> log.warn("Reconciliation: skipping piId={} — unhandled status={}",
+          // "processing" and any future statuses: leave PENDING, re-check next tick.
+          default -> log.info("Reconciliation: skipping piId={} — status={} not final",
               piId, status);
         }
       } catch (RuntimeException ex) {
         log.error("Reconciliation: error processing piId={} purchaseId={}: {}",
             piId, purchase.getId(), ex.getMessage(), ex);
       }
+    }
+  }
+
+  private void markFailed(String piId) {
+    int rows = purchaseRepository.markFailed(piId);
+    if (rows == 1) {
+      log.info("Reconciliation: marked Purchase as FAILED for paymentIntent={}", piId);
+    } else {
+      log.info("Reconciliation: idempotent FAILED transition for paymentIntent={}", piId);
     }
   }
 

--- a/backend/src/main/java/com/akdemya/adapter/infrastructure/security/OAuth2CodeStore.java
+++ b/backend/src/main/java/com/akdemya/adapter/infrastructure/security/OAuth2CodeStore.java
@@ -13,8 +13,12 @@ public class OAuth2CodeStore {
     private final ConcurrentHashMap<String, CodeEntry> codes = new ConcurrentHashMap<>();
 
     public String store(String jwt, String refreshToken, String role) {
+        Instant now = Instant.now();
+        // Codes are only removed on exchange; purge expired ones here so
+        // abandoned logins don't accumulate forever.
+        codes.values().removeIf(entry -> now.isAfter(entry.expiresAt));
         String code = UUID.randomUUID().toString();
-        codes.put(code, new CodeEntry(jwt, refreshToken, role, Instant.now().plusSeconds(60)));
+        codes.put(code, new CodeEntry(jwt, refreshToken, role, now.plusSeconds(60)));
         return code;
     }
 

--- a/backend/src/main/java/com/akdemya/adapter/infrastructure/security/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/akdemya/adapter/infrastructure/security/OAuth2SuccessHandler.java
@@ -1,6 +1,7 @@
 package com.akdemya.adapter.infrastructure.security;
 
 import com.akdemya.domain.port.in.AuthUseCase;
+import org.springframework.dao.DataIntegrityViolationException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
@@ -35,7 +36,15 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         OAuth2User oAuth2User = token.getPrincipal();
         String email = oAuth2User.getAttribute("email");
         String name  = oAuth2User.getAttribute("name");
-        AuthUseCase.AuthResponse authResponse = authUseCase.loginWithOAuth2(email, name);
+        AuthUseCase.AuthResponse authResponse;
+        try {
+            authResponse = authUseCase.loginWithOAuth2(email, name);
+        } catch (DataIntegrityViolationException e) {
+            // Two concurrent first logins for the same account can both pass
+            // the findByEmail check; the loser hits uq_users_email at commit.
+            // The user exists now, so one retry takes the existing-user path.
+            authResponse = authUseCase.loginWithOAuth2(email, name);
+        }
         String code = codeStore.store(authResponse.accessToken(), authResponse.refreshToken(), authResponse.role());
         response.sendRedirect(frontendUrl + "/oauth2/callback?code=" + code);
     }

--- a/backend/src/main/java/com/akdemya/adapter/infrastructure/security/RateLimitFilter.java
+++ b/backend/src/main/java/com/akdemya/adapter/infrastructure/security/RateLimitFilter.java
@@ -14,6 +14,10 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class RateLimitFilter extends OncePerRequestFilter {
 
+    // Hard cap on tracked IPs so an attacker rotating spoofed addresses
+    // cannot grow the bucket maps without bound.
+    private static final int MAX_TRACKED_IPS = 10_000;
+
     private final int loginRequestsPerMinute;
     private final int registerRequestsPerMinute;
 
@@ -42,6 +46,11 @@ public class RateLimitFilter extends OncePerRequestFilter {
 
     private boolean tryConsume(ConcurrentHashMap<String, Bucket> buckets, String ip, int limit,
                                 HttpServletResponse response) throws IOException {
+        if (buckets.size() >= MAX_TRACKED_IPS) {
+            // Crude but bounded: dropping all buckets briefly resets limits,
+            // which is preferable to unbounded memory growth.
+            buckets.clear();
+        }
         Bucket bucket = buckets.computeIfAbsent(ip, k -> buildBucket(limit));
         if (bucket.tryConsume(1)) {
             return true;
@@ -65,7 +74,13 @@ public class RateLimitFilter extends OncePerRequestFilter {
     private String resolveClientIp(HttpServletRequest request) {
         String forwarded = request.getHeader("X-Forwarded-For");
         if (forwarded != null && !forwarded.isBlank()) {
-            return forwarded.split(",")[0].trim();
+            // The rightmost entry is the one appended by our own reverse
+            // proxy (nginx with proxy_add_x_forwarded_for) and is the only
+            // value the client cannot forge. Leftmost entries are
+            // client-controlled and would let an attacker bypass the limit
+            // by sending a different fake IP on every request.
+            String[] hops = forwarded.split(",");
+            return hops[hops.length - 1].trim();
         }
         return request.getRemoteAddr();
     }

--- a/backend/src/main/java/com/akdemya/adapter/infrastructure/stripe/StripePaymentAdapter.java
+++ b/backend/src/main/java/com/akdemya/adapter/infrastructure/stripe/StripePaymentAdapter.java
@@ -95,4 +95,20 @@ public class StripePaymentAdapter implements StripePaymentGateway {
       throw new RuntimeException("Failed to retrieve Stripe PaymentIntent", ex);
     }
   }
+
+  @Override
+  public void cancel(String paymentIntentId) {
+    if (paymentIntentId == null || paymentIntentId.isBlank()) {
+      throw new IllegalArgumentException("paymentIntentId cannot be blank");
+    }
+    try {
+      PaymentIntent intent = PaymentIntent.retrieve(paymentIntentId);
+      intent.cancel();
+      log.info("Canceled Stripe PaymentIntent {}", paymentIntentId);
+    } catch (StripeException ex) {
+      log.error("Stripe PaymentIntent.cancel failed for paymentIntentId={}: {}",
+          paymentIntentId, ex.getMessage(), ex);
+      throw new RuntimeException("Failed to cancel Stripe PaymentIntent", ex);
+    }
+  }
 }

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/ExamAttemptPersistenceAdapter.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/ExamAttemptPersistenceAdapter.java
@@ -6,6 +6,8 @@ import com.akdemya.adapter.outbound.persistence.repository.SpringDataExamAttempt
 import com.akdemya.domain.model.ExamAttempt;
 import com.akdemya.domain.port.out.ExamAttemptRepository;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -42,5 +44,11 @@ public class ExamAttemptPersistenceAdapter implements ExamAttemptRepository {
   @Override
   public void deleteById(UUID id) {
     repository.deleteById(id);
+  }
+
+  @Override
+  @Transactional
+  public int finishIfUnfinished(UUID id, OffsetDateTime finishedAt, Integer score) {
+    return repository.finishIfUnfinished(id, finishedAt, score);
   }
 }

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/FlashcardRepositoryAdapter.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/FlashcardRepositoryAdapter.java
@@ -30,6 +30,11 @@ public class FlashcardRepositoryAdapter implements FlashcardRepository {
   }
 
   @Override
+  public Optional<Flashcard> findByIdForUpdate(UUID id) {
+    return jpa.findByIdForUpdate(id).map(mapper::toDomain);
+  }
+
+  @Override
   public List<Flashcard> findByUnitId(UUID unitId) {
     return jpa.findByUnitId(unitId).stream().map(mapper::toDomain).toList();
   }

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/PurchaseRepositoryAdapter.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/PurchaseRepositoryAdapter.java
@@ -5,6 +5,7 @@ import com.akdemya.adapter.outbound.persistence.repository.JpaPurchaseRepository
 import com.akdemya.domain.model.Purchase;
 import com.akdemya.domain.port.out.PurchaseRepository;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
@@ -69,7 +70,11 @@ public class PurchaseRepositoryAdapter implements PurchaseRepository {
   }
 
   @Override
-  @Transactional
+  // REQUIRES_NEW: this is called from an afterCommit synchronization, where
+  // the thread is still bound to the already-committed transaction. REQUIRED
+  // would join that dead transaction and fail with "no transaction is in
+  // progress" at flush time.
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void updateEmailSentAt(UUID purchaseId, Instant emailSentAt) {
     jpa.updateEmailSentAt(purchaseId, emailSentAt);
   }

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/repository/JpaFlashcardRepository.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/repository/JpaFlashcardRepository.java
@@ -1,15 +1,22 @@
 package com.akdemya.adapter.outbound.persistence.repository;
 
 import com.akdemya.adapter.outbound.persistence.entity.FlashcardEntity;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface JpaFlashcardRepository extends JpaRepository<FlashcardEntity, UUID> {
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select f from FlashcardEntity f where f.id = :id")
+  Optional<FlashcardEntity> findByIdForUpdate(@Param("id") UUID id);
 
   List<FlashcardEntity> findByUnitId(UUID unitId);
 

--- a/backend/src/main/java/com/akdemya/adapter/outbound/persistence/repository/SpringDataExamAttemptRepository.java
+++ b/backend/src/main/java/com/akdemya/adapter/outbound/persistence/repository/SpringDataExamAttemptRepository.java
@@ -2,6 +2,10 @@ package com.akdemya.adapter.outbound.persistence.repository;
 
 import com.akdemya.adapter.outbound.persistence.entity.ExamAttemptEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -9,4 +13,16 @@ public interface SpringDataExamAttemptRepository extends JpaRepository<ExamAttem
   List<ExamAttemptEntity> findByUserEmail(String email);
 
   List<ExamAttemptEntity> findByUserEmailOrderByStartedAtDesc(String email);
+
+  /**
+   * Atomically finishes an attempt. The {@code finishedAt IS NULL} filter
+   * makes concurrent submits race-safe: only the first one wins (returns 1),
+   * later ones see 0 affected rows and must keep the stored result.
+   */
+  @Modifying(flushAutomatically = true, clearAutomatically = true)
+  @Query("UPDATE ExamAttemptEntity e SET e.finishedAt = :finishedAt, e.score = :score "
+      + "WHERE e.id = :id AND e.finishedAt IS NULL")
+  int finishIfUnfinished(@Param("id") UUID id,
+                         @Param("finishedAt") OffsetDateTime finishedAt,
+                         @Param("score") Integer score);
 }

--- a/backend/src/main/java/com/akdemya/application/service/ExamManager.java
+++ b/backend/src/main/java/com/akdemya/application/service/ExamManager.java
@@ -263,8 +263,11 @@ public class ExamManager implements ExamUseCase {
     ExamScoringCalculator.ScoringResult scoring = scoringCalculator.compute(total, correct, wrong, penaltyRatio);
 
     if (attempt.getFinishedAt() == null) {
-      attempt.finish(attempt.getTotalTimeSeconds(), scoring.net());
-      attemptRepo.save(attempt);
+      // Atomic UPDATE ... WHERE finished_at IS NULL: two concurrent submits
+      // both pass the in-memory check above, but only one finishes the
+      // attempt. The loser's 0-row result is fine — the stored score is the
+      // winner's, and we still return this caller's computed view.
+      attemptRepo.finishIfUnfinished(attempt.getId(), java.time.OffsetDateTime.now(), scoring.net());
     }
 
     return new SubmitResult(scoring.total(), scoring.correct(), scoring.wrong(), scoring.penalty(), scoring.net(),

--- a/backend/src/main/java/com/akdemya/application/service/ExamManager.java
+++ b/backend/src/main/java/com/akdemya/application/service/ExamManager.java
@@ -47,21 +47,9 @@ public class ExamManager implements ExamUseCase {
 
   @Override
   public StartResponse startExam(StartCommand command) {
-    // Logic from Controller: map minutes -> totalSec, create attempt
     int totalSec = Math.max(60, command.minutes() * 60);
-    ExamAttempt attempt = ExamAttempt.start(command.userEmail());
-    // We need to set totalSeconds explicitly or use a builder/method.
-    // Domain model 'start' factory sets finishedAt=null, score=null.
-    // ExamAttemptEntity constructor took userEmail and totalTimeSeconds.
-    // ExamAttempt domain constructor takes all.
-    // I'll assume I can set totalTimeSeconds via constructor or I should've added a
-    // setter or factory method arg.
-    // Let's create a new instance with correct values instead of start() factory if
-    // it's limited.
-    // OR add logic to factory.
-    // I'll just use constructor for now to be safe as I defined it.
-    attempt = new ExamAttempt(UUID.randomUUID(), command.userEmail(), java.time.OffsetDateTime.now(), null, totalSec,
-        null);
+    ExamAttempt attempt = new ExamAttempt(UUID.randomUUID(), command.userEmail(),
+        java.time.OffsetDateTime.now(), null, totalSec, null);
 
     attemptRepo.save(attempt);
 
@@ -97,8 +85,6 @@ public class ExamManager implements ExamUseCase {
       ExamAttemptAnswer ans = ExamAttemptAnswer.create(attempt.getId(), q.getId(), null);
       answerPlaceholders.add(ans);
     }
-    // Save answers. Repo has saveAll?
-    // My ExamAttemptAnswerRepository Port has saveAll.
     attemptAnsRepo.saveAll(answerPlaceholders);
 
     List<QuestionData> questionDataList = pool.stream().map(q -> {

--- a/backend/src/main/java/com/akdemya/application/service/FlashcardReviewService.java
+++ b/backend/src/main/java/com/akdemya/application/service/FlashcardReviewService.java
@@ -51,7 +51,12 @@ public class FlashcardReviewService implements FlashcardReviewUseCase {
 
     LocalDateTime reviewedAt = command.reviewedAt() != null ? command.reviewedAt() : LocalDateTime.now();
 
-    flashcardRepo.findById(command.flashcardId())
+    // Pessimistic lock on the card row serializes concurrent registrations
+    // for the same flashcard (e.g. a double-tap firing two requests). The
+    // second transaction blocks here until the first commits, so the
+    // duplicate-review window check below sees the winner's log instead of
+    // racing past it and applying the SM-2 grade twice.
+    flashcardRepo.findByIdForUpdate(command.flashcardId())
         .orElseThrow(() -> new NoSuchElementException("Flashcard not found"));
 
     var existingLog = logRepo.findMostRecentByUserIdAndFlashcardIdAfter(

--- a/backend/src/main/java/com/akdemya/application/service/IndexDocumentService.java
+++ b/backend/src/main/java/com/akdemya/application/service/IndexDocumentService.java
@@ -9,7 +9,9 @@ import com.akdemya.domain.port.out.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -34,6 +36,7 @@ public class IndexDocumentService implements IndexSourceUseCase {
     private final FileStoragePort storage;
     private final SourceTextExtractorPort extractor;
     private final TextChunkerPort chunker;
+    private final TransactionTemplate txTemplate;
 
     public IndexDocumentService(SourceDocumentRepository documentRepo,
                                  SourceChunkRepository chunkRepo,
@@ -41,7 +44,8 @@ public class IndexDocumentService implements IndexSourceUseCase {
                                  QuestionRepository questionRepo,
                                  FileStoragePort storage,
                                  SourceTextExtractorPort extractor,
-                                 TextChunkerPort chunker) {
+                                 TextChunkerPort chunker,
+                                 PlatformTransactionManager transactionManager) {
         this.documentRepo = documentRepo;
         this.chunkRepo = chunkRepo;
         this.unitRepo = unitRepo;
@@ -49,47 +53,60 @@ public class IndexDocumentService implements IndexSourceUseCase {
         this.storage = storage;
         this.extractor = extractor;
         this.chunker = chunker;
+        this.txTemplate = new TransactionTemplate(transactionManager);
     }
 
+    /**
+     * Runs as three separate transactions instead of one. With a single
+     * transaction, a chunk-persistence failure marks it rollback-only, so the
+     * recovery {@code save(FAILED)} in the catch block is silently discarded
+     * and the commit throws {@code UnexpectedRollbackException} — the caller
+     * gets a 500 and the document row vanishes. Committing the document first
+     * guarantees the FAILED status can always be recorded.
+     */
     @Override
-    @Transactional
     public UploadPreview upload(UploadCommand command) {
-        documentRepo.findBySubjectIdAndName(command.subjectId(), command.filename())
-                .filter(d -> d.getStatus() != SourceDocument.Status.FAILED)
-                .ifPresent(d -> {
-                    throw new IllegalStateException("document_already_exists:" + d.getName());
-                });
+        SourceDocument doc = txTemplate.execute(tx -> {
+            documentRepo.findBySubjectIdAndName(command.subjectId(), command.filename())
+                    .filter(d -> d.getStatus() != SourceDocument.Status.FAILED)
+                    .ifPresent(d -> {
+                        throw new IllegalStateException("document_already_exists:" + d.getName());
+                    });
 
-        String checksum = sha256(command.bytes());
-        Path storedPath = storage.store(command.filename(), command.bytes());
+            String checksum = sha256(command.bytes());
+            Path storedPath = storage.store(command.filename(), command.bytes());
 
-        SourceDocument doc = SourceDocument.create(
-                command.subjectId(),
-                command.filename(),
-                resolveType(command.contentType()),
-                null,
-                checksum,
-                storedPath.toString()
-        );
-        doc = documentRepo.save(doc);
+            return documentRepo.save(SourceDocument.create(
+                    command.subjectId(),
+                    command.filename(),
+                    resolveType(command.contentType()),
+                    null,
+                    checksum,
+                    storedPath.toString()
+            ));
+        });
         log.info("Source document saved as PENDING_REVIEW: id={} name={}", doc.getId(), doc.getName());
 
         List<SourceChunk> chunks;
         try {
-            InputStream is = new ByteArrayInputStream(command.bytes());
-            String rawText = extractor.extract(is, command.contentType());
-            log.info("Extracted {} chars from document id={}", rawText.length(), doc.getId());
+            chunks = txTemplate.execute(tx -> {
+                InputStream is = new ByteArrayInputStream(command.bytes());
+                String rawText = extractor.extract(is, command.contentType());
+                log.info("Extracted {} chars from document id={}", rawText.length(), doc.getId());
 
-            chunks = chunker.chunk(rawText, doc);
-            log.info("Created {} chunks for document id={}", chunks.size(), doc.getId());
+                List<SourceChunk> created = chunker.chunk(rawText, doc);
+                log.info("Created {} chunks for document id={}", created.size(), doc.getId());
 
-            for (SourceChunk chunk : chunks) {
-                chunkRepo.saveWithoutEmbedding(chunk);
-            }
+                for (SourceChunk chunk : created) {
+                    chunkRepo.saveWithoutEmbedding(chunk);
+                }
+                return created;
+            });
         } catch (Exception e) {
             log.error("Failed to process document id={}: {}", doc.getId(), e.getMessage(), e);
-            documentRepo.save(doc.withStatus(SourceDocument.Status.FAILED));
-            return new UploadPreview(doc.withStatus(SourceDocument.Status.FAILED), List.of());
+            SourceDocument failed = txTemplate.execute(tx ->
+                    documentRepo.save(doc.withStatus(SourceDocument.Status.FAILED)));
+            return new UploadPreview(failed, List.of());
         }
 
         List<String> unitNames = SemanticChunker.extractDetectedUnitNames(chunks);

--- a/backend/src/main/java/com/akdemya/application/service/PurchaseService.java
+++ b/backend/src/main/java/com/akdemya/application/service/PurchaseService.java
@@ -24,6 +24,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.io.InputStream;
 import java.time.Instant;
@@ -189,6 +191,30 @@ public class PurchaseService implements
     }
     DigitalProduct product = maybeProduct.get();
 
+    // Send the email only after the surrounding transaction commits. Sending
+    // inside it risks (a) a duplicate email if the transaction rolls back
+    // after the send — markPaid is undone, so the scheduler re-settles and
+    // re-sends — and (b) holding a DB connection during an external HTTP call.
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+        @Override
+        public void afterCommit() {
+          deliverDownloadEmail(purchase, product);
+        }
+      });
+    } else {
+      deliverDownloadEmail(purchase, product);
+    }
+  }
+
+  /**
+   * Sends the download email and records {@code emailSentAt} on success.
+   * Runs outside the settlement transaction (after commit); the
+   * {@code updateEmailSentAt} adapter opens its own transaction. On failure
+   * the purchase stays PAID without {@code emailSentAt}, so the
+   * reconciliation scheduler retries delivery.
+   */
+  private void deliverDownloadEmail(Purchase purchase, DigitalProduct product) {
     String downloadUrl = frontendUrl + "/descarga/" + purchase.getDownloadToken();
     boolean delivered = emailPort.sendDownloadEmail(
         purchase.getEmail(), downloadUrl, product.getDisplayName());

--- a/backend/src/main/java/com/akdemya/domain/model/ExamAttempt.java
+++ b/backend/src/main/java/com/akdemya/domain/model/ExamAttempt.java
@@ -21,10 +21,6 @@ public class ExamAttempt {
     this.score = score;
   }
 
-  public static ExamAttempt start(String userEmail) {
-    return new ExamAttempt(UUID.randomUUID(), userEmail, OffsetDateTime.now(), null, null, null);
-  }
-
   public void finish(Integer totalTimeSeconds, Integer score) {
     this.finishedAt = OffsetDateTime.now();
     this.totalTimeSeconds = totalTimeSeconds;

--- a/backend/src/main/java/com/akdemya/domain/port/out/ExamAttemptRepository.java
+++ b/backend/src/main/java/com/akdemya/domain/port/out/ExamAttemptRepository.java
@@ -1,6 +1,7 @@
 package com.akdemya.domain.port.out;
 
 import com.akdemya.domain.model.ExamAttempt;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -13,4 +14,12 @@ public interface ExamAttemptRepository {
   List<ExamAttempt> findByUserEmail(String userEmail);
 
   void deleteById(UUID id);
+
+  /**
+   * Atomically marks the attempt as finished if it is not finished yet.
+   *
+   * @return number of rows updated: 1 when this call finished the attempt,
+   *         0 when a concurrent submit already finished it
+   */
+  int finishIfUnfinished(UUID id, OffsetDateTime finishedAt, Integer score);
 }

--- a/backend/src/main/java/com/akdemya/domain/port/out/FlashcardRepository.java
+++ b/backend/src/main/java/com/akdemya/domain/port/out/FlashcardRepository.java
@@ -11,6 +11,18 @@ public interface FlashcardRepository {
 
   Optional<Flashcard> findById(UUID id);
 
+  /**
+   * Like {@link #findById(UUID)} but acquires a pessimistic write lock on the
+   * flashcard row for the duration of the current transaction. Used to
+   * serialize concurrent review registrations for the same card so the
+   * duplicate-review window check cannot be raced. Default delegates to the
+   * unlocked read for implementations (and test fakes) without locking
+   * support.
+   */
+  default Optional<Flashcard> findByIdForUpdate(UUID id) {
+    return findById(id);
+  }
+
   List<Flashcard> findByUnitId(UUID unitId);
 
   List<Flashcard> findByIds(List<UUID> ids);

--- a/backend/src/main/java/com/akdemya/domain/port/out/StripePaymentGateway.java
+++ b/backend/src/main/java/com/akdemya/domain/port/out/StripePaymentGateway.java
@@ -69,4 +69,16 @@ public interface StripePaymentGateway {
    * @throws RuntimeException on any Stripe SDK failure
    */
   Optional<StripePaymentIntentSnapshot> retrieve(String paymentIntentId);
+
+  /**
+   * Cancels a PaymentIntent at Stripe. Used by the reconciliation scheduler
+   * before marking an abandoned {@code PENDING} purchase as FAILED: once
+   * canceled, the intent can never reach {@code succeeded}, so the customer
+   * cannot be charged for a purchase the system already gave up on.
+   *
+   * @throws RuntimeException if Stripe rejects the cancellation (e.g. the
+   *         intent already succeeded or is {@code processing}); callers must
+   *         NOT mark the purchase FAILED in that case
+   */
+  void cancel(String paymentIntentId);
 }

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -3,7 +3,3 @@ spring.flyway.locations=classpath:db/migration,classpath:db/migration-dev
 spring.flyway.ignore-migration-patterns=*:missing
 app.cookie.secure=false
 app.cors.allowed-origins=http://localhost:5173,http://127.0.0.1:5173,http://localhost:3000,http://127.0.0.1:3000
-
-app.flashcards.learning-steps-minutes=1,10
-app.flashcards.easy-interval-days=4
-app.flashcards.review-again-relearn-minutes=10

--- a/backend/src/test/java/com/akdemya/adapter/inbound/web/ManageQuestionControllerTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/inbound/web/ManageQuestionControllerTest.java
@@ -32,7 +32,8 @@ class ManageQuestionControllerTest {
   private final UserRepository userRepo = mock(UserRepository.class);
 
   private final ManageQuestionController controller =
-      new ManageQuestionController(contentService, answerRepo, userRepo);
+      new ManageQuestionController(contentService, answerRepo, userRepo,
+          mock(org.springframework.transaction.PlatformTransactionManager.class));
 
   private UUID userId = UUID.randomUUID();
 

--- a/backend/src/test/java/com/akdemya/adapter/infrastructure/scheduler/PurchaseReconciliationSchedulerTest.java
+++ b/backend/src/test/java/com/akdemya/adapter/infrastructure/scheduler/PurchaseReconciliationSchedulerTest.java
@@ -79,17 +79,57 @@ class PurchaseReconciliationSchedulerTest {
   }
 
   @Test
-  void reconcilePendingPurchases_paymentFailedIntent_marksFailed() {
-    Purchase pending = pendingPurchase("pi_failed");
+  void reconcilePendingPurchases_abandonedIntent_cancelsAtStripeThenMarksFailed() {
+    // requires_payment_method older than the 24h abandonment cutoff:
+    // cancel at Stripe first, then mark FAILED.
+    Purchase abandoned = pendingPurchase("pi_abandoned",
+        Instant.now().minus(java.time.Duration.ofHours(25)));
     when(purchaseRepository.findPendingOlderThan(any(Instant.class)))
-        .thenReturn(List.of(pending));
-    when(stripeGateway.retrieve("pi_failed"))
-        .thenReturn(Optional.of(new StripePaymentIntentSnapshot("pi_failed", "payment_failed")));
+        .thenReturn(List.of(abandoned));
+    when(stripeGateway.retrieve("pi_abandoned"))
+        .thenReturn(Optional.of(new StripePaymentIntentSnapshot("pi_abandoned", "requires_payment_method")));
 
     scheduler.reconcilePendingPurchases();
 
-    verify(purchaseRepository, times(1)).markFailed("pi_failed");
+    var order = org.mockito.Mockito.inOrder(stripeGateway, purchaseRepository);
+    order.verify(stripeGateway).cancel("pi_abandoned");
+    order.verify(purchaseRepository).markFailed("pi_abandoned");
     verify(purchaseService, never()).settlePaidPurchase(any());
+  }
+
+  @Test
+  void reconcilePendingPurchases_recentRetryableIntent_staysPending() {
+    // requires_payment_method but still within the abandonment window:
+    // the customer may yet pay, so no cancel and no FAILED transition.
+    Purchase recent = pendingPurchase("pi_recent");
+    when(purchaseRepository.findPendingOlderThan(any(Instant.class)))
+        .thenReturn(List.of(recent));
+    when(stripeGateway.retrieve("pi_recent"))
+        .thenReturn(Optional.of(new StripePaymentIntentSnapshot("pi_recent", "requires_payment_method")));
+
+    scheduler.reconcilePendingPurchases();
+
+    verify(stripeGateway, never()).cancel(any());
+    verify(purchaseRepository, never()).markFailed(any());
+    verify(purchaseService, never()).settlePaidPurchase(any());
+  }
+
+  @Test
+  void reconcilePendingPurchases_cancelFails_doesNotMarkFailed() {
+    // If Stripe rejects the cancel (e.g. the intent just succeeded), the
+    // purchase must NOT be marked FAILED — next tick re-reads the status.
+    Purchase abandoned = pendingPurchase("pi_cancel_boom",
+        Instant.now().minus(java.time.Duration.ofHours(25)));
+    when(purchaseRepository.findPendingOlderThan(any(Instant.class)))
+        .thenReturn(List.of(abandoned));
+    when(stripeGateway.retrieve("pi_cancel_boom"))
+        .thenReturn(Optional.of(new StripePaymentIntentSnapshot("pi_cancel_boom", "requires_payment_method")));
+    org.mockito.Mockito.doThrow(new RuntimeException("already succeeded"))
+        .when(stripeGateway).cancel("pi_cancel_boom");
+
+    scheduler.reconcilePendingPurchases();
+
+    verify(purchaseRepository, never()).markFailed(any());
   }
 
   @Test
@@ -212,6 +252,10 @@ class PurchaseReconciliationSchedulerTest {
   // ---------------------------------------------------------------------------
 
   private static Purchase pendingPurchase(String piId) {
+    return pendingPurchase(piId, Instant.now().minusSeconds(7200));
+  }
+
+  private static Purchase pendingPurchase(String piId, Instant createdAt) {
     return new Purchase(
         UUID.randomUUID(),
         piId,
@@ -222,7 +266,7 @@ class PurchaseReconciliationSchedulerTest {
         PurchaseStatus.PENDING,
         1500L,
         "eur",
-        Instant.now().minusSeconds(7200),
+        createdAt,
         null,
         null
     );

--- a/backend/src/test/java/com/akdemya/application/service/ExamManagerResumeTest.java
+++ b/backend/src/test/java/com/akdemya/application/service/ExamManagerResumeTest.java
@@ -291,6 +291,16 @@ class ExamManagerResumeTest {
     public void deleteById(UUID id) {
       data.remove(id);
     }
+
+    @Override
+    public int finishIfUnfinished(UUID id, java.time.OffsetDateTime finishedAt, Integer score) {
+      ExamAttempt attempt = data.get(id);
+      if (attempt == null || attempt.getFinishedAt() != null) {
+        return 0;
+      }
+      attempt.finish(attempt.getTotalTimeSeconds(), score);
+      return 1;
+    }
   }
 
   static class InMemoryAttemptAnswerRepo implements ExamAttemptAnswerRepository {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -26,29 +26,30 @@ function mergeSignal(existing?: AbortSignal, timeoutMs?: number) {
 }
 
 let isRefreshing = false;
-let refreshSubscribers: Array<() => void> = [];
+let refreshSubscribers: Array<(ok: boolean) => void> = [];
 
 async function tryRefreshToken(): Promise<boolean> {
   if (isRefreshing) {
     return new Promise<boolean>((resolve) => {
-      refreshSubscribers.push(() => resolve(true));
+      refreshSubscribers.push(resolve);
     });
   }
   isRefreshing = true;
+  let ok = false;
   try {
     const res = await fetch(`${apiBase}/api/auth/refresh`, {
       method: 'POST',
       credentials: 'include',
     });
-    if (res.ok) {
-      refreshSubscribers.forEach((cb) => cb());
-      refreshSubscribers = [];
-      return true;
-    }
-    refreshSubscribers = [];
-    return false;
+    ok = res.ok;
+    return ok;
   } finally {
+    // Always flush waiters, even when refresh fails or fetch throws —
+    // otherwise their promises never settle and the requests hang.
     isRefreshing = false;
+    const subscribers = refreshSubscribers;
+    refreshSubscribers = [];
+    subscribers.forEach((cb) => cb(ok));
   }
 }
 
@@ -58,8 +59,13 @@ export async function apiJson<T>(url: string, options: RequestOptions = {}): Pro
   try {
     const res = await fetch(url, { ...fetchOptions, signal, credentials: 'include' });
     if (res.status === 401) {
-      // Avoid refresh loops on the refresh endpoint itself
-      if (!url.includes('/api/auth/')) {
+      // Refresh on 401 except for auth endpoints themselves: refreshing and
+      // retrying login/register/refresh/logout would loop or re-send
+      // credentials. /api/auth/me is the exception — its 401 just means the
+      // access token expired, which is exactly what a refresh fixes (session
+      // restore on page reload).
+      const isRefreshableUrl = !url.includes('/api/auth/') || url.includes('/api/auth/me');
+      if (isRefreshableUrl) {
         const refreshed = await tryRefreshToken();
         if (refreshed) {
           const retryRes = await fetch(url, { ...fetchOptions, signal, credentials: 'include' });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -68,19 +68,27 @@ export async function apiJson<T>(url: string, options: RequestOptions = {}): Pro
       if (isRefreshableUrl) {
         const refreshed = await tryRefreshToken();
         if (refreshed) {
-          const retryRes = await fetch(url, { ...fetchOptions, signal, credentials: 'include' });
-          if (!retryRes.ok) {
-            const err = {
-              message: 'api_error',
-              status: retryRes.status,
-              body: await retryRes.json().catch(() => ({})),
-            };
-            throw err;
+          // Fresh timeout signal for the retry: the original may already have
+          // fired while the first attempt + refresh were in flight, which
+          // would abort the retry instantly.
+          const retry = mergeSignal(fetchOptions.signal ?? undefined, timeoutMs);
+          try {
+            const retryRes = await fetch(url, { ...fetchOptions, signal: retry.signal, credentials: 'include' });
+            if (!retryRes.ok) {
+              const err = {
+                message: 'api_error',
+                status: retryRes.status,
+                body: await retryRes.json().catch(() => ({})),
+              };
+              throw err;
+            }
+            if (retryRes.status === 204) return undefined as T;
+            const retryText = await retryRes.text();
+            if (!retryText) return undefined as T;
+            return JSON.parse(retryText) as T;
+          } finally {
+            retry.clear();
           }
-          if (retryRes.status === 204) return undefined as T;
-          const retryText = await retryRes.text();
-          if (!retryText) return undefined as T;
-          return JSON.parse(retryText) as T;
         }
       }
       const err: { message: string; status: number; body: unknown; name?: string } = {


### PR DESCRIPTION
## Resumen

Nueve hallazgos de una revisión completa del código, más cinco menores, agrupados en 4 commits temáticos. Solo correcciones de comportamiento — sin refactors ni features.

### 🔐 Auth (`932825f`)
- **Restauración de sesión rota**: tras expirar el access token (15 min), recargar la página deslogueaba al usuario aunque la cookie de refresh (7 días) fuera válida. `/api/auth/me` ahora permite refresh+retry.
- **Cuelgue en refresh concurrente**: si el refresh fallaba, las peticiones encoladas quedaban con promesas sin resolver para siempre.
- **Race en registro**: dos registros concurrentes con el mismo email producían un 500 (violación de `uq_users_email` en commit) en vez de `email_in_use`.
- **Bypass del rate limit**: se usaba el primer valor de `X-Forwarded-For` (falsificable por el cliente); ahora el último (añadido por nginx). Mapas de buckets acotados a 10k IPs.
- **Fuga en OAuth2CodeStore**: códigos no canjeados nunca se purgaban.

### 💳 Pagos y exámenes (`e0dc666`)
- **Rama muerta de Stripe**: `payment_failed` es un tipo de evento, nunca un status de PaymentIntent — los pagos fallidos quedaban PENDING para siempre, re-consultados cada 15 min. Intents abandonados (>24h) ahora se **cancelan en Stripe primero** y luego se marcan FAILED: un intent cancelado no puede llegar a `succeeded`, así que no hay ventana de cobro-sin-entrega.
- **Email dentro de la transacción**: el email de descarga se enviaba dentro de la tx de settlement (riesgo de duplicado en rollback + conexión DB retenida durante HTTP). Ahora va en `afterCommit` con `REQUIRES_NEW` para `updateEmailSentAt`.
- **Doble submit de examen**: dos submits concurrentes podían finalizar el intento dos veces. Ahora `UPDATE ... WHERE finished_at IS NULL` atómico.

### 🔄 Transacciones y locking (`831e27d`)
- **Trampa rollback-only en upload RAG**: el `save(FAILED)` del catch se descartaba silenciosamente si la tx estaba marcada rollback-only → 500 y documento desaparecido. Ahora 3 transacciones separadas.
- **Imports parciales**: un fallo al guardar respuestas dejaba la pregunta huérfana committeada. Ahora cada fila es atómica.
- **Race en reviews de flashcards**: la ventana de dedup de 60s era check-then-act; un doble-tap aplicaba SM-2 dos veces. Ahora lock pesimista sobre la fila de la flashcard.

### 🧹 Menores (`9f18323`)
Retry en race de primer login OAuth2, WARN en preguntas omitidas del export CSV, comentarios de andamiaje y factory muerta `ExamAttempt.start()` eliminados, señal de timeout fresca en el retry post-refresh, config duplicada del perfil dev.

## Test plan
- Suite completa de backend en verde (incluye tests nuevos: orden cancel→fail, ventana de abandono, fallo de cancel deja PENDING)
- Frontend: 361/361 tests, `tsc` limpio
- Verificado también sobre la base de `main` tras el cherry-pick